### PR TITLE
Cross-entity execution in the Python interpreter

### DIFF
--- a/src/rac/executor.py
+++ b/src/rac/executor.py
@@ -6,7 +6,7 @@ from pydantic import BaseModel, ConfigDict
 
 from . import ast
 from .compiler import IR
-from .schema import Data
+from .schema import Data, Schema
 
 
 class ExecutionError(Exception):
@@ -19,6 +19,7 @@ class Context(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
     data: Data
+    schema_: Schema | None = None
     computed: dict[str, Any] = {}
     current_row: dict | None = None
     current_entity: str | None = None
@@ -28,7 +29,27 @@ class Context(BaseModel):
             return self.computed[path]
         if self.current_row and path in self.current_row:
             return self.current_row[path]
+        # Reverse-relation access: `members` on a household row returns the
+        # list of related child rows, each already augmented with their
+        # computed columns so downstream FieldAccess sees them.
+        related = self._resolve_reverse_relation(path)
+        if related is not None:
+            return related
         raise ExecutionError(f"undefined: {path}")
+
+    def _resolve_reverse_relation(self, path: str) -> list[dict] | None:
+        if (
+            self.schema_ is None
+            or self.current_entity is None
+            or self.current_row is None
+        ):
+            return None
+        entity = self.schema_.entities.get(self.current_entity)
+        if entity is None or path not in entity.reverse_relations:
+            return None
+        rel = entity.reverse_relations[path]
+        pk = self.current_row.get("id")
+        return self.data.get_related(rel.source, rel.source_field, pk)
 
     def get_related(self, entity: str, fk_field: str) -> list[dict]:
         if self.current_row is None:
@@ -38,6 +59,23 @@ class Context(BaseModel):
 
     def get_fk_target(self, fk_value: Any, target_entity: str) -> dict | None:
         return self.data.get_row(target_entity, fk_value)
+
+    def resolve_fk(self, field_name: str) -> dict | None:
+        """Dereference a foreign-key field on the current entity to its target row."""
+        if (
+            self.schema_ is None
+            or self.current_entity is None
+            or self.current_row is None
+        ):
+            return None
+        entity = self.schema_.entities.get(self.current_entity)
+        if entity is None or field_name not in entity.foreign_keys:
+            return None
+        fk = entity.foreign_keys[field_name]
+        pk_val = self.current_row.get(field_name)
+        if pk_val is None:
+            return None
+        return self.data.get_row(fk.target, pk_val)
 
 
 BUILTINS = {
@@ -110,6 +148,12 @@ def evaluate(expr: ast.Expr, ctx: Context) -> Any:
             return BUILTINS[func](*arg_vals)
 
         case ast.FieldAccess(obj=obj, field=fld):
+            # FK forward access: `household.size` on a person row resolves
+            # the FK field to the target row, then reads the field from it.
+            if isinstance(obj, ast.Var):
+                target_row = ctx.resolve_fk(obj.path)
+                if target_row is not None:
+                    return target_row.get(fld)
             o = evaluate(obj, ctx)
             if isinstance(o, dict):
                 return o.get(fld)
@@ -171,7 +215,17 @@ class Executor:
         self.ir = ir
 
     def execute(self, data: Data) -> Result:
-        ctx = Context(data=data)
+        # Shallow-copy the rows so we can write computed columns back into
+        # each row. That way, when a parent entity asks for its related
+        # children via a reverse relation, it sees the augmented rows
+        # (input fields plus already-computed per-row variables).
+        working = Data(
+            tables={
+                name: [dict(row) for row in rows]
+                for name, rows in data.tables.items()
+            }
+        )
+        ctx = Context(data=working, schema_=self.ir.schema_)
         entities: dict[str, dict[str, list[Any]]] = {}
         citations: dict[str, str] = {}
 
@@ -188,21 +242,18 @@ class Executor:
                 ctx.computed[path] = evaluate(var.expr, ctx)
             else:
                 entity_name = var.entity
-                rows = data.get_rows(entity_name)
+                rows = working.get_rows(entity_name)
 
                 if entity_name not in entities:
                     entities[entity_name] = {}
                 entities[entity_name][path] = []
 
-                for i, row in enumerate(rows):
-                    augmented = dict(row)
-                    for prev_path, prev_vals in entities.get(entity_name, {}).items():
-                        if len(prev_vals) > i:
-                            augmented[prev_path] = prev_vals[i]
-                    ctx.current_row = augmented
+                for row in rows:
+                    ctx.current_row = row
                     ctx.current_entity = entity_name
                     val = evaluate(var.expr, ctx)
                     entities[entity_name][path].append(val)
+                    row[path] = val
                     ctx.current_row = None
                     ctx.current_entity = None
 

--- a/src/rac/parser.py
+++ b/src/rac/parser.py
@@ -338,6 +338,16 @@ class Parser:
         reverse_relations = []
 
         while self.at("IDENT"):
+            # Require <IDENT> <COLON> <FK | LBRACKET | IDENT-dtype> for this
+            # to still be an entity-block field. Anything else — a bare var
+            # declaration, a reserved keyword like `entity:` or `from:` — means
+            # the entity block is done and this token starts the next decl.
+            if self.peek(1).type != "COLON":
+                break
+            lookahead = self.peek(2).type
+            if lookahead not in ("FK", "LBRACKET", "IDENT"):
+                break
+
             field_name = self.consume("IDENT").value
             self.consume("COLON")
 

--- a/tests/test_rac.py
+++ b/tests/test_rac.py
@@ -532,6 +532,137 @@ class TestExecutor:
         assert result.scalars["gov/c"] == 30
 
 
+# -- Cross-entity execution -------------------------------------------------
+
+
+class TestCrossEntity:
+    """Aggregation over related child rows, plus FK forward access."""
+
+    def test_sum_over_related_children(self):
+        from rac import compile, execute, parse
+
+        module = parse("""
+            entity household:
+                size: int
+
+            entity person:
+                income: float
+                household: -> household
+
+            contribution:
+                entity: person
+                from 2024-01-01: income
+
+            household_earned_income:
+                entity: household
+                from 2024-01-01: sum(persons.contribution)
+        """)
+        ir = compile([module], as_of=date(2024, 6, 1))
+        data = {
+            "household": [{"id": 1, "size": 2}, {"id": 2, "size": 1}],
+            "person": [
+                {"id": 10, "household": 1, "income": 30000.0},
+                {"id": 11, "household": 1, "income": 20000.0},
+                {"id": 12, "household": 2, "income": 50000.0},
+            ],
+        }
+        result = execute(ir, data)
+        assert result.entities["household"]["household_earned_income"] == [50000.0, 50000.0]
+
+    def test_any_and_len_over_children(self):
+        from rac import compile, execute, parse
+
+        module = parse("""
+            entity household:
+                size: int
+
+            entity person:
+                age: int
+                is_disabled: bool
+                household: -> household
+
+            household/has_disabled_member:
+                entity: household
+                from 2024-01-01: any(persons.is_disabled)
+
+            household/member_count:
+                entity: household
+                from 2024-01-01: len(persons.id)
+        """)
+        ir = compile([module], as_of=date(2024, 6, 1))
+        data = {
+            "household": [{"id": 1, "size": 2}, {"id": 2, "size": 1}],
+            "person": [
+                {"id": 10, "household": 1, "age": 40, "is_disabled": False},
+                {"id": 11, "household": 1, "age": 38, "is_disabled": True},
+                {"id": 12, "household": 2, "age": 65, "is_disabled": False},
+            ],
+        }
+        result = execute(ir, data)
+        assert result.entities["household"]["household/has_disabled_member"] == [True, False]
+        assert result.entities["household"]["household/member_count"] == [2, 1]
+
+    def test_fk_forward_access(self):
+        from rac import compile, execute, parse
+
+        module = parse("""
+            entity household:
+                region_multiplier: float
+
+            entity person:
+                base_benefit: float
+                household: -> household
+
+            person/adjusted_benefit:
+                entity: person
+                from 2024-01-01: base_benefit * household.region_multiplier
+        """)
+        ir = compile([module], as_of=date(2024, 6, 1))
+        data = {
+            "household": [
+                {"id": 1, "region_multiplier": 1.0},
+                {"id": 2, "region_multiplier": 1.2},
+            ],
+            "person": [
+                {"id": 10, "household": 1, "base_benefit": 100.0},
+                {"id": 11, "household": 2, "base_benefit": 100.0},
+            ],
+        }
+        result = execute(ir, data)
+        assert result.entities["person"]["person/adjusted_benefit"] == [100.0, 120.0]
+
+    def test_aggregation_uses_computed_child_column(self):
+        """Reverse relations must see per-child computed columns, not just raw inputs."""
+        from rac import compile, execute, parse
+
+        module = parse("""
+            entity household:
+                size: int
+
+            entity person:
+                gross_income: float
+                household: -> household
+
+            taxable_income:
+                entity: person
+                from 2024-01-01: max(0, gross_income - 12570)
+
+            total_taxable:
+                entity: household
+                from 2024-01-01: sum(persons.taxable_income)
+        """)
+        ir = compile([module], as_of=date(2024, 6, 1))
+        data = {
+            "household": [{"id": 1, "size": 2}],
+            "person": [
+                {"id": 10, "household": 1, "gross_income": 25000.0},
+                {"id": 11, "household": 1, "gross_income": 10000.0},
+            ],
+        }
+        result = execute(ir, data)
+        assert result.entities["household"]["total_taxable"] == [12430.0]
+
+
 # -- Rust Codegen ------------------------------------------------------------
 
 


### PR DESCRIPTION
First of two PRs adding multi-entity execution to rac. This one is the interpreter-only half.

The AST always carried foreign keys and reverse relations but the executor never resolved them — a `Var` on a reverse-relation name raised "undefined" and `FieldAccess` on an FK returned the raw id. This PR wires them through:

- `sum(persons.X)` aggregates over related child rows. Child-level computed columns are visible to the aggregation (not just raw inputs), so person-level `taxable_income` can feed into a household-level `sum`.
- `household.size` on a person row resolves the FK and returns the target field.
- `any(persons.X)` and `len(persons.id)` work for bool / count aggregations.

`Context` now carries the schema and the executor works against a shallow-copied `Data` view so per-row computed columns get written back and show up in subsequent reverse-relation lookups.

Parser fix: `entity person:` blocks were eating following top-level variable declarations because the field loop didn't terminate on `IDENT COLON ...`. Added a lookahead so the block exits cleanly when the token after `COLON` isn't a valid field type.

Adds `TestCrossEntity` (4 tests). Full suite green — 379 passed.

Stacks under `feat/relational-rust-codegen` (Rust backend rewrite), which lands cross-entity for the native path.