### PR TITLE
Require Python 3.14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6.2.0
         with:
-          python-version: "3.13"
+          python-version: "3.14"
 
       - name: Install Python deps
         run: |

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -2,7 +2,7 @@
 name = "axiom-rules-engine"
 version = "0.1.0"
 description = "Thin Python wrapper for the Axiom Rules Engine executable"
-requires-python = ">=3.11"
+requires-python = "==3.14.*"
 dependencies = ["boto3>=1,<2", "numpy>=2,<3", "pydantic>=2,<3", "PyYAML>=6,<7", "rich>=14,<15"]
 
 [project.scripts]


### PR DESCRIPTION
## Summary
- require the Python 3.14 series for the Python wrapper
- run the Python package CI job on Python 3.14

## Verification
- `env -u UV_FROZEN uv run --python 3.14 --with-editable ./python --with pytest --with pyyaml --with pydantic --with rich python -m pytest -q python/tests` (21 passed)