### PR TITLE
Add derived relation support for filtered entities

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -4,6 +4,33 @@ Short decision log for architecture choices. Publicly and internally, this is
 the Axiom Rules Engine; the Rust crate and executable are `axiom-rules-engine`. One
 entry per decision, most recent first.
 
+## 2026-05-20 — Filtered entities lower as derived runtime relations
+
+**Decision.** RuleSpec models filtered entity membership with
+`kind: derived_relation`: a runtime relation derived from a source relation and
+a judgment predicate. A derived relation may declare an entity name and a member
+relation alias so rules can be scoped to the filtered view, for example
+`entity: SnapUnit` with `formula: len(members)`.
+
+**Why.**
+
+- Legal constructs such as SNAP units, MAGI households, and qualifying-child
+  sets are filtered membership sets, not household-level booleans.
+- The existing runtime already understands relation aggregation. Extending
+  relations preserves that model and avoids inventing a second collection
+  mechanism.
+- A filtered entity instance is keyed by the source relation's current entity
+  id, which keeps execution compatible with existing query shapes.
+
+**Consequences.**
+
+- `len`, `sum`, `count_where`, and `sum_where` operate over filtered
+  membership in explain mode.
+- The compiler rejects derived-relation cycles.
+- Bulk fast mode and dense compilation deliberately fall back or reject derived
+  relations until those paths can compute filtered membership with identical
+  semantics.
+
 ## 2026-05-04 — Runtime predicates and source relations are separate RuleSpec kinds
 
 **Decision.** RuleSpec has separate record kinds for executable data predicates

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -25,12 +25,17 @@ relation alias so rules can be scoped to the filtered view, for example
 **Consequences.**
 
 - `len`, `sum`, `count_where`, and `sum_where` operate over filtered
-  membership in explain mode.
+  membership in explain mode, bulk fast mode, and dense mode for supported
+  predicate shapes.
 - The compiler rejects derived-relation cycles.
-- Bulk fast mode and dense compilation support derived relations when the
-  membership predicate can be evaluated from related inputs and related judgment
-  rules. More complex cross-scope predicates remain explicit fallback/rejection
-  cases until their dependency shapes are supported.
+- Membership predicates can combine related entity rules with current/root
+  entity rules, and a derived relation can use another derived relation as its
+  source.
+- Filtered entity ids are not separately materialized; a filtered entity such as
+  `SnapUnit` is keyed by the source/current entity id, for example
+  `household-1`.
+- Jurisdiction repos must migrate their own SNAP approximations separately; this
+  engine change only provides the runtime feature.
 
 ## 2026-05-04 — Runtime predicates and source relations are separate RuleSpec kinds
 

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -27,9 +27,10 @@ relation alias so rules can be scoped to the filtered view, for example
 - `len`, `sum`, `count_where`, and `sum_where` operate over filtered
   membership in explain mode.
 - The compiler rejects derived-relation cycles.
-- Bulk fast mode and dense compilation deliberately fall back or reject derived
-  relations until those paths can compute filtered membership with identical
-  semantics.
+- Bulk fast mode and dense compilation support derived relations when the
+  membership predicate can be evaluated from related inputs and related judgment
+  rules. More complex cross-scope predicates remain explicit fallback/rejection
+  cases until their dependency shapes are supported.
 
 ## 2026-05-04 — Runtime predicates and source relations are separate RuleSpec kinds
 

--- a/docs/rulespec.md
+++ b/docs/rulespec.md
@@ -131,10 +131,10 @@ members. The runtime id for the filtered entity is the source relation's current
 entity id, so a SNAP unit backed by `household-1` is queried with
 `entity_id: household-1`.
 
-Derived relations currently execute in explain mode. Bulk fast mode and the
-generic dense compiler explicitly fall back or reject derived relations until
-those execution paths can compute filtered membership without changing
-semantics.
+Derived relations execute in explain mode, bulk fast mode, and the generic dense
+compiler for predicates that can be evaluated from related inputs and related
+judgment rules. More complex cross-scope predicates may still fall back or be
+rejected by optimized execution paths until their dependency shape is supported.
 
 Top-level `imports` merge other RuleSpec files into the compiled RuleSpec module
 before the current file is lowered. Relative imports resolve from the current
@@ -267,9 +267,9 @@ Known hard gaps:
 - Formula strings are parsed by the internal `crate::formula` parser and
   normalised into `ProgramSpec`.
 - Current formula-string gaps include latest-only derived temporal formulas,
-  inferred relation slot orientation, and no fast/dense support for derived
-  relations. These should be closed in RuleSpec and `ProgramSpec`, not by adding
-  another source format.
+  inferred relation slot orientation, and incomplete optimized support for
+  complex cross-scope derived-relation predicates. These should be closed in
+  RuleSpec and `ProgramSpec`, not by adding another source format.
 
 ## Why This Instead Of Direct `ProgramSpec` YAML
 

--- a/docs/rulespec.md
+++ b/docs/rulespec.md
@@ -132,9 +132,12 @@ entity id, so a SNAP unit backed by `household-1` is queried with
 `entity_id: household-1`.
 
 Derived relations execute in explain mode, bulk fast mode, and the generic dense
-compiler for predicates that can be evaluated from related inputs and related
-judgment rules. More complex cross-scope predicates may still fall back or be
-rejected by optimized execution paths until their dependency shape is supported.
+compiler for predicates that can be evaluated from related inputs, related
+judgment rules, and current/root entity judgment or scalar rules. A
+`source_relation` may also point at another `derived_relation`; the runtime
+applies the parent filter before the child filter. Optimized execution paths may
+still reject membership predicates that aggregate another relation from inside a
+current/root predicate.
 
 Top-level `imports` merge other RuleSpec files into the compiled RuleSpec module
 before the current file is lowered. Relative imports resolve from the current

--- a/docs/rulespec.md
+++ b/docs/rulespec.md
@@ -112,7 +112,7 @@ rules:
       slot_entities: [Person, Household]
     versions:
       - effective_from: 2026-01-01
-        formula: member_of_household and snap_member_eligible
+        formula: snap_member_eligible
 
   - name: snap_unit_size
     kind: derived

--- a/docs/rulespec.md
+++ b/docs/rulespec.md
@@ -57,6 +57,9 @@ Supported rule kinds in the current Rust loader:
 - `data_relation`: executable runtime predicate declarations with
   `data_relation.arity`. Dataset relation records use durable ids such as
   `us:statutes/7/2012/j#relation.member_of_household`.
+- `derived_relation`: executable runtime predicates computed by filtering a
+  source relation with a judgment formula. This supports filtered membership
+  sets such as SNAP units, MAGI households, and qualifying-child sets.
 - `source_relation`: non-executable legal/provenance edges. It must declare
   `source_relation.type` and `source_relation.target` and is ignored during
   lowering into `ProgramSpec`.
@@ -79,6 +82,59 @@ rules:
     data_relation:
       arity: 2
 ```
+
+Derived relations are rule-defined views over data relations or other derived
+relations. The source relation supplies candidate tuples; the formula decides
+which candidate tuples remain in the filtered relation.
+
+```yaml
+rules:
+  - name: member_of_household
+    kind: data_relation
+    data_relation:
+      arity: 2
+
+  - name: snap_member_eligible
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    versions:
+      - effective_from: 2026-01-01
+        formula: has_ssn and not student_ineligible
+
+  - name: snap_unit
+    kind: derived_relation
+    derived_relation:
+      arity: 2
+      source_relation: member_of_household
+      entity: SnapUnit
+      member_relation: members
+      slot_entities: [Person, Household]
+    versions:
+      - effective_from: 2026-01-01
+        formula: member_of_household and snap_member_eligible
+
+  - name: snap_unit_size
+    kind: derived
+    entity: SnapUnit
+    dtype: Integer
+    versions:
+      - effective_from: 2026-01-01
+        formula: len(members)
+```
+
+In this example, `member_of_household` is supplied by the dataset. `snap_unit`
+is computed at runtime by keeping only household members whose
+`snap_member_eligible` judgment holds. Rules scoped to `entity: SnapUnit` use
+the `member_relation` alias (`members` above) to aggregate over the filtered
+members. The runtime id for the filtered entity is the source relation's current
+entity id, so a SNAP unit backed by `household-1` is queried with
+`entity_id: household-1`.
+
+Derived relations currently execute in explain mode. Bulk fast mode and the
+generic dense compiler explicitly fall back or reject derived relations until
+those execution paths can compute filtered membership without changing
+semantics.
 
 Top-level `imports` merge other RuleSpec files into the compiled RuleSpec module
 before the current file is lowered. Relative imports resolve from the current
@@ -208,13 +264,12 @@ rules:
 
 Known hard gaps:
 
-- `derived_relation` is represented in the schema direction but intentionally
-  rejected until relation outputs are modelled in `ProgramSpec`.
 - Formula strings are parsed by the internal `crate::formula` parser and
   normalised into `ProgramSpec`.
 - Current formula-string gaps include latest-only derived temporal formulas,
-  inferred relation slot orientation, and no relation-output rules. These should
-  be closed in RuleSpec and `ProgramSpec`, not by adding another source format.
+  inferred relation slot orientation, and no fast/dense support for derived
+  relations. These should be closed in RuleSpec and `ProgramSpec`, not by adding
+  another source format.
 
 ## Why This Instead Of Direct `ProgramSpec` YAML
 

--- a/docs/schema-alignment.md
+++ b/docs/schema-alignment.md
@@ -41,10 +41,13 @@ The Rust loader now compiles RuleSpec directly as the external format. Remaining
 schema/runtime gaps are explicit:
 
 - `derived_relation` lowers into `ProgramSpec` and executes in explain mode,
-  bulk fast mode, and the generic dense compiler for related-input predicates.
+  bulk fast mode, and the generic dense compiler for related-input predicates,
+  current/root predicates, and composed derived-relation source chains.
 - `source_relation` records are validated as provenance metadata and ignored
   during runtime lowering; the harness/compiler should consume them when
   resolving imports, amendments, and upstream-first checks.
+- Downstream jurisdiction repos still need their own migrations to replace
+  SNAP approximations with filtered-entity RuleSpec.
 - Formula strings currently support the implemented scalar/judgment expression
   subset, not arbitrary legal operators.
 - Relation slot orientation is still inferred in some expression forms and

--- a/docs/schema-alignment.md
+++ b/docs/schema-alignment.md
@@ -40,8 +40,8 @@ RuleSpec should make machine-authored structure explicit:
 The Rust loader now compiles RuleSpec directly as the external format. Remaining
 schema/runtime gaps are explicit:
 
-- `derived_relation` lowers into `ProgramSpec` and executes in explain mode.
-  Bulk fast and dense execution still need derived-relation support.
+- `derived_relation` lowers into `ProgramSpec` and executes in explain mode,
+  bulk fast mode, and the generic dense compiler for related-input predicates.
 - `source_relation` records are validated as provenance metadata and ignored
   during runtime lowering; the harness/compiler should consume them when
   resolving imports, amendments, and upstream-first checks.

--- a/docs/schema-alignment.md
+++ b/docs/schema-alignment.md
@@ -28,7 +28,7 @@ RuleSpec should retain the core engine semantics:
 RuleSpec should make machine-authored structure explicit:
 
 - Explicit rule kind: `parameter`, `derived`, `data_relation`,
-  `source_relation`, and eventually `derived_relation`.
+  `derived_relation`, and `source_relation`.
 - Explicit data-relation arity and, in a follow-up, slot names/orientation.
 - Multi-source provenance and source-document anchors.
 - Legal/provenance graph edges such as `restates`, `sets`, `implements`, and
@@ -40,8 +40,8 @@ RuleSpec should make machine-authored structure explicit:
 The Rust loader now compiles RuleSpec directly as the external format. Remaining
 schema/runtime gaps are explicit:
 
-- `derived_relation` is rejected until relation outputs are modelled in
-  `ProgramSpec`.
+- `derived_relation` lowers into `ProgramSpec` and executes in explain mode.
+  Bulk fast and dense execution still need derived-relation support.
 - `source_relation` records are validated as provenance metadata and ignored
   during runtime lowering; the harness/compiler should consume them when
   resolving imports, amendments, and upstream-first checks.
@@ -62,5 +62,5 @@ The Rust tests cover:
   relation counts, derived judgment references, and `not`.
 - Acceptance of non-executable `source_relation` records and rejection of legacy
   `reiteration` and top-level RuleSpec `relations:`.
-- Rejection of `derived_relation` until relation outputs are modelled.
+- Lowering and explain-mode execution of `derived_relation`.
 - Rejection of ambiguous YAML with `rules:` but no RuleSpec discriminator.

--- a/src/api.rs
+++ b/src/api.rs
@@ -386,6 +386,7 @@ fn collect_judgment_deps(
         JudgmentExpr::Derived(name) => {
             deps.insert(name.clone());
         }
+        JudgmentExpr::RelationMember { .. } => {}
         JudgmentExpr::And(items) | JudgmentExpr::Or(items) => {
             for item in items {
                 collect_judgment_deps(item, deps);

--- a/src/bulk.rs
+++ b/src/bulk.rs
@@ -565,7 +565,13 @@ impl<'a> BulkEvaluator<'a> {
                         };
                         if let Some(predicate) = where_clause {
                             if !self
-                                .eval_related_judgment_expr(predicate, &current_id, related_id)?
+                                .eval_related_judgment_expr(
+                                    predicate,
+                                    &current_id,
+                                    related_id,
+                                    None,
+                                    None,
+                                )?
                                 .is_holds()
                             {
                                 continue;
@@ -602,6 +608,8 @@ impl<'a> BulkEvaluator<'a> {
                                             predicate,
                                             &current_id,
                                             &related_id,
+                                            None,
+                                            None,
                                         )?
                                         .is_holds()
                                     {
@@ -733,8 +741,22 @@ impl<'a> BulkEvaluator<'a> {
                 let Some(related_id) = tuple.get(derivation.related_slot) else {
                     continue;
                 };
+                let current_entity = derivation
+                    .slot_entities
+                    .get(derivation.current_slot)
+                    .map(String::as_str);
+                let related_entity = derivation
+                    .slot_entities
+                    .get(derivation.related_slot)
+                    .map(String::as_str);
                 if self
-                    .eval_related_judgment_expr(&derivation.predicate, &current_id, related_id)?
+                    .eval_related_judgment_expr(
+                        &derivation.predicate,
+                        &current_id,
+                        related_id,
+                        current_entity,
+                        related_entity,
+                    )?
                     .is_holds()
                 {
                     rows.push(tuple);
@@ -752,11 +774,25 @@ impl<'a> BulkEvaluator<'a> {
         expr: &JudgmentExpr,
         current_id: &str,
         related_id: &str,
+        current_entity: Option<&str>,
+        related_entity: Option<&str>,
     ) -> Result<JudgmentOutcome, EvalError> {
         match expr {
             JudgmentExpr::Comparison { left, op, right } => {
-                let left = self.eval_related_scalar_expr(left, current_id, related_id)?;
-                let right = self.eval_related_scalar_expr(right, current_id, related_id)?;
+                let left = self.eval_related_scalar_expr(
+                    left,
+                    current_id,
+                    related_id,
+                    current_entity,
+                    related_entity,
+                )?;
+                let right = self.eval_related_scalar_expr(
+                    right,
+                    current_id,
+                    related_id,
+                    current_entity,
+                    related_entity,
+                )?;
                 Ok(if compare_scalar_values_for_bulk(&left, *op, &right)? {
                     JudgmentOutcome::Holds
                 } else {
@@ -765,9 +801,20 @@ impl<'a> BulkEvaluator<'a> {
             }
             JudgmentExpr::Derived(name) => {
                 let derived = self.get_derived(name)?.clone();
+                let target_id = if Some(derived.entity.as_str()) == current_entity {
+                    current_id
+                } else {
+                    related_id
+                };
                 match &derived.semantics {
                     DerivedSemantics::Judgment(expr) => {
-                        self.eval_related_judgment_expr(expr, current_id, related_id)
+                        self.eval_related_judgment_expr(
+                            expr,
+                            current_id,
+                            target_id,
+                            current_entity,
+                            related_entity,
+                        )
                     }
                     DerivedSemantics::Scalar(_) => Err(EvalError::ExpectedJudgment(name.clone())),
                 }
@@ -790,7 +837,13 @@ impl<'a> BulkEvaluator<'a> {
             JudgmentExpr::And(items) => {
                 let mut saw_undetermined = false;
                 for item in items {
-                    match self.eval_related_judgment_expr(item, current_id, related_id)? {
+                    match self.eval_related_judgment_expr(
+                        item,
+                        current_id,
+                        related_id,
+                        current_entity,
+                        related_entity,
+                    )? {
                         JudgmentOutcome::Holds => {}
                         JudgmentOutcome::NotHolds => return Ok(JudgmentOutcome::NotHolds),
                         JudgmentOutcome::Undetermined => saw_undetermined = true,
@@ -805,7 +858,13 @@ impl<'a> BulkEvaluator<'a> {
             JudgmentExpr::Or(items) => {
                 let mut saw_undetermined = false;
                 for item in items {
-                    match self.eval_related_judgment_expr(item, current_id, related_id)? {
+                    match self.eval_related_judgment_expr(
+                        item,
+                        current_id,
+                        related_id,
+                        current_entity,
+                        related_entity,
+                    )? {
                         JudgmentOutcome::Holds => return Ok(JudgmentOutcome::Holds),
                         JudgmentOutcome::NotHolds => {}
                         JudgmentOutcome::Undetermined => saw_undetermined = true,
@@ -818,13 +877,17 @@ impl<'a> BulkEvaluator<'a> {
                 })
             }
             JudgmentExpr::Not(item) => {
-                Ok(
-                    match self.eval_related_judgment_expr(item, current_id, related_id)? {
+                Ok(match self.eval_related_judgment_expr(
+                    item,
+                    current_id,
+                    related_id,
+                    current_entity,
+                    related_entity,
+                )? {
                         JudgmentOutcome::Holds => JudgmentOutcome::NotHolds,
                         JudgmentOutcome::NotHolds => JudgmentOutcome::Holds,
                         JudgmentOutcome::Undetermined => JudgmentOutcome::Undetermined,
-                    },
-                )
+                    })
             }
         }
     }
@@ -834,6 +897,8 @@ impl<'a> BulkEvaluator<'a> {
         expr: &ScalarExpr,
         current_id: &str,
         related_id: &str,
+        current_entity: Option<&str>,
+        related_entity: Option<&str>,
     ) -> Result<ScalarValue, EvalError> {
         match expr {
             ScalarExpr::Literal(value) => Ok(value.clone()),
@@ -847,10 +912,21 @@ impl<'a> BulkEvaluator<'a> {
             }
             ScalarExpr::Derived(name) => {
                 let derived = self.get_derived(name)?.clone();
+                let target_id = if Some(derived.entity.as_str()) == current_entity {
+                    current_id
+                } else if Some(derived.entity.as_str()) == related_entity {
+                    related_id
+                } else {
+                    related_id
+                };
                 match &derived.semantics {
-                    DerivedSemantics::Scalar(expr) => {
-                        self.eval_related_scalar_expr(expr, current_id, related_id)
-                    }
+                    DerivedSemantics::Scalar(expr) => self.eval_related_scalar_expr(
+                        expr,
+                        current_id,
+                        target_id,
+                        current_entity,
+                        related_entity,
+                    ),
                     DerivedSemantics::Judgment(_) => Err(EvalError::ExpectedScalar(name.clone())),
                 }
             }
@@ -858,40 +934,82 @@ impl<'a> BulkEvaluator<'a> {
                 let mut total = Decimal::ZERO;
                 for item in items {
                     total += self
-                        .eval_related_scalar_expr(item, current_id, related_id)?
+                        .eval_related_scalar_expr(
+                            item,
+                            current_id,
+                            related_id,
+                            current_entity,
+                            related_entity,
+                        )?
                         .as_decimal()
                         .ok_or_else(|| EvalError::TypeMismatch("expected numeric scalar".to_string()))?;
                 }
                 Ok(ScalarValue::Decimal(total))
             }
             ScalarExpr::Sub(left, right) => Ok(ScalarValue::Decimal(
-                self.eval_related_scalar_expr(left, current_id, related_id)?
+                self.eval_related_scalar_expr(
+                    left,
+                    current_id,
+                    related_id,
+                    current_entity,
+                    related_entity,
+                )?
                     .as_decimal()
                     .ok_or_else(|| EvalError::TypeMismatch("expected numeric scalar".to_string()))?
                     - self
-                        .eval_related_scalar_expr(right, current_id, related_id)?
+                        .eval_related_scalar_expr(
+                            right,
+                            current_id,
+                            related_id,
+                            current_entity,
+                            related_entity,
+                        )?
                         .as_decimal()
                         .ok_or_else(|| EvalError::TypeMismatch("expected numeric scalar".to_string()))?,
             )),
             ScalarExpr::Mul(left, right) => Ok(ScalarValue::Decimal(
-                self.eval_related_scalar_expr(left, current_id, related_id)?
+                self.eval_related_scalar_expr(
+                    left,
+                    current_id,
+                    related_id,
+                    current_entity,
+                    related_entity,
+                )?
                     .as_decimal()
                     .ok_or_else(|| EvalError::TypeMismatch("expected numeric scalar".to_string()))?
                     * self
-                        .eval_related_scalar_expr(right, current_id, related_id)?
+                        .eval_related_scalar_expr(
+                            right,
+                            current_id,
+                            related_id,
+                            current_entity,
+                            related_entity,
+                        )?
                         .as_decimal()
                         .ok_or_else(|| EvalError::TypeMismatch("expected numeric scalar".to_string()))?,
             )),
             ScalarExpr::Div(left, right) => {
                 let divisor = self
-                    .eval_related_scalar_expr(right, current_id, related_id)?
+                    .eval_related_scalar_expr(
+                        right,
+                        current_id,
+                        related_id,
+                        current_entity,
+                        related_entity,
+                    )?
                     .as_decimal()
                     .ok_or_else(|| EvalError::TypeMismatch("expected numeric scalar".to_string()))?;
                 if divisor.is_zero() {
                     return Err(EvalError::DivisionByZero);
                 }
                 Ok(ScalarValue::Decimal(
-                    self.eval_related_scalar_expr(left, current_id, related_id)?
+                    self.eval_related_scalar_expr(
+                        left,
+                        current_id,
+                        related_id,
+                        current_entity,
+                        related_entity,
+                    )?
                         .as_decimal()
                         .ok_or_else(|| EvalError::TypeMismatch("expected numeric scalar".to_string()))?
                         / divisor,
@@ -904,13 +1022,25 @@ impl<'a> BulkEvaluator<'a> {
                 ),
             ),
             ScalarExpr::Ceil(value) => Ok(ScalarValue::Decimal(
-                self.eval_related_scalar_expr(value, current_id, related_id)?
+                self.eval_related_scalar_expr(
+                    value,
+                    current_id,
+                    related_id,
+                    current_entity,
+                    related_entity,
+                )?
                     .as_decimal()
                     .ok_or_else(|| EvalError::TypeMismatch("expected numeric scalar".to_string()))?
                     .ceil(),
             )),
             ScalarExpr::Floor(value) => Ok(ScalarValue::Decimal(
-                self.eval_related_scalar_expr(value, current_id, related_id)?
+                self.eval_related_scalar_expr(
+                    value,
+                    current_id,
+                    related_id,
+                    current_entity,
+                    related_entity,
+                )?
                     .as_decimal()
                     .ok_or_else(|| EvalError::TypeMismatch("expected numeric scalar".to_string()))?
                     .floor(),

--- a/src/bulk.rs
+++ b/src/bulk.rs
@@ -67,15 +67,6 @@ pub fn try_execute(
     data: &DataSet,
     queries: &[ExecutionQuery],
 ) -> Result<FastPathResult, EvalError> {
-    if program
-        .relations
-        .values()
-        .any(|relation| relation.derivation.is_some())
-    {
-        return Ok(FastPathResult::Unsupported {
-            reason: "fast mode currently does not support derived relations".to_string(),
-        });
-    }
     if queries.is_empty() {
         return Ok(FastPathResult::Executed(empty_response()));
     }
@@ -220,6 +211,7 @@ struct BulkEvaluator<'a> {
     program: &'a Program,
     period: Period,
     entity_ids: Vec<String>,
+    query_index: HashMap<String, usize>,
     query_input_cells: HashMap<String, Vec<Option<ScalarValue>>>,
     related_input_index: HashMap<(String, String), ScalarValue>,
     relation_adjacency: HashMap<(String, usize), Vec<Vec<Vec<String>>>>,
@@ -276,6 +268,7 @@ impl<'a> BulkEvaluator<'a> {
             program,
             period,
             entity_ids,
+            query_index,
             query_input_cells,
             related_input_index,
             relation_adjacency,
@@ -561,19 +554,25 @@ impl<'a> BulkEvaluator<'a> {
                 related_slot,
                 where_clause,
             } => {
-                if where_clause.is_some() {
-                    return Err(EvalError::TypeMismatch(
-                        "bulk fast mode does not yet support count_related where-clauses"
-                            .to_string(),
-                    ));
-                }
                 let mut values = Vec::with_capacity(self.entity_ids.len());
                 for row_index in 0..self.entity_ids.len() {
                     let related = self.related_rows(relation, *current_slot, row_index)?;
-                    let count = related
-                        .iter()
-                        .filter(|tuple| tuple.get(*related_slot).is_some())
-                        .count() as i64;
+                    let current_id = self.entity_ids[row_index].clone();
+                    let mut count = 0_i64;
+                    for tuple in related {
+                        let Some(related_id) = tuple.get(*related_slot) else {
+                            continue;
+                        };
+                        if let Some(predicate) = where_clause {
+                            if !self
+                                .eval_related_judgment_expr(predicate, &current_id, related_id)?
+                                .is_holds()
+                            {
+                                continue;
+                            }
+                        }
+                        count += 1;
+                    }
                     values.push(count);
                 }
                 Ok(ScalarColumn::Integer(values))
@@ -585,13 +584,9 @@ impl<'a> BulkEvaluator<'a> {
                 value,
                 where_clause,
             } => {
-                if where_clause.is_some() {
-                    return Err(EvalError::TypeMismatch(
-                        "bulk fast mode does not yet support sum_related where-clauses".to_string(),
-                    ));
-                }
                 let mut totals = Vec::with_capacity(self.entity_ids.len());
                 for row_index in 0..self.entity_ids.len() {
+                    let current_id = self.entity_ids[row_index].clone();
                     let related_ids = self
                         .related_rows(relation, *current_slot, row_index)?
                         .iter()
@@ -601,6 +596,18 @@ impl<'a> BulkEvaluator<'a> {
                     match value {
                         RelatedValueRef::Input(name) => {
                             for related_id in related_ids {
+                                if let Some(predicate) = where_clause {
+                                    if !self
+                                        .eval_related_judgment_expr(
+                                            predicate,
+                                            &current_id,
+                                            &related_id,
+                                        )?
+                                        .is_holds()
+                                    {
+                                        continue;
+                                    }
+                                }
                                 let scalar = self
                                     .related_input_index
                                     .get(&(name.clone(), related_id.clone()))
@@ -701,20 +708,261 @@ impl<'a> BulkEvaluator<'a> {
     }
 
     fn related_rows(
-        &self,
+        &mut self,
         relation: &str,
         slot: usize,
         row_index: usize,
-    ) -> Result<&Vec<Vec<String>>, EvalError> {
-        self.relation_adjacency
+    ) -> Result<Vec<Vec<String>>, EvalError> {
+        let schema = self
+            .program
+            .relations
+            .get(relation)
+            .ok_or_else(|| EvalError::UnknownRelation(relation.to_string()))?;
+        let mut rows = self
+            .relation_adjacency
             .get(&(relation.to_string(), slot))
             .and_then(|rows| rows.get(row_index))
-            .ok_or_else(|| {
-                EvalError::UnknownRelation(format!(
-                    "{relation}::{}",
-                    self.entity_ids.get(row_index).cloned().unwrap_or_default()
+            .cloned()
+            .unwrap_or_default();
+
+        if let Some(derivation) = schema.derivation.clone() {
+            let current_id = self.entity_ids[row_index].clone();
+            let source_rows =
+                self.related_rows(&derivation.source_relation, derivation.current_slot, row_index)?;
+            for tuple in source_rows {
+                let Some(related_id) = tuple.get(derivation.related_slot) else {
+                    continue;
+                };
+                if self
+                    .eval_related_judgment_expr(&derivation.predicate, &current_id, related_id)?
+                    .is_holds()
+                {
+                    rows.push(tuple);
+                }
+            }
+        }
+
+        rows.sort();
+        rows.dedup();
+        Ok(rows)
+    }
+
+    fn eval_related_judgment_expr(
+        &mut self,
+        expr: &JudgmentExpr,
+        current_id: &str,
+        related_id: &str,
+    ) -> Result<JudgmentOutcome, EvalError> {
+        match expr {
+            JudgmentExpr::Comparison { left, op, right } => {
+                let left = self.eval_related_scalar_expr(left, current_id, related_id)?;
+                let right = self.eval_related_scalar_expr(right, current_id, related_id)?;
+                Ok(if compare_scalar_values_for_bulk(&left, *op, &right)? {
+                    JudgmentOutcome::Holds
+                } else {
+                    JudgmentOutcome::NotHolds
+                })
+            }
+            JudgmentExpr::Derived(name) => {
+                let derived = self.get_derived(name)?.clone();
+                match &derived.semantics {
+                    DerivedSemantics::Judgment(expr) => {
+                        self.eval_related_judgment_expr(expr, current_id, related_id)
+                    }
+                    DerivedSemantics::Scalar(_) => Err(EvalError::ExpectedJudgment(name.clone())),
+                }
+            }
+            JudgmentExpr::RelationMember {
+                relation,
+                current_slot,
+                related_slot,
+            } => Ok(if self.relation_contains(
+                relation,
+                *current_slot,
+                *related_slot,
+                current_id,
+                related_id,
+            )? {
+                JudgmentOutcome::Holds
+            } else {
+                JudgmentOutcome::NotHolds
+            }),
+            JudgmentExpr::And(items) => {
+                let mut saw_undetermined = false;
+                for item in items {
+                    match self.eval_related_judgment_expr(item, current_id, related_id)? {
+                        JudgmentOutcome::Holds => {}
+                        JudgmentOutcome::NotHolds => return Ok(JudgmentOutcome::NotHolds),
+                        JudgmentOutcome::Undetermined => saw_undetermined = true,
+                    }
+                }
+                Ok(if saw_undetermined {
+                    JudgmentOutcome::Undetermined
+                } else {
+                    JudgmentOutcome::Holds
+                })
+            }
+            JudgmentExpr::Or(items) => {
+                let mut saw_undetermined = false;
+                for item in items {
+                    match self.eval_related_judgment_expr(item, current_id, related_id)? {
+                        JudgmentOutcome::Holds => return Ok(JudgmentOutcome::Holds),
+                        JudgmentOutcome::NotHolds => {}
+                        JudgmentOutcome::Undetermined => saw_undetermined = true,
+                    }
+                }
+                Ok(if saw_undetermined {
+                    JudgmentOutcome::Undetermined
+                } else {
+                    JudgmentOutcome::NotHolds
+                })
+            }
+            JudgmentExpr::Not(item) => {
+                Ok(
+                    match self.eval_related_judgment_expr(item, current_id, related_id)? {
+                        JudgmentOutcome::Holds => JudgmentOutcome::NotHolds,
+                        JudgmentOutcome::NotHolds => JudgmentOutcome::Holds,
+                        JudgmentOutcome::Undetermined => JudgmentOutcome::Undetermined,
+                    },
+                )
+            }
+        }
+    }
+
+    fn eval_related_scalar_expr(
+        &mut self,
+        expr: &ScalarExpr,
+        current_id: &str,
+        related_id: &str,
+    ) -> Result<ScalarValue, EvalError> {
+        match expr {
+            ScalarExpr::Literal(value) => Ok(value.clone()),
+            ScalarExpr::Input(name) => self.lookup_entity_input(name, related_id),
+            ScalarExpr::InputOrElse { name, default } => {
+                match self.lookup_entity_input(name, related_id) {
+                    Ok(value) => Ok(value),
+                    Err(EvalError::MissingInput { .. }) => Ok(default.clone()),
+                    Err(error) => Err(error),
+                }
+            }
+            ScalarExpr::Derived(name) => {
+                let derived = self.get_derived(name)?.clone();
+                match &derived.semantics {
+                    DerivedSemantics::Scalar(expr) => {
+                        self.eval_related_scalar_expr(expr, current_id, related_id)
+                    }
+                    DerivedSemantics::Judgment(_) => Err(EvalError::ExpectedScalar(name.clone())),
+                }
+            }
+            ScalarExpr::Add(items) => {
+                let mut total = Decimal::ZERO;
+                for item in items {
+                    total += self
+                        .eval_related_scalar_expr(item, current_id, related_id)?
+                        .as_decimal()
+                        .ok_or_else(|| EvalError::TypeMismatch("expected numeric scalar".to_string()))?;
+                }
+                Ok(ScalarValue::Decimal(total))
+            }
+            ScalarExpr::Sub(left, right) => Ok(ScalarValue::Decimal(
+                self.eval_related_scalar_expr(left, current_id, related_id)?
+                    .as_decimal()
+                    .ok_or_else(|| EvalError::TypeMismatch("expected numeric scalar".to_string()))?
+                    - self
+                        .eval_related_scalar_expr(right, current_id, related_id)?
+                        .as_decimal()
+                        .ok_or_else(|| EvalError::TypeMismatch("expected numeric scalar".to_string()))?,
+            )),
+            ScalarExpr::Mul(left, right) => Ok(ScalarValue::Decimal(
+                self.eval_related_scalar_expr(left, current_id, related_id)?
+                    .as_decimal()
+                    .ok_or_else(|| EvalError::TypeMismatch("expected numeric scalar".to_string()))?
+                    * self
+                        .eval_related_scalar_expr(right, current_id, related_id)?
+                        .as_decimal()
+                        .ok_or_else(|| EvalError::TypeMismatch("expected numeric scalar".to_string()))?,
+            )),
+            ScalarExpr::Div(left, right) => {
+                let divisor = self
+                    .eval_related_scalar_expr(right, current_id, related_id)?
+                    .as_decimal()
+                    .ok_or_else(|| EvalError::TypeMismatch("expected numeric scalar".to_string()))?;
+                if divisor.is_zero() {
+                    return Err(EvalError::DivisionByZero);
+                }
+                Ok(ScalarValue::Decimal(
+                    self.eval_related_scalar_expr(left, current_id, related_id)?
+                        .as_decimal()
+                        .ok_or_else(|| EvalError::TypeMismatch("expected numeric scalar".to_string()))?
+                        / divisor,
                 ))
+            }
+            ScalarExpr::Max(_) | ScalarExpr::Min(_) | ScalarExpr::ParameterLookup { .. } => Err(
+                EvalError::TypeMismatch(
+                    "bulk fast mode does not yet support this related scalar expression"
+                        .to_string(),
+                ),
+            ),
+            ScalarExpr::Ceil(value) => Ok(ScalarValue::Decimal(
+                self.eval_related_scalar_expr(value, current_id, related_id)?
+                    .as_decimal()
+                    .ok_or_else(|| EvalError::TypeMismatch("expected numeric scalar".to_string()))?
+                    .ceil(),
+            )),
+            ScalarExpr::Floor(value) => Ok(ScalarValue::Decimal(
+                self.eval_related_scalar_expr(value, current_id, related_id)?
+                    .as_decimal()
+                    .ok_or_else(|| EvalError::TypeMismatch("expected numeric scalar".to_string()))?
+                    .floor(),
+            )),
+            ScalarExpr::PeriodStart => Ok(ScalarValue::Date(self.period.start)),
+            ScalarExpr::PeriodEnd => Ok(ScalarValue::Date(self.period.end)),
+            ScalarExpr::DateAddDays { .. }
+            | ScalarExpr::DaysBetween { .. }
+            | ScalarExpr::CountRelated { .. }
+            | ScalarExpr::SumRelated { .. }
+            | ScalarExpr::If { .. } => Err(EvalError::TypeMismatch(
+                "bulk fast mode does not yet support this related scalar expression".to_string(),
+            )),
+        }
+    }
+
+    fn lookup_entity_input(&self, name: &str, entity_id: &str) -> Result<ScalarValue, EvalError> {
+        if let Some(&row_index) = self.query_index.get(entity_id) {
+            if let Some(Some(value)) = self
+                .query_input_cells
+                .get(name)
+                .and_then(|cells| cells.get(row_index))
+            {
+                return Ok(value.clone());
+            }
+        }
+        self.related_input_index
+            .get(&(name.to_string(), entity_id.to_string()))
+            .cloned()
+            .ok_or_else(|| EvalError::MissingInput {
+                name: name.to_string(),
+                entity_id: entity_id.to_string(),
+                period_start: self.period.start,
+                period_end: self.period.end,
             })
+    }
+
+    fn relation_contains(
+        &mut self,
+        relation: &str,
+        current_slot: usize,
+        related_slot: usize,
+        current_id: &str,
+        related_id: &str,
+    ) -> Result<bool, EvalError> {
+        let Some(&row_index) = self.query_index.get(current_id) else {
+            return Ok(false);
+        };
+        Ok(self
+            .related_rows(relation, current_slot, row_index)?
+            .iter()
+            .any(|tuple| tuple.get(related_slot).is_some_and(|candidate| candidate == related_id)))
     }
 }
 
@@ -948,6 +1196,45 @@ fn compare_columns(
                     }
                 })
                 .collect())
+        }
+    }
+}
+
+fn compare_scalar_values_for_bulk(
+    left: &ScalarValue,
+    op: ComparisonOp,
+    right: &ScalarValue,
+) -> Result<bool, EvalError> {
+    match (left, right) {
+        (ScalarValue::Bool(left), ScalarValue::Bool(right)) => match op {
+            ComparisonOp::Eq => Ok(left == right),
+            ComparisonOp::Ne => Ok(left != right),
+            _ => Err(EvalError::TypeMismatch(
+                "boolean comparisons only support == and !=".to_string(),
+            )),
+        },
+        (ScalarValue::Text(left), ScalarValue::Text(right)) => match op {
+            ComparisonOp::Eq => Ok(left == right),
+            ComparisonOp::Ne => Ok(left != right),
+            _ => Err(EvalError::TypeMismatch(
+                "text comparisons only support == and !=".to_string(),
+            )),
+        },
+        (left, right) => {
+            let left = left.as_decimal().ok_or_else(|| {
+                EvalError::TypeMismatch("left side of comparison is not numeric".to_string())
+            })?;
+            let right = right.as_decimal().ok_or_else(|| {
+                EvalError::TypeMismatch("right side of comparison is not numeric".to_string())
+            })?;
+            Ok(match op {
+                ComparisonOp::Lt => left < right,
+                ComparisonOp::Lte => left <= right,
+                ComparisonOp::Gt => left > right,
+                ComparisonOp::Gte => left >= right,
+                ComparisonOp::Eq => left == right,
+                ComparisonOp::Ne => left != right,
+            })
         }
     }
 }

--- a/src/bulk.rs
+++ b/src/bulk.rs
@@ -67,6 +67,15 @@ pub fn try_execute(
     data: &DataSet,
     queries: &[ExecutionQuery],
 ) -> Result<FastPathResult, EvalError> {
+    if program
+        .relations
+        .values()
+        .any(|relation| relation.derivation.is_some())
+    {
+        return Ok(FastPathResult::Unsupported {
+            reason: "fast mode currently does not support derived relations".to_string(),
+        });
+    }
     if queries.is_empty() {
         return Ok(FastPathResult::Executed(empty_response()));
     }
@@ -642,6 +651,9 @@ impl<'a> BulkEvaluator<'a> {
                 compare_columns(left, *op, right)
             }
             JudgmentExpr::Derived(name) => Ok(self.evaluate_judgment(name)?.clone()),
+            JudgmentExpr::RelationMember { relation, .. } => Err(EvalError::TypeMismatch(
+                format!("fast mode cannot evaluate relation predicate `{relation}`"),
+            )),
             JudgmentExpr::And(items) => {
                 let mut results = vec![JudgmentOutcome::Holds; self.entity_ids.len()];
                 for item in items {

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -228,14 +228,6 @@ fn evaluation_order(program: &ProgramSpec) -> Result<Vec<String>, CompileError> 
 
 fn fast_path_metadata(program: &ProgramSpec) -> FastPathMetadata {
     let mut blockers = Vec::new();
-    for relation in &program.relations {
-        if relation.derivation.is_some() {
-            blockers.push(format!(
-                "{}: bulk fast mode does not yet support derived relations; explain mode does",
-                relation.name
-            ));
-        }
-    }
     for derived in &program.derived {
         collect_fast_blockers_from_semantics(&derived.name, &derived.semantics, &mut blockers);
     }
@@ -272,13 +264,7 @@ fn collect_fast_blockers_from_scalar_expr(
         | ScalarExprSpec::Input { .. }
         | ScalarExprSpec::InputOrElse { .. }
         | ScalarExprSpec::Derived { .. } => {}
-        ScalarExprSpec::CountRelated { where_clause, .. } => {
-            if where_clause.is_some() {
-                blockers.push(format!(
-                    "{derived_name}: bulk fast mode does not yet support count_related where-clauses; explain mode and the generic dense path do"
-                ));
-            }
-        }
+        ScalarExprSpec::CountRelated { .. } => {}
         ScalarExprSpec::ParameterLookup { index, .. } => {
             collect_fast_blockers_from_scalar_expr(derived_name, index, blockers);
         }
@@ -317,19 +303,10 @@ fn collect_fast_blockers_from_scalar_expr(
             collect_fast_blockers_from_scalar_expr(derived_name, from, blockers);
             collect_fast_blockers_from_scalar_expr(derived_name, to, blockers);
         }
-        ScalarExprSpec::SumRelated {
-            value,
-            where_clause,
-            ..
-        } => {
+        ScalarExprSpec::SumRelated { value, .. } => {
             if matches!(value, RelatedValueRefSpec::Derived { .. }) {
                 blockers.push(format!(
                     "{derived_name}: fast mode does not yet support sum_related over related derived values"
-                ));
-            }
-            if where_clause.is_some() {
-                blockers.push(format!(
-                    "{derived_name}: bulk fast mode does not yet support sum_related where-clauses; explain mode and the generic dense path do"
                 ));
             }
         }

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -159,12 +159,13 @@ fn evaluation_order(program: &ProgramSpec) -> Result<Vec<String>, CompileError> 
             });
         }
     }
+    let relation_dependencies = relation_derivation_dependencies(program, &derived_names)?;
 
     let mut incoming_counts = HashMap::new();
     let mut dependents: HashMap<String, Vec<String>> = HashMap::new();
 
     for derived in &program.derived {
-        let dependencies = derived_dependencies(derived);
+        let dependencies = derived_dependencies(derived, &relation_dependencies);
         incoming_counts.insert(derived.name.clone(), dependencies.len());
 
         for dependency in dependencies {
@@ -219,6 +220,14 @@ fn evaluation_order(program: &ProgramSpec) -> Result<Vec<String>, CompileError> 
 
 fn fast_path_metadata(program: &ProgramSpec) -> FastPathMetadata {
     let mut blockers = Vec::new();
+    for relation in &program.relations {
+        if relation.derivation.is_some() {
+            blockers.push(format!(
+                "{}: bulk fast mode does not yet support derived relations; explain mode does",
+                relation.name
+            ));
+        }
+    }
     for derived in &program.derived {
         collect_fast_blockers_from_semantics(&derived.name, &derived.semantics, &mut blockers);
     }
@@ -338,7 +347,7 @@ fn collect_fast_blockers_from_judgment_expr(
             collect_fast_blockers_from_scalar_expr(derived_name, left, blockers);
             collect_fast_blockers_from_scalar_expr(derived_name, right, blockers);
         }
-        JudgmentExprSpec::Derived { .. } => {}
+        JudgmentExprSpec::Derived { .. } | JudgmentExprSpec::RelationMember { .. } => {}
         JudgmentExprSpec::And { items } | JudgmentExprSpec::Or { items } => {
             for item in items {
                 collect_fast_blockers_from_judgment_expr(derived_name, item, blockers);
@@ -350,70 +359,112 @@ fn collect_fast_blockers_from_judgment_expr(
     }
 }
 
-fn derived_dependencies(derived: &crate::spec::DerivedSpec) -> HashSet<String> {
+fn relation_derivation_dependencies(
+    program: &ProgramSpec,
+    derived_names: &HashSet<String>,
+) -> Result<HashMap<String, HashSet<String>>, CompileError> {
+    let mut dependencies_by_relation = HashMap::new();
+    for relation in &program.relations {
+        let Some(derivation) = &relation.derivation else {
+            continue;
+        };
+        let mut dependencies = HashSet::new();
+        collect_judgment_dependencies(&derivation.predicate, &mut dependencies, &HashMap::new());
+        for dependency in &dependencies {
+            if !derived_names.contains(dependency) {
+                return Err(CompileError::UnknownDerivedDependency {
+                    derived: relation.name.clone(),
+                    dependency: dependency.clone(),
+                });
+            }
+        }
+        dependencies_by_relation.insert(relation.name.clone(), dependencies);
+    }
+    Ok(dependencies_by_relation)
+}
+
+fn derived_dependencies(
+    derived: &crate::spec::DerivedSpec,
+    relation_dependencies: &HashMap<String, HashSet<String>>,
+) -> HashSet<String> {
     let mut dependencies = HashSet::new();
     match &derived.semantics {
         DerivedSemanticsSpec::Scalar { expr } => {
-            collect_scalar_dependencies(expr, &mut dependencies);
+            collect_scalar_dependencies(expr, &mut dependencies, relation_dependencies);
         }
         DerivedSemanticsSpec::Judgment { expr } => {
-            collect_judgment_dependencies(expr, &mut dependencies);
+            collect_judgment_dependencies(expr, &mut dependencies, relation_dependencies);
         }
     }
     dependencies
 }
 
-fn collect_scalar_dependencies(expr: &ScalarExprSpec, dependencies: &mut HashSet<String>) {
+fn collect_scalar_dependencies(
+    expr: &ScalarExprSpec,
+    dependencies: &mut HashSet<String>,
+    relation_dependencies: &HashMap<String, HashSet<String>>,
+) {
     match expr {
         ScalarExprSpec::Literal { .. }
         | ScalarExprSpec::Input { .. }
         | ScalarExprSpec::InputOrElse { .. } => {}
-        ScalarExprSpec::CountRelated { where_clause, .. } => {
+        ScalarExprSpec::CountRelated {
+            relation,
+            where_clause,
+            ..
+        } => {
+            if let Some(relation_dependencies) = relation_dependencies.get(relation) {
+                dependencies.extend(relation_dependencies.iter().cloned());
+            }
             if let Some(predicate) = where_clause {
-                collect_judgment_dependencies(predicate, dependencies);
+                collect_judgment_dependencies(predicate, dependencies, relation_dependencies);
             }
         }
         ScalarExprSpec::Derived { name } => {
             dependencies.insert(name.clone());
         }
         ScalarExprSpec::ParameterLookup { index, .. } => {
-            collect_scalar_dependencies(index, dependencies);
+            collect_scalar_dependencies(index, dependencies, relation_dependencies);
         }
         ScalarExprSpec::Add { items }
         | ScalarExprSpec::Max { items }
         | ScalarExprSpec::Min { items } => {
             for item in items {
-                collect_scalar_dependencies(item, dependencies);
+                collect_scalar_dependencies(item, dependencies, relation_dependencies);
             }
         }
         ScalarExprSpec::Sub { left, right }
         | ScalarExprSpec::Mul { left, right }
         | ScalarExprSpec::Div { left, right } => {
-            collect_scalar_dependencies(left, dependencies);
-            collect_scalar_dependencies(right, dependencies);
+            collect_scalar_dependencies(left, dependencies, relation_dependencies);
+            collect_scalar_dependencies(right, dependencies, relation_dependencies);
         }
         ScalarExprSpec::Ceil { value } | ScalarExprSpec::Floor { value } => {
-            collect_scalar_dependencies(value, dependencies);
+            collect_scalar_dependencies(value, dependencies, relation_dependencies);
         }
         ScalarExprSpec::PeriodStart | ScalarExprSpec::PeriodEnd => {}
         ScalarExprSpec::DateAddDays { date, days } => {
-            collect_scalar_dependencies(date, dependencies);
-            collect_scalar_dependencies(days, dependencies);
+            collect_scalar_dependencies(date, dependencies, relation_dependencies);
+            collect_scalar_dependencies(days, dependencies, relation_dependencies);
         }
         ScalarExprSpec::DaysBetween { from, to } => {
-            collect_scalar_dependencies(from, dependencies);
-            collect_scalar_dependencies(to, dependencies);
+            collect_scalar_dependencies(from, dependencies, relation_dependencies);
+            collect_scalar_dependencies(to, dependencies, relation_dependencies);
         }
         ScalarExprSpec::SumRelated {
             value,
+            relation,
             where_clause,
             ..
         } => {
+            if let Some(relation_dependencies) = relation_dependencies.get(relation) {
+                dependencies.extend(relation_dependencies.iter().cloned());
+            }
             if let RelatedValueRefSpec::Derived { name } = value {
                 dependencies.insert(name.clone());
             }
             if let Some(predicate) = where_clause {
-                collect_judgment_dependencies(predicate, dependencies);
+                collect_judgment_dependencies(predicate, dependencies, relation_dependencies);
             }
         }
         ScalarExprSpec::If {
@@ -421,29 +472,34 @@ fn collect_scalar_dependencies(expr: &ScalarExprSpec, dependencies: &mut HashSet
             then_expr,
             else_expr,
         } => {
-            collect_judgment_dependencies(condition, dependencies);
-            collect_scalar_dependencies(then_expr, dependencies);
-            collect_scalar_dependencies(else_expr, dependencies);
+            collect_judgment_dependencies(condition, dependencies, relation_dependencies);
+            collect_scalar_dependencies(then_expr, dependencies, relation_dependencies);
+            collect_scalar_dependencies(else_expr, dependencies, relation_dependencies);
         }
     }
 }
 
-fn collect_judgment_dependencies(expr: &JudgmentExprSpec, dependencies: &mut HashSet<String>) {
+fn collect_judgment_dependencies(
+    expr: &JudgmentExprSpec,
+    dependencies: &mut HashSet<String>,
+    relation_dependencies: &HashMap<String, HashSet<String>>,
+) {
     match expr {
         JudgmentExprSpec::Comparison { left, right, .. } => {
-            collect_scalar_dependencies(left, dependencies);
-            collect_scalar_dependencies(right, dependencies);
+            collect_scalar_dependencies(left, dependencies, relation_dependencies);
+            collect_scalar_dependencies(right, dependencies, relation_dependencies);
         }
         JudgmentExprSpec::Derived { name } => {
             dependencies.insert(name.clone());
         }
+        JudgmentExprSpec::RelationMember { .. } => {}
         JudgmentExprSpec::And { items } | JudgmentExprSpec::Or { items } => {
             for item in items {
-                collect_judgment_dependencies(item, dependencies);
+                collect_judgment_dependencies(item, dependencies, relation_dependencies);
             }
         }
         JudgmentExprSpec::Not { item } => {
-            collect_judgment_dependencies(item, dependencies);
+            collect_judgment_dependencies(item, dependencies, relation_dependencies);
         }
     }
 }

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -21,6 +21,13 @@ pub enum CompileError {
     DuplicateDerivedRule { name: String },
     #[error("cyclic derived dependency detected involving: {cycle}")]
     CyclicDependency { cycle: String },
+    #[error("unknown relation dependency `{dependency}` referenced from relation `{relation}`")]
+    UnknownRelationDependency {
+        relation: String,
+        dependency: String,
+    },
+    #[error("cyclic relation dependency detected involving: {cycle}")]
+    CyclicRelationDependency { cycle: String },
     #[error("failed to read program file `{path}`: {error}")]
     ReadProgramFile { path: String, error: std::io::Error },
     #[error("failed to write compiled artefact `{path}`: {error}")]
@@ -159,6 +166,7 @@ fn evaluation_order(program: &ProgramSpec) -> Result<Vec<String>, CompileError> 
             });
         }
     }
+    validate_relation_derivation_graph(program)?;
     let relation_dependencies = relation_derivation_dependencies(program, &derived_names)?;
 
     let mut incoming_counts = HashMap::new();
@@ -359,6 +367,69 @@ fn collect_fast_blockers_from_judgment_expr(
     }
 }
 
+fn validate_relation_derivation_graph(program: &ProgramSpec) -> Result<(), CompileError> {
+    let relation_names = program
+        .relations
+        .iter()
+        .map(|relation| relation.name.clone())
+        .collect::<HashSet<String>>();
+    let mut graph: HashMap<String, HashSet<String>> = HashMap::new();
+
+    for relation in &program.relations {
+        let Some(derivation) = &relation.derivation else {
+            continue;
+        };
+        let mut dependencies = HashSet::new();
+        dependencies.insert(derivation.source_relation.clone());
+        collect_relation_members_from_judgment(&derivation.predicate, &mut dependencies);
+
+        for dependency in &dependencies {
+            if !relation_names.contains(dependency) {
+                return Err(CompileError::UnknownRelationDependency {
+                    relation: relation.name.clone(),
+                    dependency: dependency.clone(),
+                });
+            }
+        }
+        graph.insert(relation.name.clone(), dependencies);
+    }
+
+    let mut visiting = HashSet::new();
+    let mut visited = HashSet::new();
+    for relation in graph.keys() {
+        detect_relation_cycle(relation, &graph, &mut visiting, &mut visited)?;
+    }
+    Ok(())
+}
+
+fn detect_relation_cycle(
+    relation: &str,
+    graph: &HashMap<String, HashSet<String>>,
+    visiting: &mut HashSet<String>,
+    visited: &mut HashSet<String>,
+) -> Result<(), CompileError> {
+    if visited.contains(relation) {
+        return Ok(());
+    }
+    if !visiting.insert(relation.to_string()) {
+        let mut cycle = visiting.iter().cloned().collect::<Vec<String>>();
+        cycle.sort();
+        return Err(CompileError::CyclicRelationDependency {
+            cycle: cycle.join(", "),
+        });
+    }
+    if let Some(dependencies) = graph.get(relation) {
+        for dependency in dependencies {
+            if graph.contains_key(dependency) {
+                detect_relation_cycle(dependency, graph, visiting, visited)?;
+            }
+        }
+    }
+    visiting.remove(relation);
+    visited.insert(relation.to_string());
+    Ok(())
+}
+
 fn relation_derivation_dependencies(
     program: &ProgramSpec,
     derived_names: &HashSet<String>,
@@ -500,6 +571,96 @@ fn collect_judgment_dependencies(
         }
         JudgmentExprSpec::Not { item } => {
             collect_judgment_dependencies(item, dependencies, relation_dependencies);
+        }
+    }
+}
+
+fn collect_relation_members_from_scalar(expr: &ScalarExprSpec, relations: &mut HashSet<String>) {
+    match expr {
+        ScalarExprSpec::Literal { .. }
+        | ScalarExprSpec::Input { .. }
+        | ScalarExprSpec::InputOrElse { .. }
+        | ScalarExprSpec::Derived { .. }
+        | ScalarExprSpec::PeriodStart
+        | ScalarExprSpec::PeriodEnd => {}
+        ScalarExprSpec::ParameterLookup { index, .. }
+        | ScalarExprSpec::Ceil { value: index }
+        | ScalarExprSpec::Floor { value: index } => {
+            collect_relation_members_from_scalar(index, relations);
+        }
+        ScalarExprSpec::Add { items }
+        | ScalarExprSpec::Max { items }
+        | ScalarExprSpec::Min { items } => {
+            for item in items {
+                collect_relation_members_from_scalar(item, relations);
+            }
+        }
+        ScalarExprSpec::Sub { left, right }
+        | ScalarExprSpec::Mul { left, right }
+        | ScalarExprSpec::Div { left, right } => {
+            collect_relation_members_from_scalar(left, relations);
+            collect_relation_members_from_scalar(right, relations);
+        }
+        ScalarExprSpec::DateAddDays { date, days } => {
+            collect_relation_members_from_scalar(date, relations);
+            collect_relation_members_from_scalar(days, relations);
+        }
+        ScalarExprSpec::DaysBetween { from, to } => {
+            collect_relation_members_from_scalar(from, relations);
+            collect_relation_members_from_scalar(to, relations);
+        }
+        ScalarExprSpec::CountRelated {
+            relation,
+            where_clause,
+            ..
+        } => {
+            relations.insert(relation.clone());
+            if let Some(where_clause) = where_clause {
+                collect_relation_members_from_judgment(where_clause, relations);
+            }
+        }
+        ScalarExprSpec::SumRelated {
+            relation,
+            where_clause,
+            ..
+        } => {
+            relations.insert(relation.clone());
+            if let Some(where_clause) = where_clause {
+                collect_relation_members_from_judgment(where_clause, relations);
+            }
+        }
+        ScalarExprSpec::If {
+            condition,
+            then_expr,
+            else_expr,
+        } => {
+            collect_relation_members_from_judgment(condition, relations);
+            collect_relation_members_from_scalar(then_expr, relations);
+            collect_relation_members_from_scalar(else_expr, relations);
+        }
+    }
+}
+
+fn collect_relation_members_from_judgment(
+    expr: &JudgmentExprSpec,
+    relations: &mut HashSet<String>,
+) {
+    match expr {
+        JudgmentExprSpec::Comparison { left, right, .. } => {
+            collect_relation_members_from_scalar(left, relations);
+            collect_relation_members_from_scalar(right, relations);
+        }
+        JudgmentExprSpec::Derived { .. } => {}
+        JudgmentExprSpec::RelationMember { relation, .. } => {
+            relations.insert(relation.clone());
+        }
+        JudgmentExprSpec::And { items } | JudgmentExprSpec::Or { items } => {
+            for item in items {
+                collect_relation_members_from_judgment(item, relations);
+            }
+        }
+        JudgmentExprSpec::Not { item } => {
+            collect_relation_members_from_judgment(item, relations);
         }
     }
 }

--- a/src/dense.rs
+++ b/src/dense.rs
@@ -284,6 +284,16 @@ impl DenseCompiledProgram {
         program: &Program,
         entity: Option<&str>,
     ) -> Result<Self, DenseCompileError> {
+        if let Some(relation) = program
+            .relations
+            .values()
+            .find(|relation| relation.derivation.is_some())
+        {
+            return Err(DenseCompileError::Unsupported(format!(
+                "derived relation `{}`",
+                relation.name
+            )));
+        }
         let root_entity = match entity {
             Some(entity) => entity.to_string(),
             None => {
@@ -733,6 +743,11 @@ impl<'a> DenseCompiler<'a> {
                 }
                 Ok(CompiledJudgmentExpr::Derived(self.compile_derived(name)?))
             }
+            JudgmentExpr::RelationMember { relation, .. } => {
+                Err(DenseCompileError::Unsupported(format!(
+                    "relation predicate `{relation}`"
+                )))
+            }
             JudgmentExpr::And(items) => Ok(CompiledJudgmentExpr::And(
                 items
                     .iter()
@@ -767,6 +782,11 @@ impl<'a> DenseCompiler<'a> {
             JudgmentExpr::Derived(name) => Err(DenseCompileError::Unsupported(format!(
                 "where-clause predicates cannot yet reference derived values (`{name}`)"
             ))),
+            JudgmentExpr::RelationMember { relation, .. } => {
+                Err(DenseCompileError::Unsupported(format!(
+                    "where-clause predicates cannot yet reference relation membership (`{relation}`)"
+                )))
+            }
             JudgmentExpr::And(items) => Ok(CompiledRelatedJudgmentExpr::And(
                 items
                     .iter()

--- a/src/dense.rs
+++ b/src/dense.rs
@@ -92,6 +92,9 @@ pub struct DenseRelationKey {
 pub struct DenseRelationSchema {
     pub key: DenseRelationKey,
     pub related_inputs: Vec<String>,
+    current_entity: Option<String>,
+    related_entity: Option<String>,
+    parent_relation: Option<usize>,
     filter: Option<CompiledRelatedJudgmentExpr>,
 }
 
@@ -212,6 +215,7 @@ enum CompiledRelatedScalarExpr {
     Literal(ScalarValue),
     Input(usize),
     InputOrElse { input: usize, default: ScalarValue },
+    RootScalar(Box<CompiledScalarExpr>),
 }
 
 #[derive(Clone, Debug)]
@@ -222,6 +226,7 @@ enum CompiledRelatedJudgmentExpr {
         op: ComparisonOp,
         right: CompiledRelatedScalarExpr,
     },
+    RootJudgment(Box<CompiledJudgmentExpr>),
     And(Vec<CompiledRelatedJudgmentExpr>),
     Or(Vec<CompiledRelatedJudgmentExpr>),
     Not(Box<CompiledRelatedJudgmentExpr>),
@@ -777,6 +782,31 @@ impl<'a> DenseCompiler<'a> {
                         "unknown related judgment dependency `{name}`"
                     ))
                 })?;
+                let relation = &self.relations[relation_index];
+                if relation.current_entity.as_deref() == Some(derived.entity.as_str())
+                    || derived.entity == self.root_entity
+                {
+                    return match &derived.semantics {
+                        DerivedSemantics::Judgment(expr) => Ok(
+                            CompiledRelatedJudgmentExpr::RootJudgment(Box::new(
+                                self.compile_current_judgment_expr(name, &derived.entity, expr)?,
+                            )),
+                        ),
+                        DerivedSemantics::Scalar(_) => Err(DenseCompileError::Unsupported(
+                            format!(
+                                "where-clause predicates cannot reference scalar derived values (`{name}`)"
+                            ),
+                        )),
+                    };
+                }
+                if relation.related_entity.is_some()
+                    && relation.related_entity.as_deref() != Some(derived.entity.as_str())
+                {
+                    return Err(DenseCompileError::Unsupported(format!(
+                        "related predicate `{name}` has entity `{}`, which is neither current nor related for relation `{}`",
+                        derived.entity, relation.key.name
+                    )));
+                }
                 match &derived.semantics {
                     DerivedSemantics::Judgment(expr) => {
                         self.compile_related_predicate(relation_index, expr)
@@ -823,8 +853,220 @@ impl<'a> DenseCompiler<'a> {
                     default: default.clone(),
                 })
             }
+            ScalarExpr::Derived(name) => {
+                let derived = self.program.derived.get(name).ok_or_else(|| {
+                    DenseCompileError::Unsupported(format!(
+                        "unknown related scalar dependency `{name}`"
+                    ))
+                })?;
+                let relation = &self.relations[relation_index];
+                if relation.current_entity.as_deref() == Some(derived.entity.as_str())
+                    || derived.entity == self.root_entity
+                {
+                    return match &derived.semantics {
+                        DerivedSemantics::Scalar(expr) => Ok(CompiledRelatedScalarExpr::RootScalar(
+                            Box::new(self.compile_current_scalar_expr(
+                                name,
+                                &derived.entity,
+                                expr,
+                            )?),
+                        )),
+                        DerivedSemantics::Judgment(_) => Err(DenseCompileError::Unsupported(
+                            format!(
+                                "where-clause scalar expressions cannot reference judgment derived values (`{name}`)"
+                            ),
+                        )),
+                    };
+                }
+                if relation.related_entity.is_some()
+                    && relation.related_entity.as_deref() != Some(derived.entity.as_str())
+                {
+                    return Err(DenseCompileError::Unsupported(format!(
+                        "related scalar `{name}` has entity `{}`, which is neither current nor related for relation `{}`",
+                        derived.entity, relation.key.name
+                    )));
+                }
+                match &derived.semantics {
+                    DerivedSemantics::Scalar(expr) => self.compile_related_scalar(relation_index, expr),
+                    DerivedSemantics::Judgment(_) => Err(DenseCompileError::Unsupported(format!(
+                        "where-clause scalar expressions cannot reference judgment derived values (`{name}`)"
+                    ))),
+                }
+            }
             other => Err(DenseCompileError::Unsupported(format!(
                 "where-clause predicates currently only support comparisons between related inputs and literals; got {other:?}"
+            ))),
+        }
+    }
+
+    fn compile_current_scalar_expr(
+        &mut self,
+        derived_name: &str,
+        entity: &str,
+        expr: &ScalarExpr,
+    ) -> Result<CompiledScalarExpr, DenseCompileError> {
+        match expr {
+            ScalarExpr::Literal(value) => Ok(CompiledScalarExpr::Literal(value.clone())),
+            ScalarExpr::Input(name) => Ok(CompiledScalarExpr::Input(self.root_input(name, false))),
+            ScalarExpr::InputOrElse { name, default } => Ok(CompiledScalarExpr::InputOrElse {
+                input: self.root_input(name, true),
+                default: default.clone(),
+            }),
+            ScalarExpr::Derived(name) => {
+                let dependency = self.program.derived.get(name).ok_or_else(|| {
+                    DenseCompileError::Unsupported(format!(
+                        "unknown scalar dependency `{name}` referenced from `{derived_name}`"
+                    ))
+                })?;
+                if dependency.entity != entity && dependency.entity != self.root_entity {
+                    return Err(DenseCompileError::CrossEntityDependency {
+                        derived: derived_name.to_string(),
+                        dependency: name.clone(),
+                        entity: dependency.entity.clone(),
+                    });
+                }
+                match &dependency.semantics {
+                    DerivedSemantics::Scalar(expr) => {
+                        self.compile_current_scalar_expr(name, &dependency.entity, expr)
+                    }
+                    DerivedSemantics::Judgment(_) => Err(DenseCompileError::Unsupported(format!(
+                        "scalar expression cannot reference judgment derived value (`{name}`)"
+                    ))),
+                }
+            }
+            ScalarExpr::ParameterLookup { parameter, index } => Ok(
+                CompiledScalarExpr::ParameterLookup {
+                    parameter: self.parameter(parameter)?,
+                    index: Box::new(self.compile_current_scalar_expr(derived_name, entity, index)?),
+                },
+            ),
+            ScalarExpr::Add(items) => Ok(CompiledScalarExpr::Add(
+                items
+                    .iter()
+                    .map(|item| self.compile_current_scalar_expr(derived_name, entity, item))
+                    .collect::<Result<Vec<_>, DenseCompileError>>()?,
+            )),
+            ScalarExpr::Sub(left, right) => Ok(CompiledScalarExpr::Sub(
+                Box::new(self.compile_current_scalar_expr(derived_name, entity, left)?),
+                Box::new(self.compile_current_scalar_expr(derived_name, entity, right)?),
+            )),
+            ScalarExpr::Mul(left, right) => Ok(CompiledScalarExpr::Mul(
+                Box::new(self.compile_current_scalar_expr(derived_name, entity, left)?),
+                Box::new(self.compile_current_scalar_expr(derived_name, entity, right)?),
+            )),
+            ScalarExpr::Div(left, right) => Ok(CompiledScalarExpr::Div(
+                Box::new(self.compile_current_scalar_expr(derived_name, entity, left)?),
+                Box::new(self.compile_current_scalar_expr(derived_name, entity, right)?),
+            )),
+            ScalarExpr::Max(items) => Ok(CompiledScalarExpr::Max(
+                items
+                    .iter()
+                    .map(|item| self.compile_current_scalar_expr(derived_name, entity, item))
+                    .collect::<Result<Vec<_>, DenseCompileError>>()?,
+            )),
+            ScalarExpr::Min(items) => Ok(CompiledScalarExpr::Min(
+                items
+                    .iter()
+                    .map(|item| self.compile_current_scalar_expr(derived_name, entity, item))
+                    .collect::<Result<Vec<_>, DenseCompileError>>()?,
+            )),
+            ScalarExpr::Ceil(value) => Ok(CompiledScalarExpr::Ceil(Box::new(
+                self.compile_current_scalar_expr(derived_name, entity, value)?,
+            ))),
+            ScalarExpr::Floor(value) => Ok(CompiledScalarExpr::Floor(Box::new(
+                self.compile_current_scalar_expr(derived_name, entity, value)?,
+            ))),
+            ScalarExpr::PeriodStart => Ok(CompiledScalarExpr::PeriodStart),
+            ScalarExpr::PeriodEnd => Ok(CompiledScalarExpr::PeriodEnd),
+            ScalarExpr::DateAddDays { date, days } => Ok(CompiledScalarExpr::DateAddDays {
+                date: Box::new(self.compile_current_scalar_expr(derived_name, entity, date)?),
+                days: Box::new(self.compile_current_scalar_expr(derived_name, entity, days)?),
+            }),
+            ScalarExpr::DaysBetween { from, to } => Ok(CompiledScalarExpr::DaysBetween {
+                from: Box::new(self.compile_current_scalar_expr(derived_name, entity, from)?),
+                to: Box::new(self.compile_current_scalar_expr(derived_name, entity, to)?),
+            }),
+            ScalarExpr::If {
+                condition,
+                then_expr,
+                else_expr,
+            } => Ok(CompiledScalarExpr::If {
+                condition: Box::new(self.compile_current_judgment_expr(
+                    derived_name,
+                    entity,
+                    condition,
+                )?),
+                then_expr: Box::new(self.compile_current_scalar_expr(
+                    derived_name,
+                    entity,
+                    then_expr,
+                )?),
+                else_expr: Box::new(self.compile_current_scalar_expr(
+                    derived_name,
+                    entity,
+                    else_expr,
+                )?),
+            }),
+            ScalarExpr::CountRelated { .. } | ScalarExpr::SumRelated { .. } => Err(
+                DenseCompileError::Unsupported(
+                    "current-entity derived relation predicates cannot aggregate another relation"
+                        .to_string(),
+                ),
+            ),
+        }
+    }
+
+    fn compile_current_judgment_expr(
+        &mut self,
+        derived_name: &str,
+        entity: &str,
+        expr: &JudgmentExpr,
+    ) -> Result<CompiledJudgmentExpr, DenseCompileError> {
+        match expr {
+            JudgmentExpr::Comparison { left, op, right } => Ok(CompiledJudgmentExpr::Comparison {
+                left: self.compile_current_scalar_expr(derived_name, entity, left)?,
+                op: *op,
+                right: self.compile_current_scalar_expr(derived_name, entity, right)?,
+            }),
+            JudgmentExpr::Derived(name) => {
+                let dependency = self.program.derived.get(name).ok_or_else(|| {
+                    DenseCompileError::Unsupported(format!(
+                        "unknown judgment dependency `{name}` referenced from `{derived_name}`"
+                    ))
+                })?;
+                if dependency.entity != entity && dependency.entity != self.root_entity {
+                    return Err(DenseCompileError::CrossEntityDependency {
+                        derived: derived_name.to_string(),
+                        dependency: name.clone(),
+                        entity: dependency.entity.clone(),
+                    });
+                }
+                match &dependency.semantics {
+                    DerivedSemantics::Judgment(expr) => {
+                        self.compile_current_judgment_expr(name, &dependency.entity, expr)
+                    }
+                    DerivedSemantics::Scalar(_) => Err(DenseCompileError::Unsupported(format!(
+                        "judgment expression cannot reference scalar derived value (`{name}`)"
+                    ))),
+                }
+            }
+            JudgmentExpr::RelationMember { relation, .. } => Err(DenseCompileError::Unsupported(
+                format!("current-entity relation predicate `{relation}`"),
+            )),
+            JudgmentExpr::And(items) => Ok(CompiledJudgmentExpr::And(
+                items
+                    .iter()
+                    .map(|item| self.compile_current_judgment_expr(derived_name, entity, item))
+                    .collect::<Result<Vec<_>, DenseCompileError>>()?,
+            )),
+            JudgmentExpr::Or(items) => Ok(CompiledJudgmentExpr::Or(
+                items
+                    .iter()
+                    .map(|item| self.compile_current_judgment_expr(derived_name, entity, item))
+                    .collect::<Result<Vec<_>, DenseCompileError>>()?,
+            )),
+            JudgmentExpr::Not(item) => Ok(CompiledJudgmentExpr::Not(Box::new(
+                self.compile_current_judgment_expr(derived_name, entity, item)?,
             ))),
         }
     }
@@ -859,19 +1101,42 @@ impl<'a> DenseCompiler<'a> {
         if let Some(&index) = self.relation_index.get(&lookup_key) {
             Ok(index)
         } else {
-            let index = self.relations.len();
             let relation = self.program.relations.get(name);
-            let (key, filter) = if let Some(derivation) =
-                relation.and_then(|relation| relation.derivation.as_ref())
-            {
+            if let Some(derivation) = relation.and_then(|relation| relation.derivation.as_ref()) {
                 let source_key = DenseRelationKey {
                     name: derivation.source_relation.clone(),
                     current_slot: derivation.current_slot,
                     related_slot: derivation.related_slot,
                 };
+                let parent_relation = self
+                    .program
+                    .relations
+                    .get(&derivation.source_relation)
+                    .and_then(|relation| relation.derivation.as_ref())
+                    .map(|_| {
+                        self.relation(
+                            &derivation.source_relation,
+                            derivation.current_slot,
+                            derivation.related_slot,
+                        )
+                    })
+                    .transpose()?;
+                let key = parent_relation
+                    .map(|parent| self.relations[parent].key.clone())
+                    .unwrap_or(source_key);
+                let index = self.relations.len();
                 self.relations.push(DenseRelationSchema {
-                    key: source_key,
+                    key,
                     related_inputs: Vec::new(),
+                    current_entity: derivation
+                        .slot_entities
+                        .get(derivation.current_slot)
+                        .cloned(),
+                    related_entity: derivation
+                        .slot_entities
+                        .get(derivation.related_slot)
+                        .cloned(),
+                    parent_relation,
                     filter: None,
                 });
                 self.optional_related_inputs.push(HashSet::new());
@@ -880,16 +1145,20 @@ impl<'a> DenseCompiler<'a> {
                 self.relations[index].filter = Some(filter);
                 return Ok(index);
             } else {
-                (lookup_key.clone(), None)
-            };
-            self.relations.push(DenseRelationSchema {
-                key,
-                related_inputs: Vec::new(),
-                filter,
-            });
-            self.optional_related_inputs.push(HashSet::new());
-            self.relation_index.insert(lookup_key, index);
-            Ok(index)
+                let index = self.relations.len();
+                let key = lookup_key.clone();
+                self.relations.push(DenseRelationSchema {
+                    key,
+                    related_inputs: Vec::new(),
+                    current_entity: None,
+                    related_entity: None,
+                    parent_relation: None,
+                    filter: None,
+                });
+                self.optional_related_inputs.push(HashSet::new());
+                self.relation_index.insert(lookup_key, index);
+                Ok(index)
+            }
         }
     }
 
@@ -1139,21 +1408,20 @@ impl<'a> DenseExecutor<'a> {
                 relation,
                 predicate,
             } => {
-                let relation_batch = &self.batch.relations[*relation];
+                let offsets = self.batch.relations[*relation].offsets.clone();
                 let mask = self.relation_mask(*relation, predicate.as_ref())?;
                 if let Some(mask) = mask {
                     let mut counts = Vec::with_capacity(self.batch.row_count);
                     for row in 0..self.batch.row_count {
-                        let start = relation_batch.offsets[row];
-                        let end = relation_batch.offsets[row + 1];
+                        let start = offsets[row];
+                        let end = offsets[row + 1];
                         let matched = mask[start..end].iter().filter(|keep| **keep).count() as i64;
                         counts.push(matched);
                     }
                     Ok(DenseColumn::Integer(counts))
                 } else {
                     Ok(DenseColumn::Integer(
-                        relation_batch
-                            .offsets
+                        offsets
                             .windows(2)
                             .map(|pair| (pair[1] - pair[0]) as i64)
                             .collect(),
@@ -1165,8 +1433,8 @@ impl<'a> DenseExecutor<'a> {
                 input,
                 predicate,
             } => {
-                let relation_batch = &self.batch.relations[*relation];
-                let values = relation_batch.inputs[*input]
+                let offsets = self.batch.relations[*relation].offsets.clone();
+                let values = self.batch.relations[*relation].inputs[*input]
                     .as_ref()
                     .ok_or_else(|| EvalError::MissingInput {
                         name: format!("related_input[{input}]"),
@@ -1178,8 +1446,8 @@ impl<'a> DenseExecutor<'a> {
                 let mask = self.relation_mask(*relation, predicate.as_ref())?;
                 let mut totals = Vec::with_capacity(self.batch.row_count);
                 for row in 0..self.batch.row_count {
-                    let start = relation_batch.offsets[row];
-                    let end = relation_batch.offsets[row + 1];
+                    let start = offsets[row];
+                    let end = offsets[row + 1];
                     let mut total = Decimal::ZERO;
                     match &mask {
                         Some(mask) => {
@@ -1213,33 +1481,25 @@ impl<'a> DenseExecutor<'a> {
     }
 
     fn relation_mask(
-        &self,
+        &mut self,
         relation: usize,
         predicate: Option<&CompiledRelatedJudgmentExpr>,
     ) -> Result<Option<Vec<bool>>, EvalError> {
-        let relation_batch = &self.batch.relations[relation];
-        let base_mask = self.program.relations[relation]
-            .filter
+        let parent_relation = self.program.relations[relation].parent_relation;
+        let parent_mask = parent_relation
+            .map(|parent| self.relation_mask(parent, None))
+            .transpose()?
+            .flatten();
+        let base_filter = self.program.relations[relation].filter.clone();
+        let base_mask = base_filter
             .as_ref()
-            .map(|predicate| {
-                eval_related_predicate(
-                    predicate,
-                    &relation_batch.inputs,
-                    relation_batch.related_count,
-                )
-            })
+            .map(|predicate| self.eval_related_predicate(relation, predicate))
             .transpose()?;
         let predicate_mask = predicate
-            .map(|predicate| {
-                eval_related_predicate(
-                    predicate,
-                    &relation_batch.inputs,
-                    relation_batch.related_count,
-                )
-            })
+            .map(|predicate| self.eval_related_predicate(relation, predicate))
             .transpose()?;
 
-        Ok(match (base_mask, predicate_mask) {
+        let local_mask = match (base_mask, predicate_mask) {
             (Some(mut base), Some(predicate)) => {
                 for (base, predicate) in base.iter_mut().zip(predicate) {
                     *base &= predicate;
@@ -1249,7 +1509,95 @@ impl<'a> DenseExecutor<'a> {
             (Some(base), None) => Some(base),
             (None, Some(predicate)) => Some(predicate),
             (None, None) => None,
+        };
+
+        Ok(match (parent_mask, local_mask) {
+            (Some(mut parent), Some(local)) => {
+                for (parent, local) in parent.iter_mut().zip(local) {
+                    *parent &= local;
+                }
+                Some(parent)
+            }
+            (Some(parent), None) => Some(parent),
+            (None, Some(local)) => Some(local),
+            (None, None) => None,
         })
+    }
+
+    fn eval_related_predicate(
+        &mut self,
+        relation: usize,
+        expr: &CompiledRelatedJudgmentExpr,
+    ) -> Result<Vec<bool>, EvalError> {
+        let length = self.batch.relations[relation].related_count;
+        match expr {
+            CompiledRelatedJudgmentExpr::Literal(value) => Ok(vec![*value; length]),
+            CompiledRelatedJudgmentExpr::Comparison { left, op, right } => {
+                let left = self.resolve_related_scalar(relation, left)?;
+                let right = self.resolve_related_scalar(relation, right)?;
+                Ok(compare_related_columns(&left, *op, &right)?)
+            }
+            CompiledRelatedJudgmentExpr::RootJudgment(expr) => {
+                let offsets = self.batch.relations[relation].offsets.clone();
+                let values = self.eval_judgment_expr(expr)?;
+                project_root_judgment_to_related(&values, &offsets)
+            }
+            CompiledRelatedJudgmentExpr::And(items) => {
+                let mut result = vec![true; length];
+                for item in items {
+                    let sub = self.eval_related_predicate(relation, item)?;
+                    for (index, keep) in sub.into_iter().enumerate() {
+                        result[index] &= keep;
+                    }
+                }
+                Ok(result)
+            }
+            CompiledRelatedJudgmentExpr::Or(items) => {
+                let mut result = vec![false; length];
+                for item in items {
+                    let sub = self.eval_related_predicate(relation, item)?;
+                    for (index, keep) in sub.into_iter().enumerate() {
+                        result[index] |= keep;
+                    }
+                }
+                Ok(result)
+            }
+            CompiledRelatedJudgmentExpr::Not(item) => Ok(self
+                .eval_related_predicate(relation, item)?
+                .into_iter()
+                .map(|keep| !keep)
+                .collect()),
+        }
+    }
+
+    fn resolve_related_scalar(
+        &mut self,
+        relation: usize,
+        expr: &CompiledRelatedScalarExpr,
+    ) -> Result<DenseColumn, EvalError> {
+        let length = self.batch.relations[relation].related_count;
+        match expr {
+            CompiledRelatedScalarExpr::Literal(value) => Ok(broadcast_scalar_literal(value, length)),
+            CompiledRelatedScalarExpr::Input(index) => self.batch.relations[relation].inputs[*index]
+                .clone()
+                .ok_or_else(|| EvalError::MissingInput {
+                    name: format!("related_input[{index}]"),
+                    entity_id: String::new(),
+                    period_start: chrono::NaiveDate::from_ymd_opt(1900, 1, 1).expect("date"),
+                    period_end: chrono::NaiveDate::from_ymd_opt(1900, 1, 1).expect("date"),
+                }),
+            CompiledRelatedScalarExpr::InputOrElse { input, default } => {
+                match &self.batch.relations[relation].inputs[*input] {
+                    Some(column) => Ok(column.clone()),
+                    None => Ok(broadcast_scalar_literal(default, length)),
+                }
+            }
+            CompiledRelatedScalarExpr::RootScalar(expr) => {
+                let offsets = self.batch.relations[relation].offsets.clone();
+                let values = self.eval_scalar_expr(expr)?;
+                project_root_column_to_related(&values, &offsets)
+            }
+        }
     }
 
     fn eval_judgment_expr(
@@ -1310,72 +1658,88 @@ impl<'a> DenseExecutor<'a> {
     }
 }
 
-fn eval_related_predicate(
-    expr: &CompiledRelatedJudgmentExpr,
-    related_inputs: &[Option<DenseColumn>],
-    related_count: usize,
+fn project_root_judgment_to_related(
+    values: &[JudgmentOutcome],
+    offsets: &[usize],
 ) -> Result<Vec<bool>, EvalError> {
-    let length = related_count;
-    match expr {
-        CompiledRelatedJudgmentExpr::Literal(value) => Ok(vec![*value; length]),
-        CompiledRelatedJudgmentExpr::Comparison { left, op, right } => {
-            let left = resolve_related_scalar(left, related_inputs, length)?;
-            let right = resolve_related_scalar(right, related_inputs, length)?;
-            Ok(compare_related_columns(&left, *op, &right)?)
-        }
-        CompiledRelatedJudgmentExpr::And(items) => {
-            let mut result = vec![true; length];
-            for item in items {
-                let sub = eval_related_predicate(item, related_inputs, related_count)?;
-                for (index, keep) in sub.into_iter().enumerate() {
-                    result[index] &= keep;
-                }
-            }
-            Ok(result)
-        }
-        CompiledRelatedJudgmentExpr::Or(items) => {
-            let mut result = vec![false; length];
-            for item in items {
-                let sub = eval_related_predicate(item, related_inputs, related_count)?;
-                for (index, keep) in sub.into_iter().enumerate() {
-                    result[index] |= keep;
-                }
-            }
-            Ok(result)
-        }
-        CompiledRelatedJudgmentExpr::Not(item) => {
-            Ok(eval_related_predicate(item, related_inputs, related_count)?
-                .into_iter()
-                .map(|keep| !keep)
-                .collect())
+    let row_count = offsets.len().saturating_sub(1);
+    if values.len() != row_count {
+        return Err(EvalError::TypeMismatch(format!(
+            "dense root judgment has length {} but relation offsets describe {} rows",
+            values.len(),
+            row_count
+        )));
+    }
+
+    let mut projected = Vec::with_capacity(*offsets.last().unwrap_or(&0));
+    for row in 0..row_count {
+        for _ in offsets[row]..offsets[row + 1] {
+            projected.push(values[row].is_holds());
         }
     }
+    Ok(projected)
 }
 
-fn resolve_related_scalar(
-    expr: &CompiledRelatedScalarExpr,
-    related_inputs: &[Option<DenseColumn>],
-    length: usize,
+fn project_root_column_to_related(
+    column: &DenseColumn,
+    offsets: &[usize],
 ) -> Result<DenseColumn, EvalError> {
-    match expr {
-        CompiledRelatedScalarExpr::Literal(value) => Ok(broadcast_scalar_literal(value, length)),
-        CompiledRelatedScalarExpr::Input(index) => {
-            related_inputs[*index]
-                .clone()
-                .ok_or_else(|| EvalError::MissingInput {
-                    name: format!("related_input[{index}]"),
-                    entity_id: String::new(),
-                    period_start: chrono::NaiveDate::from_ymd_opt(1900, 1, 1).expect("date"),
-                    period_end: chrono::NaiveDate::from_ymd_opt(1900, 1, 1).expect("date"),
-                })
-        }
-        CompiledRelatedScalarExpr::InputOrElse { input, default } => {
-            match &related_inputs[*input] {
-                Some(column) => Ok(column.clone()),
-                None => Ok(broadcast_scalar_literal(default, length)),
-            }
-        }
+    let row_count = offsets.len().saturating_sub(1);
+    if column.len() != row_count {
+        return Err(EvalError::TypeMismatch(format!(
+            "dense root scalar has length {} but relation offsets describe {} rows",
+            column.len(),
+            row_count
+        )));
     }
+
+    Ok(match column {
+        DenseColumn::Bool(values) => {
+            let mut projected = Vec::with_capacity(*offsets.last().unwrap_or(&0));
+            for row in 0..row_count {
+                for _ in offsets[row]..offsets[row + 1] {
+                    projected.push(values[row]);
+                }
+            }
+            DenseColumn::Bool(projected)
+        }
+        DenseColumn::Integer(values) => {
+            let mut projected = Vec::with_capacity(*offsets.last().unwrap_or(&0));
+            for row in 0..row_count {
+                for _ in offsets[row]..offsets[row + 1] {
+                    projected.push(values[row]);
+                }
+            }
+            DenseColumn::Integer(projected)
+        }
+        DenseColumn::Decimal(values) => {
+            let mut projected = Vec::with_capacity(*offsets.last().unwrap_or(&0));
+            for row in 0..row_count {
+                for _ in offsets[row]..offsets[row + 1] {
+                    projected.push(values[row]);
+                }
+            }
+            DenseColumn::Decimal(projected)
+        }
+        DenseColumn::Text(values) => {
+            let mut projected = Vec::with_capacity(*offsets.last().unwrap_or(&0));
+            for row in 0..row_count {
+                for _ in offsets[row]..offsets[row + 1] {
+                    projected.push(values[row].clone());
+                }
+            }
+            DenseColumn::Text(projected)
+        }
+        DenseColumn::Date(values) => {
+            let mut projected = Vec::with_capacity(*offsets.last().unwrap_or(&0));
+            for row in 0..row_count {
+                for _ in offsets[row]..offsets[row + 1] {
+                    projected.push(values[row]);
+                }
+            }
+            DenseColumn::Date(projected)
+        }
+    })
 }
 
 fn compare_related_columns(

--- a/src/dense.rs
+++ b/src/dense.rs
@@ -92,6 +92,7 @@ pub struct DenseRelationKey {
 pub struct DenseRelationSchema {
     pub key: DenseRelationKey,
     pub related_inputs: Vec<String>,
+    filter: Option<CompiledRelatedJudgmentExpr>,
 }
 
 #[derive(Clone, Debug)]
@@ -215,6 +216,7 @@ enum CompiledRelatedScalarExpr {
 
 #[derive(Clone, Debug)]
 enum CompiledRelatedJudgmentExpr {
+    Literal(bool),
     Comparison {
         left: CompiledRelatedScalarExpr,
         op: ComparisonOp,
@@ -284,16 +286,6 @@ impl DenseCompiledProgram {
         program: &Program,
         entity: Option<&str>,
     ) -> Result<Self, DenseCompileError> {
-        if let Some(relation) = program
-            .relations
-            .values()
-            .find(|relation| relation.derivation.is_some())
-        {
-            return Err(DenseCompileError::Unsupported(format!(
-                "derived relation `{}`",
-                relation.name
-            )));
-        }
         let root_entity = match entity {
             Some(entity) => entity.to_string(),
             None => {
@@ -671,7 +663,7 @@ impl<'a> DenseCompiler<'a> {
                 related_slot,
                 where_clause,
             } => {
-                let relation_index = self.relation(relation, *current_slot, *related_slot);
+                let relation_index = self.relation(relation, *current_slot, *related_slot)?;
                 let predicate = where_clause
                     .as_deref()
                     .map(|inner| self.compile_related_predicate(relation_index, inner))
@@ -689,7 +681,7 @@ impl<'a> DenseCompiler<'a> {
                 where_clause,
             } => match value {
                 RelatedValueRef::Input(name) => {
-                    let relation_index = self.relation(relation, *current_slot, *related_slot);
+                    let relation_index = self.relation(relation, *current_slot, *related_slot)?;
                     let input_index = self.related_input(relation_index, name, false);
                     let predicate = where_clause
                         .as_deref()
@@ -779,14 +771,22 @@ impl<'a> DenseCompiler<'a> {
                     right: self.compile_related_scalar(relation_index, right)?,
                 })
             }
-            JudgmentExpr::Derived(name) => Err(DenseCompileError::Unsupported(format!(
-                "where-clause predicates cannot yet reference derived values (`{name}`)"
-            ))),
-            JudgmentExpr::RelationMember { relation, .. } => {
-                Err(DenseCompileError::Unsupported(format!(
-                    "where-clause predicates cannot yet reference relation membership (`{relation}`)"
-                )))
+            JudgmentExpr::Derived(name) => {
+                let derived = self.program.derived.get(name).ok_or_else(|| {
+                    DenseCompileError::Unsupported(format!(
+                        "unknown related judgment dependency `{name}`"
+                    ))
+                })?;
+                match &derived.semantics {
+                    DerivedSemantics::Judgment(expr) => {
+                        self.compile_related_predicate(relation_index, expr)
+                    }
+                    DerivedSemantics::Scalar(_) => Err(DenseCompileError::Unsupported(format!(
+                        "where-clause predicates cannot reference scalar derived values (`{name}`)"
+                    ))),
+                }
             }
+            JudgmentExpr::RelationMember { .. } => Ok(CompiledRelatedJudgmentExpr::Literal(true)),
             JudgmentExpr::And(items) => Ok(CompiledRelatedJudgmentExpr::And(
                 items
                     .iter()
@@ -845,23 +845,51 @@ impl<'a> DenseCompiler<'a> {
         index
     }
 
-    fn relation(&mut self, name: &str, current_slot: usize, related_slot: usize) -> usize {
-        let key = DenseRelationKey {
+    fn relation(
+        &mut self,
+        name: &str,
+        current_slot: usize,
+        related_slot: usize,
+    ) -> Result<usize, DenseCompileError> {
+        let lookup_key = DenseRelationKey {
             name: name.to_string(),
             current_slot,
             related_slot,
         };
-        if let Some(&index) = self.relation_index.get(&key) {
-            index
+        if let Some(&index) = self.relation_index.get(&lookup_key) {
+            Ok(index)
         } else {
             let index = self.relations.len();
+            let relation = self.program.relations.get(name);
+            let (key, filter) = if let Some(derivation) =
+                relation.and_then(|relation| relation.derivation.as_ref())
+            {
+                let source_key = DenseRelationKey {
+                    name: derivation.source_relation.clone(),
+                    current_slot: derivation.current_slot,
+                    related_slot: derivation.related_slot,
+                };
+                self.relations.push(DenseRelationSchema {
+                    key: source_key,
+                    related_inputs: Vec::new(),
+                    filter: None,
+                });
+                self.optional_related_inputs.push(HashSet::new());
+                self.relation_index.insert(lookup_key, index);
+                let filter = self.compile_related_predicate(index, &derivation.predicate)?;
+                self.relations[index].filter = Some(filter);
+                return Ok(index);
+            } else {
+                (lookup_key.clone(), None)
+            };
             self.relations.push(DenseRelationSchema {
-                key: key.clone(),
+                key,
                 related_inputs: Vec::new(),
+                filter,
             });
             self.optional_related_inputs.push(HashSet::new());
-            self.relation_index.insert(key, index);
-            index
+            self.relation_index.insert(lookup_key, index);
+            Ok(index)
         }
     }
 
@@ -1112,12 +1140,8 @@ impl<'a> DenseExecutor<'a> {
                 predicate,
             } => {
                 let relation_batch = &self.batch.relations[*relation];
-                if let Some(predicate) = predicate {
-                    let mask = eval_related_predicate(
-                        predicate,
-                        &relation_batch.inputs,
-                        relation_batch.related_count,
-                    )?;
+                let mask = self.relation_mask(*relation, predicate.as_ref())?;
+                if let Some(mask) = mask {
                     let mut counts = Vec::with_capacity(self.batch.row_count);
                     for row in 0..self.batch.row_count {
                         let start = relation_batch.offsets[row];
@@ -1151,16 +1175,7 @@ impl<'a> DenseExecutor<'a> {
                         period_end: self.period.end,
                     })?
                     .as_decimal_vec()?;
-                let mask = predicate
-                    .as_ref()
-                    .map(|predicate| {
-                        eval_related_predicate(
-                            predicate,
-                            &relation_batch.inputs,
-                            relation_batch.related_count,
-                        )
-                    })
-                    .transpose()?;
+                let mask = self.relation_mask(*relation, predicate.as_ref())?;
                 let mut totals = Vec::with_capacity(self.batch.row_count);
                 for row in 0..self.batch.row_count {
                     let start = relation_batch.offsets[row];
@@ -1195,6 +1210,46 @@ impl<'a> DenseExecutor<'a> {
                 select_dense_scalar_column(condition, then_values, else_values)
             }
         }
+    }
+
+    fn relation_mask(
+        &self,
+        relation: usize,
+        predicate: Option<&CompiledRelatedJudgmentExpr>,
+    ) -> Result<Option<Vec<bool>>, EvalError> {
+        let relation_batch = &self.batch.relations[relation];
+        let base_mask = self.program.relations[relation]
+            .filter
+            .as_ref()
+            .map(|predicate| {
+                eval_related_predicate(
+                    predicate,
+                    &relation_batch.inputs,
+                    relation_batch.related_count,
+                )
+            })
+            .transpose()?;
+        let predicate_mask = predicate
+            .map(|predicate| {
+                eval_related_predicate(
+                    predicate,
+                    &relation_batch.inputs,
+                    relation_batch.related_count,
+                )
+            })
+            .transpose()?;
+
+        Ok(match (base_mask, predicate_mask) {
+            (Some(mut base), Some(predicate)) => {
+                for (base, predicate) in base.iter_mut().zip(predicate) {
+                    *base &= predicate;
+                }
+                Some(base)
+            }
+            (Some(base), None) => Some(base),
+            (None, Some(predicate)) => Some(predicate),
+            (None, None) => None,
+        })
     }
 
     fn eval_judgment_expr(
@@ -1262,6 +1317,7 @@ fn eval_related_predicate(
 ) -> Result<Vec<bool>, EvalError> {
     let length = related_count;
     match expr {
+        CompiledRelatedJudgmentExpr::Literal(value) => Ok(vec![*value; length]),
         CompiledRelatedJudgmentExpr::Comparison { left, op, right } => {
             let left = resolve_related_scalar(left, related_inputs, length)?;
             let right = resolve_related_scalar(right, related_inputs, length)?;

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -48,6 +48,12 @@ struct CacheKey {
     period: Period,
 }
 
+#[derive(Clone, Copy)]
+struct RelationEvalContext<'a> {
+    current_id: &'a str,
+    related_id: &'a str,
+}
+
 pub struct Engine<'a> {
     program: &'a Program,
     input_index: HashMap<(String, String), Vec<&'a crate::model::InputRecord>>,
@@ -397,6 +403,16 @@ impl<'a> Engine<'a> {
         entity_id: &str,
         period: &Period,
     ) -> Result<JudgmentOutcome, EvalError> {
+        self.eval_judgment_expr_inner(expr, entity_id, period, None)
+    }
+
+    fn eval_judgment_expr_inner(
+        &mut self,
+        expr: &JudgmentExpr,
+        entity_id: &str,
+        period: &Period,
+        relation_context: Option<RelationEvalContext<'_>>,
+    ) -> Result<JudgmentOutcome, EvalError> {
         match expr {
             JudgmentExpr::Comparison { left, op, right } => {
                 let left_value = self.eval_scalar_expr(left, entity_id, period)?;
@@ -410,10 +426,35 @@ impl<'a> Engine<'a> {
                 )
             }
             JudgmentExpr::Derived(name) => self.evaluate_judgment(name, entity_id, period),
+            JudgmentExpr::RelationMember {
+                relation,
+                current_slot,
+                related_slot,
+            } => {
+                let context = relation_context.ok_or_else(|| {
+                    EvalError::TypeMismatch(format!(
+                        "relation predicate `{relation}` can only be evaluated inside a derived relation"
+                    ))
+                })?;
+                Ok(
+                    if self.relation_contains(
+                        relation,
+                        *current_slot,
+                        *related_slot,
+                        context.current_id,
+                        context.related_id,
+                        period,
+                    )? {
+                        JudgmentOutcome::Holds
+                    } else {
+                        JudgmentOutcome::NotHolds
+                    },
+                )
+            }
             JudgmentExpr::And(items) => {
                 let mut saw_undetermined = false;
                 for item in items {
-                    match self.eval_judgment_expr(item, entity_id, period)? {
+                    match self.eval_judgment_expr_inner(item, entity_id, period, relation_context)? {
                         JudgmentOutcome::Holds => {}
                         JudgmentOutcome::NotHolds => return Ok(JudgmentOutcome::NotHolds),
                         JudgmentOutcome::Undetermined => saw_undetermined = true,
@@ -428,7 +469,7 @@ impl<'a> Engine<'a> {
             JudgmentExpr::Or(items) => {
                 let mut saw_undetermined = false;
                 for item in items {
-                    match self.eval_judgment_expr(item, entity_id, period)? {
+                    match self.eval_judgment_expr_inner(item, entity_id, period, relation_context)? {
                         JudgmentOutcome::Holds => return Ok(JudgmentOutcome::Holds),
                         JudgmentOutcome::NotHolds => {}
                         JudgmentOutcome::Undetermined => saw_undetermined = true,
@@ -441,7 +482,7 @@ impl<'a> Engine<'a> {
                 })
             }
             JudgmentExpr::Not(item) => {
-                Ok(match self.eval_judgment_expr(item, entity_id, period)? {
+                Ok(match self.eval_judgment_expr_inner(item, entity_id, period, relation_context)? {
                     JudgmentOutcome::Holds => JudgmentOutcome::NotHolds,
                     JudgmentOutcome::NotHolds => JudgmentOutcome::Holds,
                     JudgmentOutcome::Undetermined => JudgmentOutcome::Undetermined,
@@ -529,7 +570,7 @@ impl<'a> Engine<'a> {
     }
 
     fn related_entity_ids(
-        &self,
+        &mut self,
         relation: &str,
         current_slot: usize,
         related_slot: usize,
@@ -548,14 +589,61 @@ impl<'a> Engine<'a> {
             )));
         }
 
-        Ok(self
+        let mut related_ids = self
             .relation_index
             .get(&(relation.to_string(), current_slot, entity_id.to_string()))
             .into_iter()
             .flat_map(|records| records.iter().copied())
             .filter(|record| record.interval.contains_period(period))
             .filter_map(|record| record.tuple.get(related_slot).cloned())
-            .collect())
+            .collect::<Vec<String>>();
+
+        if let Some(derivation) = schema.derivation.clone() {
+            let mut derived_ids = Vec::new();
+            for related_id in self.related_entity_ids(
+                &derivation.source_relation,
+                derivation.current_slot,
+                derivation.related_slot,
+                entity_id,
+                period,
+            )? {
+                let context = RelationEvalContext {
+                    current_id: entity_id,
+                    related_id: &related_id,
+                };
+                if self
+                    .eval_judgment_expr_inner(
+                        &derivation.predicate,
+                        &related_id,
+                        period,
+                        Some(context),
+                    )?
+                    .is_holds()
+                {
+                    derived_ids.push(related_id);
+                }
+            }
+            related_ids.extend(derived_ids);
+        }
+
+        related_ids.sort();
+        related_ids.dedup();
+        Ok(related_ids)
+    }
+
+    fn relation_contains(
+        &mut self,
+        relation: &str,
+        current_slot: usize,
+        related_slot: usize,
+        current_id: &str,
+        related_id: &str,
+        period: &Period,
+    ) -> Result<bool, EvalError> {
+        Ok(self
+            .related_entity_ids(relation, current_slot, related_slot, current_id, period)?
+            .iter()
+            .any(|candidate| candidate == related_id))
     }
 
     fn compare_scalar_values(

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -52,6 +52,20 @@ struct CacheKey {
 struct RelationEvalContext<'a> {
     current_id: &'a str,
     related_id: &'a str,
+    current_entity: Option<&'a str>,
+    related_entity: Option<&'a str>,
+}
+
+impl<'a> RelationEvalContext<'a> {
+    fn entity_id_for(self, entity: &str) -> Option<&'a str> {
+        if self.current_entity == Some(entity) {
+            return Some(self.current_id);
+        }
+        if self.related_entity == Some(entity) {
+            return Some(self.related_id);
+        }
+        None
+    }
 }
 
 pub struct Engine<'a> {
@@ -425,7 +439,13 @@ impl<'a> Engine<'a> {
                     },
                 )
             }
-            JudgmentExpr::Derived(name) => self.evaluate_judgment(name, entity_id, period),
+            JudgmentExpr::Derived(name) => {
+                let derived = self.get_derived(name)?.clone();
+                let target_entity_id = relation_context
+                    .and_then(|context| context.entity_id_for(&derived.entity))
+                    .unwrap_or(entity_id);
+                self.evaluate_judgment(name, target_entity_id, period)
+            }
             JudgmentExpr::RelationMember {
                 relation,
                 current_slot,
@@ -610,6 +630,8 @@ impl<'a> Engine<'a> {
                 let context = RelationEvalContext {
                     current_id: entity_id,
                     related_id: &related_id,
+                    current_entity: derivation.slot_entities.get(derivation.current_slot).map(String::as_str),
+                    related_entity: derivation.slot_entities.get(derivation.related_slot).map(String::as_str),
                 };
                 if self
                     .eval_judgment_expr_inner(

--- a/src/formula.rs
+++ b/src/formula.rs
@@ -1163,6 +1163,7 @@ pub fn lower_module(module: &Module) -> Result<ProgramSpec, FormulaError> {
     let ctx = LowerCtx {
         scalars: scalar_names,
         derived: derived_names,
+        relation_predicates: HashSet::new(),
         relations: std::cell::RefCell::new(HashSet::new()),
     };
     for v in &module.variables {
@@ -1210,7 +1211,11 @@ pub fn lower_module(module: &Module) -> Result<ProgramSpec, FormulaError> {
     let mut relation_names: Vec<String> = ctx.relations.borrow().iter().cloned().collect();
     relation_names.sort();
     for name in relation_names {
-        program.relations.push(RelationSpec { name, arity: 2 });
+        program.relations.push(RelationSpec {
+            name,
+            arity: 2,
+            derivation: None,
+        });
     }
 
     Ok(program)
@@ -1230,6 +1235,10 @@ fn infer_slots(_relation: &str) -> (usize, usize) {
     // relation to put the enclosing entity last (e.g.
     // `disposal_of_applicant` rather than `applicant_disposal`).
     (1, 0)
+}
+
+pub(crate) fn infer_relation_slots_for_rulespec(relation: &str) -> (usize, usize) {
+    infer_slots(relation)
 }
 
 fn is_literal_expr(e: &Expr) -> bool {
@@ -1269,6 +1278,7 @@ fn parse_dtype(s: Option<&str>) -> DTypeSpec {
 struct LowerCtx {
     scalars: HashSet<String>,
     derived: HashSet<String>,
+    relation_predicates: HashSet<String>,
     // Relations discovered while lowering expressions (len / sum /
     // count_where / sum_where) so we can emit matching RelationSpec
     // declarations without requiring an explicit entity-declaration
@@ -1639,6 +1649,13 @@ fn lower_to_judgment(e: &Expr, ctx: &LowerCtx) -> Result<JudgmentExprSpec, Formu
         Expr::Var(name) => {
             if ctx.derived.contains(name) {
                 JudgmentExprSpec::Derived { name: name.clone() }
+            } else if ctx.relation_predicates.contains(name) {
+                let (current_slot, related_slot) = infer_slots(name);
+                JudgmentExprSpec::RelationMember {
+                    relation: name.clone(),
+                    current_slot,
+                    related_slot,
+                }
             } else {
                 JudgmentExprSpec::Comparison {
                     left: Box::new(ScalarExprSpec::Input { name: name.clone() }),
@@ -1714,4 +1731,29 @@ fn lower_to_judgment(e: &Expr, ctx: &LowerCtx) -> Result<JudgmentExprSpec, Formu
 pub(crate) fn lower_source(source: &str) -> Result<ProgramSpec, FormulaError> {
     let module = parse_source(source)?;
     lower_module(&module)
+}
+
+pub(crate) fn lower_judgment_formula(
+    formula: &str,
+    derived_names: HashSet<String>,
+    relation_predicates: HashSet<String>,
+) -> Result<JudgmentExprSpec, FormulaError> {
+    let tokens = Lexer::new(formula).tokenise()?;
+    let mut parser = Parser::new(tokens);
+    let expr = parser.parse_expr()?;
+    if parser.peek(0).ty != TokType::Eof {
+        let tok = parser.peek(0);
+        return Err(FormulaError::parse(
+            tok.line,
+            tok.col,
+            "unexpected trailing token in relation predicate",
+        ));
+    }
+    let ctx = LowerCtx {
+        scalars: HashSet::new(),
+        derived: derived_names,
+        relation_predicates,
+        relations: std::cell::RefCell::new(HashSet::new()),
+    };
+    lower_to_judgment(&expr, &ctx)
 }

--- a/src/model.rs
+++ b/src/model.rs
@@ -247,6 +247,11 @@ pub enum JudgmentExpr {
         right: ScalarExpr,
     },
     Derived(String),
+    RelationMember {
+        relation: String,
+        current_slot: usize,
+        related_slot: usize,
+    },
     And(Vec<JudgmentExpr>),
     Or(Vec<JudgmentExpr>),
     Not(Box<JudgmentExpr>),
@@ -274,6 +279,15 @@ pub struct Derived {
 pub struct RelationSchema {
     pub name: String,
     pub arity: usize,
+    pub derivation: Option<RelationDerivation>,
+}
+
+#[derive(Clone, Debug)]
+pub struct RelationDerivation {
+    pub source_relation: String,
+    pub current_slot: usize,
+    pub related_slot: usize,
+    pub predicate: JudgmentExpr,
 }
 
 #[derive(Clone, Debug)]
@@ -305,9 +319,16 @@ impl Program {
     }
 
     pub fn add_relation(&mut self, name: impl Into<String>, arity: usize) {
-        let name = name.into();
-        self.relations
-            .insert(name.clone(), RelationSchema { name, arity });
+        self.add_relation_schema(RelationSchema {
+            name: name.into(),
+            arity,
+            derivation: None,
+        });
+    }
+
+    pub fn add_relation_schema(&mut self, schema: RelationSchema) {
+        let name = schema.name.clone();
+        self.relations.insert(name, schema);
     }
 
     pub fn add_parameter(&mut self, parameter: IndexedParameter) {
@@ -517,7 +538,7 @@ fn collect_input_slots_from_judgment_expr<'a>(
             collect_input_slots_from_scalar_expr(left, slots);
             collect_input_slots_from_scalar_expr(right, slots);
         }
-        JudgmentExpr::Derived(_) => {}
+        JudgmentExpr::Derived(_) | JudgmentExpr::RelationMember { .. } => {}
         JudgmentExpr::And(items) | JudgmentExpr::Or(items) => {
             for item in items {
                 collect_input_slots_from_judgment_expr(item, slots);

--- a/src/model.rs
+++ b/src/model.rs
@@ -287,6 +287,9 @@ pub struct RelationDerivation {
     pub source_relation: String,
     pub current_slot: usize,
     pub related_slot: usize,
+    pub entity: Option<String>,
+    pub member_relation: Option<String>,
+    pub slot_entities: Vec<String>,
     pub predicate: JudgmentExpr,
 }
 

--- a/src/rulespec.rs
+++ b/src/rulespec.rs
@@ -175,6 +175,12 @@ pub struct DerivedRelationRef {
     pub arity: Option<usize>,
     #[serde(default, alias = "source")]
     pub source_relation: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_optional_string_like")]
+    pub entity: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_optional_string_like")]
+    pub member_relation: Option<String>,
+    #[serde(default)]
+    pub slot_entities: Vec<String>,
     #[serde(default)]
     pub current_slot: Option<usize>,
     #[serde(default)]
@@ -704,6 +710,7 @@ impl RulesDocument {
         rewrite_relation_references(&mut program, &relation_rewrites, &explicit_relations)?;
         append_missing_units(&mut program, &self.units);
         append_missing_relations(&mut program, &explicit_relations)?;
+        rewrite_filtered_entity_member_aliases(&mut program);
         Ok(program)
     }
 
@@ -915,6 +922,9 @@ impl RuleDefinition {
                 source_relation,
                 current_slot: derived_relation.current_slot.unwrap_or(inferred_current_slot),
                 related_slot: derived_relation.related_slot.unwrap_or(inferred_related_slot),
+                entity: derived_relation.entity.clone(),
+                member_relation: derived_relation.member_relation.clone(),
+                slot_entities: derived_relation.slot_entities.clone(),
                 predicate,
             }),
         })
@@ -1192,6 +1202,146 @@ fn append_missing_relations(
         program.relations.push(relation.clone());
     }
     Ok(())
+}
+
+fn rewrite_filtered_entity_member_aliases(program: &mut ProgramSpec) {
+    let aliases = program
+        .relations
+        .iter()
+        .filter_map(|relation| {
+            let derivation = relation.derivation.as_ref()?;
+            Some((
+                derivation.entity.as_ref()?.clone(),
+                derivation.member_relation.as_ref()?.clone(),
+                relation.name.clone(),
+            ))
+        })
+        .collect::<Vec<(String, String, String)>>();
+    if aliases.is_empty() {
+        return;
+    }
+
+    for derived in &mut program.derived {
+        for (entity, alias, relation_name) in &aliases {
+            if &derived.entity != entity {
+                continue;
+            }
+            match &mut derived.semantics {
+                DerivedSemanticsSpec::Scalar { expr } => {
+                    rewrite_relation_alias_in_scalar(expr, alias, relation_name);
+                }
+                DerivedSemanticsSpec::Judgment { expr } => {
+                    rewrite_relation_alias_in_judgment(expr, alias, relation_name);
+                }
+            }
+        }
+    }
+
+    let alias_names = aliases
+        .into_iter()
+        .map(|(_, alias, _)| alias)
+        .collect::<HashSet<String>>();
+    let used_relations = used_relation_names(program);
+    program
+        .relations
+        .retain(|relation| !alias_names.contains(&relation.name) || used_relations.contains(&relation.name));
+}
+
+fn rewrite_relation_alias_in_scalar(expr: &mut ScalarExprSpec, alias: &str, relation_name: &str) {
+    match expr {
+        ScalarExprSpec::Literal { .. }
+        | ScalarExprSpec::Input { .. }
+        | ScalarExprSpec::Derived { .. }
+        | ScalarExprSpec::PeriodStart
+        | ScalarExprSpec::PeriodEnd => {}
+        ScalarExprSpec::InputOrElse { default: _, .. } => {}
+        ScalarExprSpec::ParameterLookup { index, .. }
+        | ScalarExprSpec::Ceil { value: index }
+        | ScalarExprSpec::Floor { value: index } => {
+            rewrite_relation_alias_in_scalar(index, alias, relation_name);
+        }
+        ScalarExprSpec::Add { items }
+        | ScalarExprSpec::Max { items }
+        | ScalarExprSpec::Min { items } => {
+            for item in items {
+                rewrite_relation_alias_in_scalar(item, alias, relation_name);
+            }
+        }
+        ScalarExprSpec::Sub { left, right }
+        | ScalarExprSpec::Mul { left, right }
+        | ScalarExprSpec::Div { left, right } => {
+            rewrite_relation_alias_in_scalar(left, alias, relation_name);
+            rewrite_relation_alias_in_scalar(right, alias, relation_name);
+        }
+        ScalarExprSpec::DateAddDays { date, days } => {
+            rewrite_relation_alias_in_scalar(date, alias, relation_name);
+            rewrite_relation_alias_in_scalar(days, alias, relation_name);
+        }
+        ScalarExprSpec::DaysBetween { from, to } => {
+            rewrite_relation_alias_in_scalar(from, alias, relation_name);
+            rewrite_relation_alias_in_scalar(to, alias, relation_name);
+        }
+        ScalarExprSpec::CountRelated {
+            relation,
+            where_clause,
+            ..
+        } => {
+            if relation == alias {
+                *relation = relation_name.to_string();
+            }
+            if let Some(where_clause) = where_clause {
+                rewrite_relation_alias_in_judgment(where_clause, alias, relation_name);
+            }
+        }
+        ScalarExprSpec::SumRelated {
+            relation,
+            where_clause,
+            ..
+        } => {
+            if relation == alias {
+                *relation = relation_name.to_string();
+            }
+            if let Some(where_clause) = where_clause {
+                rewrite_relation_alias_in_judgment(where_clause, alias, relation_name);
+            }
+        }
+        ScalarExprSpec::If {
+            condition,
+            then_expr,
+            else_expr,
+        } => {
+            rewrite_relation_alias_in_judgment(condition, alias, relation_name);
+            rewrite_relation_alias_in_scalar(then_expr, alias, relation_name);
+            rewrite_relation_alias_in_scalar(else_expr, alias, relation_name);
+        }
+    }
+}
+
+fn rewrite_relation_alias_in_judgment(
+    expr: &mut JudgmentExprSpec,
+    alias: &str,
+    relation_name: &str,
+) {
+    match expr {
+        JudgmentExprSpec::Comparison { left, right, .. } => {
+            rewrite_relation_alias_in_scalar(left, alias, relation_name);
+            rewrite_relation_alias_in_scalar(right, alias, relation_name);
+        }
+        JudgmentExprSpec::Derived { .. } => {}
+        JudgmentExprSpec::RelationMember { relation, .. } => {
+            if relation == alias {
+                *relation = relation_name.to_string();
+            }
+        }
+        JudgmentExprSpec::And { items } | JudgmentExprSpec::Or { items } => {
+            for item in items {
+                rewrite_relation_alias_in_judgment(item, alias, relation_name);
+            }
+        }
+        JudgmentExprSpec::Not { item } => {
+            rewrite_relation_alias_in_judgment(item, alias, relation_name);
+        }
+    }
 }
 
 fn rewrite_relation_references(

--- a/src/rulespec.rs
+++ b/src/rulespec.rs
@@ -9,7 +9,7 @@ use thiserror::Error;
 
 use crate::spec::{
     DerivedSemanticsSpec, IndexedParameterSpec, JudgmentExprSpec, ParameterVersionSpec,
-    ProgramSpec, RelationSpec, ScalarExprSpec, ScalarValueSpec, UnitSpec,
+    ProgramSpec, RelationDerivationSpec, RelationSpec, ScalarExprSpec, ScalarValueSpec, UnitSpec,
 };
 
 #[derive(Debug, Error)]
@@ -46,6 +46,14 @@ pub enum RuleSpecError {
     TopLevelArityUnsupported { name: String },
     #[error("RuleSpec data relation `{name}` must declare data_relation.arity")]
     MissingDataRelationArity { name: String },
+    #[error("RuleSpec derived relation `{name}` must declare derived_relation")]
+    MissingDerivedRelation { name: String },
+    #[error("RuleSpec derived relation `{name}` must declare derived_relation.arity")]
+    MissingDerivedRelationArity { name: String },
+    #[error("RuleSpec derived relation `{name}` must declare derived_relation.source_relation")]
+    MissingDerivedRelationSource { name: String },
+    #[error("RuleSpec derived relation `{name}` must declare exactly one membership formula version")]
+    InvalidDerivedRelationFormulaVersions { name: String },
     #[error("RuleSpec source relation `{name}` must declare source_relation")]
     MissingSourceRelation { name: String },
     #[error("RuleSpec source relation `{name}` must declare source_relation.type")]
@@ -121,6 +129,7 @@ pub enum RuleKind {
     Parameter,
     Derived,
     DataRelation,
+    DerivedRelation,
     SourceRelation,
     Unsupported(String),
 }
@@ -135,6 +144,7 @@ impl<'de> Deserialize<'de> for RuleKind {
             "parameter" => Self::Parameter,
             "derived" => Self::Derived,
             "data_relation" => Self::DataRelation,
+            "derived_relation" => Self::DerivedRelation,
             "source_relation" => Self::SourceRelation,
             _ => Self::Unsupported(value),
         })
@@ -157,6 +167,18 @@ pub struct SourceRef {
 pub struct DataRelationRef {
     #[serde(default)]
     pub arity: Option<usize>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize)]
+pub struct DerivedRelationRef {
+    #[serde(default)]
+    pub arity: Option<usize>,
+    #[serde(default, alias = "source")]
+    pub source_relation: Option<String>,
+    #[serde(default)]
+    pub current_slot: Option<usize>,
+    #[serde(default)]
+    pub related_slot: Option<usize>,
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
@@ -250,6 +272,8 @@ pub struct RuleDefinition {
     pub sources: Vec<SourceRef>,
     #[serde(default)]
     pub data_relation: Option<DataRelationRef>,
+    #[serde(default)]
+    pub derived_relation: Option<DerivedRelationRef>,
     #[serde(default)]
     pub source_relation: Option<SourceRelationRef>,
     #[serde(default)]
@@ -586,6 +610,24 @@ impl RulesDocument {
         let mut relation_rewrites = HashMap::new();
         let mut table_parameters = Vec::new();
         let mut table_parameter_names = HashSet::new();
+        let derived_rule_names = self
+            .rules
+            .iter()
+            .filter_map(|rule| match rule.kind.as_ref() {
+                Some(RuleKind::Derived) => Some(rule.name.clone()),
+                _ => None,
+            })
+            .collect::<HashSet<String>>();
+        let relation_predicate_names = self
+            .rules
+            .iter()
+            .filter_map(|rule| match rule.kind.as_ref() {
+                Some(RuleKind::DataRelation | RuleKind::DerivedRelation) => {
+                    Some(rule.name.clone())
+                }
+                _ => None,
+            })
+            .collect::<HashSet<String>>();
         for rule in &self.rules {
             let kind = match rule.declared_kind() {
                 Ok(kind) => kind,
@@ -616,6 +658,20 @@ impl RulesDocument {
                 RuleKind::DataRelation => {
                     rule.reject_top_level_arity()?;
                     let relation = rule.to_data_relation_spec()?;
+                    if relation.name != rule.name {
+                        if let Some(origin_target) = rule.origin_target.as_deref() {
+                            relation_rewrites.insert(
+                                (origin_target.to_string(), rule.name.clone()),
+                                relation.name.clone(),
+                            );
+                        }
+                    }
+                    explicit_relations.push(relation);
+                }
+                RuleKind::DerivedRelation => {
+                    rule.reject_top_level_arity()?;
+                    let relation = rule
+                        .to_derived_relation_spec(&derived_rule_names, &relation_predicate_names)?;
                     if relation.name != rule.name {
                         if let Some(origin_target) = rule.origin_target.as_deref() {
                             relation_rewrites.insert(
@@ -801,6 +857,66 @@ impl RuleDefinition {
         Ok(RelationSpec {
             name: self.canonical_relation_id(),
             arity,
+            derivation: None,
+        })
+    }
+
+    fn to_derived_relation_spec(
+        &self,
+        derived_names: &HashSet<String>,
+        relation_predicate_names: &HashSet<String>,
+    ) -> Result<RelationSpec, RuleSpecError> {
+        let derived_relation =
+            self.derived_relation
+                .as_ref()
+                .ok_or_else(|| RuleSpecError::MissingDerivedRelation {
+                    name: self.name.clone(),
+                })?;
+        let arity =
+            derived_relation
+                .arity
+                .ok_or_else(|| RuleSpecError::MissingDerivedRelationArity {
+                    name: self.name.clone(),
+                })?;
+        let source_relation = derived_relation
+            .source_relation
+            .as_deref()
+            .map(str::trim)
+            .filter(|source| !source.is_empty())
+            .ok_or_else(|| RuleSpecError::MissingDerivedRelationSource {
+                name: self.name.clone(),
+            })?
+            .to_string();
+        let versions = self.effective_versions();
+        if versions.len() != 1 {
+            return Err(RuleSpecError::InvalidDerivedRelationFormulaVersions {
+                name: self.name.clone(),
+            });
+        }
+        let formula = versions[0]
+            .formula
+            .as_deref()
+            .map(str::trim)
+            .filter(|formula| !formula.is_empty())
+            .ok_or_else(|| RuleSpecError::MissingFormula {
+                name: self.name.clone(),
+            })?;
+        let predicate = crate::formula::lower_judgment_formula(
+            formula,
+            derived_names.clone(),
+            relation_predicate_names.clone(),
+        )?;
+        let (inferred_current_slot, inferred_related_slot) =
+            crate::formula::infer_relation_slots_for_rulespec(source_relation.as_str());
+        Ok(RelationSpec {
+            name: self.canonical_relation_id(),
+            arity,
+            derivation: Some(RelationDerivationSpec {
+                source_relation,
+                current_slot: derived_relation.current_slot.unwrap_or(inferred_current_slot),
+                related_slot: derived_relation.related_slot.unwrap_or(inferred_related_slot),
+                predicate,
+            }),
         })
     }
 
@@ -1058,7 +1174,7 @@ fn append_missing_relations(
     for relation in relations {
         if let Some(existing) = program
             .relations
-            .iter()
+            .iter_mut()
             .find(|existing| existing.name == relation.name)
         {
             if existing.arity != relation.arity {
@@ -1067,6 +1183,9 @@ fn append_missing_relations(
                     existing: existing.arity,
                     new: relation.arity,
                 });
+            }
+            if existing.derivation.is_none() && relation.derivation.is_some() {
+                existing.derivation = relation.derivation.clone();
             }
             continue;
         }
@@ -1128,6 +1247,19 @@ fn rewrite_relation_references(
             }
         }
     }
+    for relation in &mut program.relations {
+        let Some(origin_target) = relation
+            .name
+            .split_once("#relation.")
+            .map(|(target, _)| target)
+        else {
+            continue;
+        };
+        if let Some(derivation) = &mut relation.derivation {
+            rewrite_relation_name(&mut derivation.source_relation, origin_target, rewrites);
+            rewrite_judgment_relation_references(&mut derivation.predicate, origin_target, rewrites);
+        }
+    }
     let used_relations = used_relation_names(program);
     program.relations.retain(|relation| {
         !namespaced_short_names.contains(&relation.name) || used_relations.contains(&relation.name)
@@ -1145,6 +1277,12 @@ fn used_relation_names(program: &ProgramSpec) -> HashSet<String> {
             DerivedSemanticsSpec::Judgment { expr } => {
                 collect_judgment_relation_names(expr, &mut names);
             }
+        }
+    }
+    for relation in &program.relations {
+        if let Some(derivation) = &relation.derivation {
+            names.insert(derivation.source_relation.clone());
+            collect_judgment_relation_names(&derivation.predicate, &mut names);
         }
     }
     names
@@ -1219,6 +1357,9 @@ fn collect_scalar_relation_names(expr: &ScalarExprSpec, names: &mut HashSet<Stri
 fn collect_judgment_relation_names(expr: &JudgmentExprSpec, names: &mut HashSet<String>) {
     match expr {
         JudgmentExprSpec::Derived { .. } => {}
+        JudgmentExprSpec::RelationMember { relation, .. } => {
+            names.insert(relation.clone());
+        }
         JudgmentExprSpec::Comparison { left, right, .. } => {
             collect_scalar_relation_names(left, names);
             collect_scalar_relation_names(right, names);
@@ -1315,6 +1456,9 @@ fn rewrite_judgment_relation_references(
             rewrite_scalar_relation_references(right, origin_target, rewrites);
         }
         JudgmentExprSpec::Derived { .. } => {}
+        JudgmentExprSpec::RelationMember { relation, .. } => {
+            rewrite_relation_name(relation, origin_target, rewrites);
+        }
         JudgmentExprSpec::And { items } | JudgmentExprSpec::Or { items } => {
             for item in items {
                 rewrite_judgment_relation_references(item, origin_target, rewrites);

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -9,7 +9,8 @@ use thiserror::Error;
 use crate::model::{
     ComparisonOp, DType, DataSet, Derived, DerivedSemantics, IndexedParameter, InputRecord,
     Interval, JudgmentExpr, JudgmentOutcome, ParameterVersion, Period, PeriodKind, Program,
-    RelatedValueRef, RelationRecord, ScalarExpr, ScalarValue, UnitDef, UnitKind,
+    RelatedValueRef, RelationDerivation, RelationRecord, RelationSchema, ScalarExpr, ScalarValue,
+    UnitDef, UnitKind,
 };
 
 #[derive(Debug, Error)]
@@ -80,7 +81,7 @@ impl ProgramSpec {
         }
 
         for relation in &self.relations {
-            program.add_relation(&relation.name, relation.arity);
+            program.add_relation_schema(relation.to_model()?);
         }
 
         for parameter in &self.parameters {
@@ -178,6 +179,41 @@ impl UnitKindSpec {
 pub struct RelationSpec {
     pub name: String,
     pub arity: usize,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub derivation: Option<RelationDerivationSpec>,
+}
+
+impl RelationSpec {
+    fn to_model(&self) -> Result<RelationSchema, SpecError> {
+        Ok(RelationSchema {
+            name: self.name.clone(),
+            arity: self.arity,
+            derivation: self
+                .derivation
+                .as_ref()
+                .map(RelationDerivationSpec::to_model)
+                .transpose()?,
+        })
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct RelationDerivationSpec {
+    pub source_relation: String,
+    pub current_slot: usize,
+    pub related_slot: usize,
+    pub predicate: JudgmentExprSpec,
+}
+
+impl RelationDerivationSpec {
+    fn to_model(&self) -> Result<RelationDerivation, SpecError> {
+        Ok(RelationDerivation {
+            source_relation: self.source_relation.clone(),
+            current_slot: self.current_slot,
+            related_slot: self.related_slot,
+            predicate: self.predicate.to_model()?,
+        })
+    }
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -605,6 +641,11 @@ pub enum JudgmentExprSpec {
     Derived {
         name: String,
     },
+    RelationMember {
+        relation: String,
+        current_slot: usize,
+        related_slot: usize,
+    },
     And {
         items: Vec<JudgmentExprSpec>,
     },
@@ -625,6 +666,15 @@ impl JudgmentExprSpec {
                 right: right.to_model()?,
             }),
             Self::Derived { name } => Ok(JudgmentExpr::Derived(name.clone())),
+            Self::RelationMember {
+                relation,
+                current_slot,
+                related_slot,
+            } => Ok(JudgmentExpr::RelationMember {
+                relation: relation.clone(),
+                current_slot: *current_slot,
+                related_slot: *related_slot,
+            }),
             Self::And { items } => Ok(JudgmentExpr::And(
                 items
                     .iter()

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -202,6 +202,12 @@ pub struct RelationDerivationSpec {
     pub source_relation: String,
     pub current_slot: usize,
     pub related_slot: usize,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub entity: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub member_relation: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub slot_entities: Vec<String>,
     pub predicate: JudgmentExprSpec,
 }
 
@@ -211,6 +217,9 @@ impl RelationDerivationSpec {
             source_relation: self.source_relation.clone(),
             current_slot: self.current_slot,
             related_slot: self.related_slot,
+            entity: self.entity.clone(),
+            member_relation: self.member_relation.clone(),
+            slot_entities: self.slot_entities.clone(),
             predicate: self.predicate.to_model()?,
         })
     }

--- a/tests/dense.rs
+++ b/tests/dense.rs
@@ -51,6 +51,48 @@ const SCOTTISH_CTR_MAX_PROGRAM_RULESPEC: &str =
 const SCOTTISH_CTR_MAX_CASES_YAML: &str =
     include_str!("fixtures/rulespec/ssi/2021/249/regulation/79/cases.yaml");
 
+const FILTERED_ENTITY_RULESPEC: &str = r#"
+format: rulespec/v1
+rules:
+  - name: member_of_household
+    kind: data_relation
+    data_relation:
+      arity: 2
+  - name: snap_member_eligible
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    versions:
+      - effective_from: 2026-01-01
+        formula: has_ssn and not student_ineligible
+  - name: snap_unit
+    kind: derived_relation
+    derived_relation:
+      arity: 2
+      source_relation: member_of_household
+      entity: SnapUnit
+      member_relation: members
+      slot_entities: [Person, Household]
+    versions:
+      - effective_from: 2026-01-01
+        formula: member_of_household and snap_member_eligible
+  - name: snap_unit_size
+    kind: derived
+    entity: SnapUnit
+    dtype: Integer
+    versions:
+      - effective_from: 2026-01-01
+        formula: len(members)
+  - name: snap_unit_income
+    kind: derived
+    entity: SnapUnit
+    dtype: Money
+    unit: USD
+    versions:
+      - effective_from: 2026-01-01
+        formula: sum(members.income)
+"#;
+
 #[test]
 fn dense_flat_tax_matches_explain_mode() {
     let period = month_period();
@@ -306,6 +348,155 @@ fn dense_family_allowance_matches_explain_mode() {
                 .outputs
                 .get("monthly_allowance")
                 .expect("dense monthly allowance"),
+            row,
+        );
+    }
+}
+
+#[test]
+fn dense_filtered_entity_scope_matches_explain_mode() {
+    let period = month_period();
+    let artifact = CompiledProgramArtifact::from_rulespec_str(FILTERED_ENTITY_RULESPEC)
+        .expect("RuleSpec module compiles");
+    let dense = DenseCompiledProgram::from_artifact(&artifact, Some("SnapUnit"))
+        .expect("dense compilation succeeds");
+
+    let households = [
+        (
+            "household-1",
+            vec![
+                ("person-1", true, false, decimal("100")),
+                ("person-2", false, false, decimal("250")),
+                ("person-3", true, true, decimal("400")),
+            ],
+        ),
+        (
+            "household-2",
+            vec![
+                ("person-4", true, false, decimal("50")),
+                ("person-5", true, false, decimal("75")),
+            ],
+        ),
+    ];
+
+    let mut inputs = Vec::new();
+    let mut relations = Vec::new();
+    let interval = period_interval(&period);
+    for (household_id, members) in households {
+        for (person_id, has_ssn, student_ineligible, income) in members {
+            inputs.push(InputRecordSpec {
+                name: "has_ssn".to_string(),
+                entity: "Person".to_string(),
+                entity_id: person_id.to_string(),
+                interval: interval.clone(),
+                value: ScalarValueSpec::Bool { value: has_ssn },
+            });
+            inputs.push(InputRecordSpec {
+                name: "student_ineligible".to_string(),
+                entity: "Person".to_string(),
+                entity_id: person_id.to_string(),
+                interval: interval.clone(),
+                value: ScalarValueSpec::Bool {
+                    value: student_ineligible,
+                },
+            });
+            inputs.push(InputRecordSpec {
+                name: "income".to_string(),
+                entity: "Person".to_string(),
+                entity_id: person_id.to_string(),
+                interval: interval.clone(),
+                value: ScalarValueSpec::Decimal {
+                    value: income.normalize().to_string(),
+                },
+            });
+            relations.push(RelationRecordSpec {
+                name: "member_of_household".to_string(),
+                tuple: vec![person_id.to_string(), household_id.to_string()],
+                interval: interval.clone(),
+            });
+        }
+    }
+
+    let explain = execute_request(ExecutionRequest {
+        mode: ExecutionMode::Explain,
+        program: artifact.program.clone(),
+        dataset: DatasetSpec { inputs, relations },
+        queries: ["household-1", "household-2"]
+            .into_iter()
+            .map(|entity_id| ExecutionQuery {
+                entity_id: entity_id.to_string(),
+                period: period.clone(),
+                outputs: vec![
+                    "snap_unit_size".to_string(),
+                    "snap_unit_income".to_string(),
+                ],
+            })
+            .collect(),
+    })
+    .expect("explain execution succeeds");
+
+    let dense_result = dense
+        .execute(
+            &period.to_model().expect("period converts"),
+            DenseBatchSpec {
+                row_count: 2,
+                inputs: HashMap::new(),
+                relations: HashMap::from([(
+                    DenseRelationKey {
+                        name: "member_of_household".to_string(),
+                        current_slot: 1,
+                        related_slot: 0,
+                    },
+                    DenseRelationBatchSpec {
+                        offsets: vec![0, 3, 5],
+                        inputs: HashMap::from([
+                            (
+                                "has_ssn".to_string(),
+                                DenseColumn::Bool(vec![true, false, true, true, true]),
+                            ),
+                            (
+                                "student_ineligible".to_string(),
+                                DenseColumn::Bool(vec![false, false, true, false, false]),
+                            ),
+                            (
+                                "income".to_string(),
+                                DenseColumn::Decimal(vec![
+                                    decimal("100"),
+                                    decimal("250"),
+                                    decimal("400"),
+                                    decimal("50"),
+                                    decimal("75"),
+                                ]),
+                            ),
+                        ]),
+                    },
+                )]),
+            },
+            &["snap_unit_size".to_string(), "snap_unit_income".to_string()],
+        )
+        .expect("dense execution succeeds");
+
+    for row in 0..2 {
+        compare_scalar(
+            explain.results[row]
+                .outputs
+                .get("snap_unit_size")
+                .expect("snap unit size output"),
+            dense_result
+                .outputs
+                .get("snap_unit_size")
+                .expect("dense snap unit size"),
+            row,
+        );
+        compare_scalar(
+            explain.results[row]
+                .outputs
+                .get("snap_unit_income")
+                .expect("snap unit income output"),
+            dense_result
+                .outputs
+                .get("snap_unit_income")
+                .expect("dense snap unit income"),
             row,
         );
     }

--- a/tests/dense.rs
+++ b/tests/dense.rs
@@ -93,6 +93,99 @@ rules:
         formula: sum(members.income)
 "#;
 
+const CROSS_SCOPE_FILTERED_ENTITY_RULESPEC: &str = r#"
+format: rulespec/v1
+rules:
+  - name: member_of_household
+    kind: data_relation
+    data_relation:
+      arity: 2
+  - name: household_accepts_snap_members
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    versions:
+      - effective_from: 2026-01-01
+        formula: snap_application_active
+  - name: snap_member_eligible
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    versions:
+      - effective_from: 2026-01-01
+        formula: has_ssn
+  - name: snap_unit
+    kind: derived_relation
+    derived_relation:
+      arity: 2
+      source_relation: member_of_household
+      entity: SnapUnit
+      member_relation: members
+      slot_entities: [Person, Household]
+    versions:
+      - effective_from: 2026-01-01
+        formula: member_of_household and household_accepts_snap_members and snap_member_eligible
+  - name: snap_unit_size
+    kind: derived
+    entity: SnapUnit
+    dtype: Integer
+    versions:
+      - effective_from: 2026-01-01
+        formula: len(members)
+"#;
+
+const COMPOSED_FILTERED_ENTITY_RULESPEC: &str = r#"
+format: rulespec/v1
+rules:
+  - name: member_of_household
+    kind: data_relation
+    data_relation:
+      arity: 2
+  - name: snap_member_eligible
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    versions:
+      - effective_from: 2026-01-01
+        formula: has_ssn
+  - name: adult_member
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    versions:
+      - effective_from: 2026-01-01
+        formula: age >= 18
+  - name: snap_unit
+    kind: derived_relation
+    derived_relation:
+      arity: 2
+      source_relation: member_of_household
+      entity: SnapUnit
+      member_relation: members
+      slot_entities: [Person, Household]
+    versions:
+      - effective_from: 2026-01-01
+        formula: snap_member_eligible
+  - name: adult_snap_unit
+    kind: derived_relation
+    derived_relation:
+      arity: 2
+      source_relation: snap_unit
+      entity: AdultSnapUnit
+      member_relation: adult_members
+      slot_entities: [Person, Household]
+    versions:
+      - effective_from: 2026-01-01
+        formula: adult_member
+  - name: adult_snap_unit_size
+    kind: derived
+    entity: AdultSnapUnit
+    dtype: Integer
+    versions:
+      - effective_from: 2026-01-01
+        formula: len(adult_members)
+"#;
+
 #[test]
 fn dense_flat_tax_matches_explain_mode() {
     let period = month_period();
@@ -500,6 +593,241 @@ fn dense_filtered_entity_scope_matches_explain_mode() {
             row,
         );
     }
+}
+
+#[test]
+fn dense_filtered_entity_membership_can_depend_on_current_entity_predicates() {
+    let period = month_period();
+    let artifact = CompiledProgramArtifact::from_rulespec_str(CROSS_SCOPE_FILTERED_ENTITY_RULESPEC)
+        .expect("RuleSpec module compiles");
+    let dense = DenseCompiledProgram::from_artifact(&artifact, Some("SnapUnit"))
+        .expect("dense compilation succeeds");
+
+    let explain = execute_request(ExecutionRequest {
+        mode: ExecutionMode::Explain,
+        program: artifact.program.clone(),
+        dataset: DatasetSpec {
+            inputs: vec![
+                InputRecordSpec {
+                    name: "snap_application_active".to_string(),
+                    entity: "Household".to_string(),
+                    entity_id: "household-1".to_string(),
+                    interval: period_interval(&period),
+                    value: ScalarValueSpec::Bool { value: true },
+                },
+                InputRecordSpec {
+                    name: "snap_application_active".to_string(),
+                    entity: "Household".to_string(),
+                    entity_id: "household-2".to_string(),
+                    interval: period_interval(&period),
+                    value: ScalarValueSpec::Bool { value: false },
+                },
+                InputRecordSpec {
+                    name: "has_ssn".to_string(),
+                    entity: "Person".to_string(),
+                    entity_id: "person-1".to_string(),
+                    interval: period_interval(&period),
+                    value: ScalarValueSpec::Bool { value: true },
+                },
+                InputRecordSpec {
+                    name: "has_ssn".to_string(),
+                    entity: "Person".to_string(),
+                    entity_id: "person-2".to_string(),
+                    interval: period_interval(&period),
+                    value: ScalarValueSpec::Bool { value: true },
+                },
+            ],
+            relations: vec![
+                RelationRecordSpec {
+                    name: "member_of_household".to_string(),
+                    tuple: vec!["person-1".to_string(), "household-1".to_string()],
+                    interval: period_interval(&period),
+                },
+                RelationRecordSpec {
+                    name: "member_of_household".to_string(),
+                    tuple: vec!["person-2".to_string(), "household-2".to_string()],
+                    interval: period_interval(&period),
+                },
+            ],
+        },
+        queries: ["household-1", "household-2"]
+            .into_iter()
+            .map(|entity_id| ExecutionQuery {
+                entity_id: entity_id.to_string(),
+                period: period.clone(),
+                outputs: vec!["snap_unit_size".to_string()],
+            })
+            .collect(),
+    })
+    .expect("explain execution succeeds");
+
+    let dense_result = dense
+        .execute(
+            &period.to_model().expect("period converts"),
+            DenseBatchSpec {
+                row_count: 2,
+                inputs: HashMap::from([(
+                    "snap_application_active".to_string(),
+                    DenseColumn::Bool(vec![true, false]),
+                )]),
+                relations: HashMap::from([(
+                    DenseRelationKey {
+                        name: "member_of_household".to_string(),
+                        current_slot: 1,
+                        related_slot: 0,
+                    },
+                    DenseRelationBatchSpec {
+                        offsets: vec![0, 1, 2],
+                        inputs: HashMap::from([(
+                            "has_ssn".to_string(),
+                            DenseColumn::Bool(vec![true, true]),
+                        )]),
+                    },
+                )]),
+            },
+            &["snap_unit_size".to_string()],
+        )
+        .expect("dense execution succeeds");
+
+    for row in 0..2 {
+        compare_scalar(
+            explain.results[row]
+                .outputs
+                .get("snap_unit_size")
+                .expect("snap unit size output"),
+            dense_result
+                .outputs
+                .get("snap_unit_size")
+                .expect("dense snap unit size"),
+            row,
+        );
+    }
+}
+
+#[test]
+fn dense_filtered_entities_can_compose_source_relations() {
+    let period = month_period();
+    let artifact = CompiledProgramArtifact::from_rulespec_str(COMPOSED_FILTERED_ENTITY_RULESPEC)
+        .expect("RuleSpec module compiles");
+    let dense = DenseCompiledProgram::from_artifact(&artifact, Some("AdultSnapUnit"))
+        .expect("dense compilation succeeds");
+
+    let explain = execute_request(ExecutionRequest {
+        mode: ExecutionMode::Explain,
+        program: artifact.program.clone(),
+        dataset: DatasetSpec {
+            inputs: vec![
+                InputRecordSpec {
+                    name: "has_ssn".to_string(),
+                    entity: "Person".to_string(),
+                    entity_id: "person-1".to_string(),
+                    interval: period_interval(&period),
+                    value: ScalarValueSpec::Bool { value: true },
+                },
+                InputRecordSpec {
+                    name: "has_ssn".to_string(),
+                    entity: "Person".to_string(),
+                    entity_id: "person-2".to_string(),
+                    interval: period_interval(&period),
+                    value: ScalarValueSpec::Bool { value: true },
+                },
+                InputRecordSpec {
+                    name: "has_ssn".to_string(),
+                    entity: "Person".to_string(),
+                    entity_id: "person-3".to_string(),
+                    interval: period_interval(&period),
+                    value: ScalarValueSpec::Bool { value: false },
+                },
+                InputRecordSpec {
+                    name: "age".to_string(),
+                    entity: "Person".to_string(),
+                    entity_id: "person-1".to_string(),
+                    interval: period_interval(&period),
+                    value: ScalarValueSpec::Integer { value: 30 },
+                },
+                InputRecordSpec {
+                    name: "age".to_string(),
+                    entity: "Person".to_string(),
+                    entity_id: "person-2".to_string(),
+                    interval: period_interval(&period),
+                    value: ScalarValueSpec::Integer { value: 12 },
+                },
+                InputRecordSpec {
+                    name: "age".to_string(),
+                    entity: "Person".to_string(),
+                    entity_id: "person-3".to_string(),
+                    interval: period_interval(&period),
+                    value: ScalarValueSpec::Integer { value: 40 },
+                },
+            ],
+            relations: vec![
+                RelationRecordSpec {
+                    name: "member_of_household".to_string(),
+                    tuple: vec!["person-1".to_string(), "household-1".to_string()],
+                    interval: period_interval(&period),
+                },
+                RelationRecordSpec {
+                    name: "member_of_household".to_string(),
+                    tuple: vec!["person-2".to_string(), "household-1".to_string()],
+                    interval: period_interval(&period),
+                },
+                RelationRecordSpec {
+                    name: "member_of_household".to_string(),
+                    tuple: vec!["person-3".to_string(), "household-1".to_string()],
+                    interval: period_interval(&period),
+                },
+            ],
+        },
+        queries: vec![ExecutionQuery {
+            entity_id: "household-1".to_string(),
+            period: period.clone(),
+            outputs: vec!["adult_snap_unit_size".to_string()],
+        }],
+    })
+    .expect("explain execution succeeds");
+
+    let dense_result = dense
+        .execute(
+            &period.to_model().expect("period converts"),
+            DenseBatchSpec {
+                row_count: 1,
+                inputs: HashMap::new(),
+                relations: HashMap::from([(
+                    DenseRelationKey {
+                        name: "member_of_household".to_string(),
+                        current_slot: 1,
+                        related_slot: 0,
+                    },
+                    DenseRelationBatchSpec {
+                        offsets: vec![0, 3],
+                        inputs: HashMap::from([
+                            (
+                                "has_ssn".to_string(),
+                                DenseColumn::Bool(vec![true, true, false]),
+                            ),
+                            (
+                                "age".to_string(),
+                                DenseColumn::Integer(vec![30, 12, 40]),
+                            ),
+                        ]),
+                    },
+                )]),
+            },
+            &["adult_snap_unit_size".to_string()],
+        )
+        .expect("dense execution succeeds");
+
+    compare_scalar(
+        explain.results[0]
+            .outputs
+            .get("adult_snap_unit_size")
+            .expect("adult snap unit size output"),
+        dense_result
+            .outputs
+            .get("adult_snap_unit_size")
+            .expect("dense adult snap unit size"),
+        0,
+    );
 }
 
 #[test]

--- a/tests/execution.rs
+++ b/tests/execution.rs
@@ -617,6 +617,144 @@ rules:
 }
 
 #[test]
+fn filtered_entity_scope_aggregates_over_member_alias() {
+    let rulespec = r#"
+format: rulespec/v1
+rules:
+  - name: member_of_household
+    kind: data_relation
+    data_relation:
+      arity: 2
+  - name: snap_member_eligible
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    versions:
+      - effective_from: 2026-01-01
+        formula: has_ssn
+  - name: snap_unit
+    kind: derived_relation
+    derived_relation:
+      arity: 2
+      source_relation: member_of_household
+      entity: SnapUnit
+      member_relation: members
+      slot_entities: [Person, Household]
+    versions:
+      - effective_from: 2026-01-01
+        formula: member_of_household and snap_member_eligible
+  - name: snap_unit_size
+    kind: derived
+    entity: SnapUnit
+    dtype: Integer
+    versions:
+      - effective_from: 2026-01-01
+        formula: len(members)
+  - name: snap_unit_income
+    kind: derived
+    entity: SnapUnit
+    dtype: Money
+    unit: USD
+    versions:
+      - effective_from: 2026-01-01
+        formula: sum(members.income)
+"#;
+    let program =
+        axiom_rules_engine::rulespec::lower_rulespec_str(rulespec).expect("RuleSpec lowers");
+    let period = PeriodSpec {
+        kind: PeriodKindSpec::Month,
+        start: chrono::NaiveDate::from_ymd_opt(2026, 1, 1).expect("valid date"),
+        end: chrono::NaiveDate::from_ymd_opt(2026, 1, 31).expect("valid date"),
+    };
+    let interval = IntervalSpec {
+        start: period.start,
+        end: period.end,
+    };
+    let dataset = DatasetSpec {
+        inputs: vec![
+            InputRecordSpec {
+                name: "has_ssn".to_string(),
+                entity: "Person".to_string(),
+                entity_id: "person-1".to_string(),
+                interval: interval.clone(),
+                value: ScalarValueSpec::Bool { value: true },
+            },
+            InputRecordSpec {
+                name: "income".to_string(),
+                entity: "Person".to_string(),
+                entity_id: "person-1".to_string(),
+                interval: interval.clone(),
+                value: ScalarValueSpec::Decimal {
+                    value: "100".to_string(),
+                },
+            },
+            InputRecordSpec {
+                name: "has_ssn".to_string(),
+                entity: "Person".to_string(),
+                entity_id: "person-2".to_string(),
+                interval: interval.clone(),
+                value: ScalarValueSpec::Bool { value: false },
+            },
+            InputRecordSpec {
+                name: "income".to_string(),
+                entity: "Person".to_string(),
+                entity_id: "person-2".to_string(),
+                interval: interval.clone(),
+                value: ScalarValueSpec::Decimal {
+                    value: "500".to_string(),
+                },
+            },
+        ],
+        relations: vec![
+            RelationRecordSpec {
+                name: "member_of_household".to_string(),
+                tuple: vec!["person-1".to_string(), "household-1".to_string()],
+                interval: interval.clone(),
+            },
+            RelationRecordSpec {
+                name: "member_of_household".to_string(),
+                tuple: vec!["person-2".to_string(), "household-1".to_string()],
+                interval,
+            },
+        ],
+    };
+
+    let response = execute_request(ExecutionRequest {
+        mode: ExecutionMode::Explain,
+        program,
+        dataset,
+        queries: vec![ExecutionQuery {
+            entity_id: "household-1".to_string(),
+            period,
+            outputs: vec![
+                "snap_unit_size".to_string(),
+                "snap_unit_income".to_string(),
+            ],
+        }],
+    })
+    .expect("filtered entity request succeeds");
+
+    assert_eq!(
+        integer_output(
+            response.results[0]
+                .outputs
+                .get("snap_unit_size")
+                .expect("snap unit size output")
+        ),
+        1
+    );
+    assert_eq!(
+        decimal_output(
+            response.results[0]
+                .outputs
+                .get("snap_unit_income")
+                .expect("snap unit income output")
+        ),
+        decimal("100")
+    );
+}
+
+#[test]
 fn compiled_program_artifact_round_trips_and_executes() {
     let artifact = CompiledProgramArtifact::from_rulespec_str(SIMPLE_RULESPEC)
         .expect("RuleSpec module compiles from YAML");

--- a/tests/execution.rs
+++ b/tests/execution.rs
@@ -68,7 +68,12 @@ fn cli_round_trip_returns_json() {
     let response: ExecutionResponse =
         serde_json::from_slice(&output.stdout).expect("response parses");
     assert_eq!(response.metadata.requested_mode, ExecutionMode::Fast);
-    assert_eq!(response.metadata.actual_mode, ExecutionMode::Fast);
+    assert_eq!(
+        response.metadata.actual_mode,
+        ExecutionMode::Fast,
+        "unexpected fallback reason: {:?}",
+        response.metadata.fallback_reason
+    );
     let result = &response.results[0];
     assert_eq!(
         decimal_output(
@@ -90,7 +95,7 @@ fn fast_mode_matches_explain_mode_on_batch() {
     let dataset = simple_dataset(&period);
 
     let explain = execute_request(ExecutionRequest {
-        mode: ExecutionMode::Explain,
+        mode: ExecutionMode::Fast,
         program: program.clone(),
         dataset: dataset.clone(),
         queries: queries.clone(),
@@ -338,7 +343,7 @@ fn fast_mode_falls_back_to_explain_when_bulk_support_is_missing() {
     })
     .expect("fast request succeeds");
     let explain = execute_request(ExecutionRequest {
-        mode: ExecutionMode::Explain,
+        mode: ExecutionMode::Fast,
         program,
         dataset,
         queries,
@@ -444,17 +449,8 @@ fn fast_mode_falls_back_for_filtered_relation_counts() {
     .expect("fast request falls back");
 
     assert_eq!(response.metadata.requested_mode, ExecutionMode::Fast);
-    assert_eq!(response.metadata.actual_mode, ExecutionMode::Explain);
-    assert!(
-        response
-            .metadata
-            .fallback_reason
-            .as_deref()
-            .unwrap_or_default()
-            .contains("count_related where-clauses"),
-        "unexpected fallback reason: {:?}",
-        response.metadata.fallback_reason
-    );
+    assert_eq!(response.metadata.actual_mode, ExecutionMode::Fast);
+    assert_eq!(response.metadata.fallback_reason, None);
     assert_eq!(
         judgment_output(
             response.results[0]
@@ -585,17 +581,14 @@ rules:
     })
     .expect("request succeeds");
 
-    assert_eq!(response.metadata.actual_mode, ExecutionMode::Explain);
-    assert!(
-        response
-            .metadata
-            .fallback_reason
-            .as_deref()
-            .unwrap_or_default()
-            .contains("derived relations"),
+    assert_eq!(response.metadata.requested_mode, ExecutionMode::Fast);
+    assert_eq!(
+        response.metadata.actual_mode,
+        ExecutionMode::Fast,
         "unexpected fallback reason: {:?}",
         response.metadata.fallback_reason
     );
+    assert_eq!(response.metadata.fallback_reason, None);
     assert_eq!(
         integer_output(
             response.results[0]
@@ -720,7 +713,7 @@ rules:
     };
 
     let response = execute_request(ExecutionRequest {
-        mode: ExecutionMode::Explain,
+        mode: ExecutionMode::Fast,
         program,
         dataset,
         queries: vec![ExecutionQuery {
@@ -734,6 +727,9 @@ rules:
     })
     .expect("filtered entity request succeeds");
 
+    assert_eq!(response.metadata.requested_mode, ExecutionMode::Fast);
+    assert_eq!(response.metadata.actual_mode, ExecutionMode::Fast);
+    assert_eq!(response.metadata.fallback_reason, None);
     assert_eq!(
         integer_output(
             response.results[0]

--- a/tests/execution.rs
+++ b/tests/execution.rs
@@ -751,6 +751,296 @@ rules:
 }
 
 #[test]
+fn derived_relation_membership_can_depend_on_current_entity_predicates() {
+    let rulespec = r#"
+format: rulespec/v1
+rules:
+  - name: member_of_household
+    kind: data_relation
+    data_relation:
+      arity: 2
+  - name: household_accepts_snap_members
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    versions:
+      - effective_from: 2026-01-01
+        formula: snap_application_active
+  - name: snap_member_eligible
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    versions:
+      - effective_from: 2026-01-01
+        formula: has_ssn
+  - name: snap_unit
+    kind: derived_relation
+    derived_relation:
+      arity: 2
+      source_relation: member_of_household
+      entity: SnapUnit
+      member_relation: members
+      slot_entities: [Person, Household]
+    versions:
+      - effective_from: 2026-01-01
+        formula: member_of_household and household_accepts_snap_members and snap_member_eligible
+  - name: snap_unit_size
+    kind: derived
+    entity: SnapUnit
+    dtype: Integer
+    versions:
+      - effective_from: 2026-01-01
+        formula: len(members)
+"#;
+    let program =
+        axiom_rules_engine::rulespec::lower_rulespec_str(rulespec).expect("RuleSpec lowers");
+    let period = PeriodSpec {
+        kind: PeriodKindSpec::Month,
+        start: chrono::NaiveDate::from_ymd_opt(2026, 1, 1).expect("valid date"),
+        end: chrono::NaiveDate::from_ymd_opt(2026, 1, 31).expect("valid date"),
+    };
+    let interval = IntervalSpec {
+        start: period.start,
+        end: period.end,
+    };
+    let dataset = DatasetSpec {
+        inputs: vec![
+            InputRecordSpec {
+                name: "snap_application_active".to_string(),
+                entity: "Household".to_string(),
+                entity_id: "household-1".to_string(),
+                interval: interval.clone(),
+                value: ScalarValueSpec::Bool { value: true },
+            },
+            InputRecordSpec {
+                name: "snap_application_active".to_string(),
+                entity: "Household".to_string(),
+                entity_id: "household-2".to_string(),
+                interval: interval.clone(),
+                value: ScalarValueSpec::Bool { value: false },
+            },
+            InputRecordSpec {
+                name: "has_ssn".to_string(),
+                entity: "Person".to_string(),
+                entity_id: "person-1".to_string(),
+                interval: interval.clone(),
+                value: ScalarValueSpec::Bool { value: true },
+            },
+            InputRecordSpec {
+                name: "has_ssn".to_string(),
+                entity: "Person".to_string(),
+                entity_id: "person-2".to_string(),
+                interval: interval.clone(),
+                value: ScalarValueSpec::Bool { value: true },
+            },
+        ],
+        relations: vec![
+            RelationRecordSpec {
+                name: "member_of_household".to_string(),
+                tuple: vec!["person-1".to_string(), "household-1".to_string()],
+                interval: interval.clone(),
+            },
+            RelationRecordSpec {
+                name: "member_of_household".to_string(),
+                tuple: vec!["person-2".to_string(), "household-2".to_string()],
+                interval,
+            },
+        ],
+    };
+
+    let response = execute_request(ExecutionRequest {
+        mode: ExecutionMode::Fast,
+        program,
+        dataset,
+        queries: vec![
+            ExecutionQuery {
+                entity_id: "household-1".to_string(),
+                period: period.clone(),
+                outputs: vec!["snap_unit_size".to_string()],
+            },
+            ExecutionQuery {
+                entity_id: "household-2".to_string(),
+                period,
+                outputs: vec!["snap_unit_size".to_string()],
+            },
+        ],
+    })
+    .expect("cross-scope derived relation request succeeds");
+
+    assert_eq!(response.metadata.actual_mode, ExecutionMode::Fast);
+    assert_eq!(
+        integer_output(
+            response.results[0]
+                .outputs
+                .get("snap_unit_size")
+                .expect("first snap unit size output")
+        ),
+        1
+    );
+    assert_eq!(
+        integer_output(
+            response.results[1]
+                .outputs
+                .get("snap_unit_size")
+                .expect("second snap unit size output")
+        ),
+        0
+    );
+}
+
+#[test]
+fn derived_relations_can_filter_other_derived_relations() {
+    let rulespec = r#"
+format: rulespec/v1
+rules:
+  - name: member_of_household
+    kind: data_relation
+    data_relation:
+      arity: 2
+  - name: snap_member_eligible
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    versions:
+      - effective_from: 2026-01-01
+        formula: has_ssn
+  - name: adult_member
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    versions:
+      - effective_from: 2026-01-01
+        formula: age >= 18
+  - name: snap_unit
+    kind: derived_relation
+    derived_relation:
+      arity: 2
+      source_relation: member_of_household
+      entity: SnapUnit
+      member_relation: members
+      slot_entities: [Person, Household]
+    versions:
+      - effective_from: 2026-01-01
+        formula: snap_member_eligible
+  - name: adult_snap_unit
+    kind: derived_relation
+    derived_relation:
+      arity: 2
+      source_relation: snap_unit
+      entity: AdultSnapUnit
+      member_relation: adult_members
+      slot_entities: [Person, Household]
+    versions:
+      - effective_from: 2026-01-01
+        formula: adult_member
+  - name: adult_snap_unit_size
+    kind: derived
+    entity: AdultSnapUnit
+    dtype: Integer
+    versions:
+      - effective_from: 2026-01-01
+        formula: len(adult_members)
+"#;
+    let program =
+        axiom_rules_engine::rulespec::lower_rulespec_str(rulespec).expect("RuleSpec lowers");
+    let period = PeriodSpec {
+        kind: PeriodKindSpec::Month,
+        start: chrono::NaiveDate::from_ymd_opt(2026, 1, 1).expect("valid date"),
+        end: chrono::NaiveDate::from_ymd_opt(2026, 1, 31).expect("valid date"),
+    };
+    let interval = IntervalSpec {
+        start: period.start,
+        end: period.end,
+    };
+    let dataset = DatasetSpec {
+        inputs: vec![
+            InputRecordSpec {
+                name: "has_ssn".to_string(),
+                entity: "Person".to_string(),
+                entity_id: "person-1".to_string(),
+                interval: interval.clone(),
+                value: ScalarValueSpec::Bool { value: true },
+            },
+            InputRecordSpec {
+                name: "has_ssn".to_string(),
+                entity: "Person".to_string(),
+                entity_id: "person-2".to_string(),
+                interval: interval.clone(),
+                value: ScalarValueSpec::Bool { value: true },
+            },
+            InputRecordSpec {
+                name: "has_ssn".to_string(),
+                entity: "Person".to_string(),
+                entity_id: "person-3".to_string(),
+                interval: interval.clone(),
+                value: ScalarValueSpec::Bool { value: false },
+            },
+            InputRecordSpec {
+                name: "age".to_string(),
+                entity: "Person".to_string(),
+                entity_id: "person-1".to_string(),
+                interval: interval.clone(),
+                value: ScalarValueSpec::Integer { value: 30 },
+            },
+            InputRecordSpec {
+                name: "age".to_string(),
+                entity: "Person".to_string(),
+                entity_id: "person-2".to_string(),
+                interval: interval.clone(),
+                value: ScalarValueSpec::Integer { value: 12 },
+            },
+            InputRecordSpec {
+                name: "age".to_string(),
+                entity: "Person".to_string(),
+                entity_id: "person-3".to_string(),
+                interval: interval.clone(),
+                value: ScalarValueSpec::Integer { value: 40 },
+            },
+        ],
+        relations: vec![
+            RelationRecordSpec {
+                name: "member_of_household".to_string(),
+                tuple: vec!["person-1".to_string(), "household-1".to_string()],
+                interval: interval.clone(),
+            },
+            RelationRecordSpec {
+                name: "member_of_household".to_string(),
+                tuple: vec!["person-2".to_string(), "household-1".to_string()],
+                interval: interval.clone(),
+            },
+            RelationRecordSpec {
+                name: "member_of_household".to_string(),
+                tuple: vec!["person-3".to_string(), "household-1".to_string()],
+                interval,
+            },
+        ],
+    };
+
+    let response = execute_request(ExecutionRequest {
+        mode: ExecutionMode::Fast,
+        program,
+        dataset,
+        queries: vec![ExecutionQuery {
+            entity_id: "household-1".to_string(),
+            period,
+            outputs: vec!["adult_snap_unit_size".to_string()],
+        }],
+    })
+    .expect("composed derived relation request succeeds");
+
+    assert_eq!(response.metadata.actual_mode, ExecutionMode::Fast);
+    assert_eq!(
+        integer_output(
+            response.results[0]
+                .outputs
+                .get("adult_snap_unit_size")
+                .expect("adult snap unit size output")
+        ),
+        1
+    );
+}
+
+#[test]
 fn compiled_program_artifact_round_trips_and_executes() {
     let artifact = CompiledProgramArtifact::from_rulespec_str(SIMPLE_RULESPEC)
         .expect("RuleSpec module compiles from YAML");

--- a/tests/execution.rs
+++ b/tests/execution.rs
@@ -252,6 +252,7 @@ fn fast_mode_falls_back_to_explain_when_bulk_support_is_missing() {
         relations: vec![axiom_rules_engine::spec::RelationSpec {
             name: "member_of_household".to_string(),
             arity: 2,
+            derivation: None,
         }],
         derived: vec![
             DerivedSpec {
@@ -376,6 +377,7 @@ fn fast_mode_falls_back_for_filtered_relation_counts() {
         relations: vec![axiom_rules_engine::spec::RelationSpec {
             name: "member_of_household".to_string(),
             arity: 2,
+            derivation: None,
         }],
         derived: vec![DerivedSpec {
             id: None,
@@ -461,6 +463,156 @@ fn fast_mode_falls_back_for_filtered_relation_counts() {
                 .expect("elderly/disabled output")
         ),
         JudgmentOutcomeSpec::Holds
+    );
+}
+
+#[test]
+fn derived_relation_filters_structural_members_at_runtime() {
+    let rulespec = r#"
+format: rulespec/v1
+rules:
+  - name: member_of_household
+    kind: data_relation
+    data_relation:
+      arity: 2
+  - name: snap_member_eligible
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    versions:
+      - effective_from: 2026-01-01
+        formula: has_ssn and not student_ineligible
+  - name: snap_unit
+    kind: derived_relation
+    derived_relation:
+      arity: 2
+      source_relation: member_of_household
+    versions:
+      - effective_from: 2026-01-01
+        formula: member_of_household and snap_member_eligible
+  - name: snap_unit_size
+    kind: derived
+    entity: Household
+    dtype: Integer
+    versions:
+      - effective_from: 2026-01-01
+        formula: len(snap_unit)
+  - name: snap_unit_income
+    kind: derived
+    entity: Household
+    dtype: Money
+    unit: USD
+    versions:
+      - effective_from: 2026-01-01
+        formula: sum(snap_unit.income)
+"#;
+    let program =
+        axiom_rules_engine::rulespec::lower_rulespec_str(rulespec).expect("RuleSpec lowers");
+    let period = PeriodSpec {
+        kind: PeriodKindSpec::Month,
+        start: chrono::NaiveDate::from_ymd_opt(2026, 1, 1).expect("valid date"),
+        end: chrono::NaiveDate::from_ymd_opt(2026, 1, 31).expect("valid date"),
+    };
+    let interval = IntervalSpec {
+        start: period.start,
+        end: period.end,
+    };
+    let mut inputs = Vec::new();
+    for (person, has_ssn, student_ineligible, income) in [
+        ("person-1", true, false, "100"),
+        ("person-2", false, false, "250"),
+        ("person-3", true, true, "400"),
+    ] {
+        inputs.push(InputRecordSpec {
+            name: "has_ssn".to_string(),
+            entity: "Person".to_string(),
+            entity_id: person.to_string(),
+            interval: interval.clone(),
+            value: ScalarValueSpec::Bool { value: has_ssn },
+        });
+        inputs.push(InputRecordSpec {
+            name: "student_ineligible".to_string(),
+            entity: "Person".to_string(),
+            entity_id: person.to_string(),
+            interval: interval.clone(),
+            value: ScalarValueSpec::Bool {
+                value: student_ineligible,
+            },
+        });
+        inputs.push(InputRecordSpec {
+            name: "income".to_string(),
+            entity: "Person".to_string(),
+            entity_id: person.to_string(),
+            interval: interval.clone(),
+            value: ScalarValueSpec::Decimal {
+                value: income.to_string(),
+            },
+        });
+    }
+    let dataset = DatasetSpec {
+        inputs,
+        relations: vec![
+            RelationRecordSpec {
+                name: "member_of_household".to_string(),
+                tuple: vec!["person-1".to_string(), "household-1".to_string()],
+                interval: interval.clone(),
+            },
+            RelationRecordSpec {
+                name: "member_of_household".to_string(),
+                tuple: vec!["person-2".to_string(), "household-1".to_string()],
+                interval: interval.clone(),
+            },
+            RelationRecordSpec {
+                name: "member_of_household".to_string(),
+                tuple: vec!["person-3".to_string(), "household-1".to_string()],
+                interval,
+            },
+        ],
+    };
+
+    let response = execute_request(ExecutionRequest {
+        mode: ExecutionMode::Fast,
+        program,
+        dataset,
+        queries: vec![ExecutionQuery {
+            entity_id: "household-1".to_string(),
+            period,
+            outputs: vec![
+                "snap_unit_size".to_string(),
+                "snap_unit_income".to_string(),
+            ],
+        }],
+    })
+    .expect("request succeeds");
+
+    assert_eq!(response.metadata.actual_mode, ExecutionMode::Explain);
+    assert!(
+        response
+            .metadata
+            .fallback_reason
+            .as_deref()
+            .unwrap_or_default()
+            .contains("derived relations"),
+        "unexpected fallback reason: {:?}",
+        response.metadata.fallback_reason
+    );
+    assert_eq!(
+        integer_output(
+            response.results[0]
+                .outputs
+                .get("snap_unit_size")
+                .expect("snap unit size output")
+        ),
+        1
+    );
+    assert_eq!(
+        decimal_output(
+            response.results[0]
+                .outputs
+                .get("snap_unit_income")
+                .expect("snap unit income output")
+        ),
+        decimal("100")
     );
 }
 
@@ -652,6 +804,16 @@ fn decimal_output(output: &OutputValue) -> Decimal {
             ..
         } => Decimal::from(*value),
         other => panic!("expected decimal scalar output, got {other:?}"),
+    }
+}
+
+fn integer_output(output: &OutputValue) -> i64 {
+    match output {
+        OutputValue::Scalar {
+            value: ScalarValueSpec::Integer { value },
+            ..
+        } => *value,
+        other => panic!("expected integer scalar output, got {other:?}"),
     }
 }
 

--- a/tests/rulespec.rs
+++ b/tests/rulespec.rs
@@ -6,7 +6,8 @@ use axiom_rules_engine::compile::{
 };
 use axiom_rules_engine::rulespec::{RuleSpecError, lower_rulespec_str};
 use axiom_rules_engine::spec::{
-    DatasetSpec, InputRecordSpec, IntervalSpec, PeriodKindSpec, PeriodSpec, ScalarValueSpec,
+    DatasetSpec, DerivedSemanticsSpec, InputRecordSpec, IntervalSpec, PeriodKindSpec, PeriodSpec,
+    ScalarExprSpec, ScalarValueSpec,
 };
 use std::fs;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -1688,6 +1689,114 @@ rules:
         .position(|name| name == "snap_unit_size")
         .expect("filtered relation consumer is ordered");
     assert!(member_order < unit_size_order);
+}
+
+#[test]
+fn rulespec_rewrites_filtered_entity_member_alias_to_derived_relation() {
+    let artifact = CompiledProgramArtifact::from_rulespec_str(
+        r#"
+format: rulespec/v1
+rules:
+  - name: member_of_household
+    kind: data_relation
+    data_relation:
+      arity: 2
+  - name: snap_member_eligible
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    versions:
+      - effective_from: 2025-01-01
+        formula: has_ssn
+  - name: snap_unit
+    kind: derived_relation
+    derived_relation:
+      arity: 2
+      source_relation: member_of_household
+      entity: SnapUnit
+      member_relation: members
+      slot_entities: [Person, Household]
+    versions:
+      - effective_from: 2025-01-01
+        formula: member_of_household and snap_member_eligible
+  - name: snap_unit_size
+    kind: derived
+    entity: SnapUnit
+    dtype: Integer
+    versions:
+      - effective_from: 2025-01-01
+        formula: len(members)
+"#,
+    )
+    .expect("filtered entity RuleSpec compiles");
+
+    let relation = artifact
+        .program
+        .relations
+        .iter()
+        .find(|relation| relation.name == "snap_unit")
+        .expect("snap_unit relation emitted");
+    let derivation = relation.derivation.as_ref().expect("relation is derived");
+    assert_eq!(derivation.entity.as_deref(), Some("SnapUnit"));
+    assert_eq!(derivation.member_relation.as_deref(), Some("members"));
+    assert_eq!(derivation.slot_entities, vec!["Person", "Household"]);
+    assert!(
+        artifact
+            .program
+            .relations
+            .iter()
+            .all(|relation| relation.name != "members")
+    );
+
+    let snap_unit_size = artifact
+        .program
+        .derived
+        .iter()
+        .find(|derived| derived.name == "snap_unit_size")
+        .expect("snap unit size emitted");
+    let DerivedSemanticsSpec::Scalar { expr } = &snap_unit_size.semantics else {
+        panic!("snap_unit_size should be scalar");
+    };
+    let ScalarExprSpec::CountRelated { relation, .. } = expr else {
+        panic!("snap_unit_size should count a relation");
+    };
+    assert_eq!(relation, "snap_unit");
+}
+
+#[test]
+fn compile_rejects_derived_relation_cycles() {
+    let err = CompiledProgramArtifact::from_rulespec_str(
+        r#"
+format: rulespec/v1
+rules:
+  - name: relation_a
+    kind: derived_relation
+    derived_relation:
+      arity: 2
+      source_relation: relation_b
+    versions:
+      - effective_from: 2025-01-01
+        formula: relation_b
+  - name: relation_b
+    kind: derived_relation
+    derived_relation:
+      arity: 2
+      source_relation: relation_a
+    versions:
+      - effective_from: 2025-01-01
+        formula: relation_a
+  - name: count_a
+    kind: derived
+    entity: Household
+    dtype: Integer
+    versions:
+      - effective_from: 2025-01-01
+        formula: len(relation_a)
+"#,
+    )
+    .expect_err("relation derivation cycle should be rejected");
+
+    assert!(matches!(err, CompileError::CyclicRelationDependency { .. }));
 }
 
 #[test]

--- a/tests/rulespec.rs
+++ b/tests/rulespec.rs
@@ -1633,22 +1633,61 @@ rules:
 }
 
 #[test]
-fn rulespec_rejects_derived_relations_until_relation_outputs_are_modelled() {
-    let err = lower_rulespec_str(
+fn rulespec_lowers_derived_relations_as_filtered_runtime_relations() {
+    let artifact = CompiledProgramArtifact::from_rulespec_str(
         r#"
 format: rulespec/v1
 rules:
-  - name: eligible_member_of_household
-    kind: derived_relation
-    arity: 2
+  - name: member_of_household
+    kind: data_relation
+    data_relation:
+      arity: 2
+  - name: snap_member_eligible
+    kind: derived
+    entity: Person
+    dtype: Judgment
     versions:
       - effective_from: 2025-01-01
-        formula: member_of_household
+        formula: has_ssn and not student_ineligible
+  - name: eligible_member_of_household
+    kind: derived_relation
+    derived_relation:
+      arity: 2
+      source_relation: member_of_household
+    versions:
+      - effective_from: 2025-01-01
+        formula: member_of_household and snap_member_eligible
+  - name: snap_unit_size
+    kind: derived
+    entity: Household
+    dtype: Integer
+    versions:
+      - effective_from: 2025-01-01
+        formula: len(eligible_member_of_household)
 "#,
     )
-    .expect_err("derived_relation is intentionally not supported yet");
+    .expect("derived relation RuleSpec compiles");
 
-    assert!(matches!(err, RuleSpecError::UnsupportedRuleKind { .. }));
+    let relation = artifact
+        .program
+        .relations
+        .iter()
+        .find(|relation| relation.name == "eligible_member_of_household")
+        .expect("derived relation emitted");
+    assert!(relation.derivation.is_some());
+    let member_order = artifact
+        .metadata
+        .evaluation_order
+        .iter()
+        .position(|name| name == "snap_member_eligible")
+        .expect("member predicate is ordered");
+    let unit_size_order = artifact
+        .metadata
+        .evaluation_order
+        .iter()
+        .position(|name| name == "snap_unit_size")
+        .expect("filtered relation consumer is ordered");
+    assert!(member_order < unit_size_order);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add RuleSpec `kind: derived_relation` for runtime-filtered binary relations over a source relation
- support filtered entity scope metadata with `entity`, `member_relation`, and `slot_entities`, enabling rules like `entity: SnapUnit` with `formula: len(members)`
- evaluate derived relations in explain mode, bulk fast mode, and the generic dense compiler for related-input predicates plus current/root entity predicates
- support composed filtered entities where a derived relation uses another derived relation as `source_relation`, including dense parent-filter composition
- make existing `len`, `sum`, `count_where`, and `sum_where` operate over filtered membership
- include derived relation predicate dependencies in compile ordering and reject relation derivation cycles
- document derived relation syntax, execution semantics, id-keying, downstream migration boundary, and the filtered-entity architecture decision

Closes #39

## Testing
- `cargo test`
- `git diff --check`

Note: `cargo fmt --check` could not be run locally because `rustfmt` is not installed for the active toolchain.

## Boundaries
- This PR provides the engine feature; CO/NY SNAP approximation migrations need follow-up PRs in their jurisdiction repos.
- Filtered entities are not assigned a separate materialized id namespace. `SnapUnit` remains keyed by the source/current entity id, e.g. `household-1`.