### PR TITLE
Version compiled artifacts; bound Python engine subprocesses with timeouts

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -4,6 +4,35 @@ Short decision log for architecture choices. Publicly and internally, this is
 the Axiom Rules Engine; the Rust crate and executable are `axiom-rules-engine`. One
 entry per decision, most recent first.
 
+## 2026-06-09 — Compiled artifacts carry a format version and are bounded subprocesses
+
+**Decision.** `CompiledProgramArtifact` stamps `artifact_format_version`
+(currently 1) and `engine_version` at compile time. Loading rejects artifacts
+whose format version is newer than the engine supports; artifacts without the
+field (version 0, pre-stamping) still load. The Python wrapper bounds every
+engine subprocess with a configurable timeout (default 600 s, `None` to
+disable).
+
+**Why.**
+
+- Artifacts are durable and ship to consumers (finbot, microsim, demos).
+  Without a version field, an engine reading an artifact from a different
+  generation fails late or silently miscalculates; with one, mismatches fail
+  loudly at load.
+- A pathological or hung engine process previously blocked Python callers
+  forever; web apps and batch microsim runs sit on that path.
+
+**Consequences.**
+
+- New artifacts include two extra JSON fields; legacy artifacts deserialize
+  with `artifact_format_version: 0` and `engine_version: null`, so nothing
+  shipped breaks.
+- Future IR-breaking changes must bump `ARTIFACT_FORMAT_VERSION` so older
+  engines reject newer artifacts instead of guessing.
+- The `compile` CLI summary now reports both versions.
+- Callers that legitimately run longer than 600 s must pass an explicit
+  `timeout` (or `None`).
+
 ## 2026-05-20 — Filtered entities lower as derived runtime relations
 
 **Decision.** RuleSpec models filtered entity membership with

--- a/python/axiom_rules_engine/client.py
+++ b/python/axiom_rules_engine/client.py
@@ -15,9 +15,25 @@ from .models import (
 )
 
 
+DEFAULT_TIMEOUT_SECONDS = 600.0
+
+
 class AxiomRulesEngine:
-    def __init__(self, binary_path: str | Path = "target/debug/axiom-rules-engine") -> None:
+    def __init__(
+        self,
+        binary_path: str | Path = "target/debug/axiom-rules-engine",
+        *,
+        timeout: float | None = DEFAULT_TIMEOUT_SECONDS,
+    ) -> None:
+        """Wrap the Rust engine binary.
+
+        ``timeout`` bounds every engine subprocess in seconds so a
+        pathological program cannot hang the caller; ``None`` disables the
+        bound. On expiry the engine process is killed and
+        ``subprocess.TimeoutExpired`` is raised.
+        """
         self.binary_path = Path(binary_path)
+        self.timeout = timeout
 
     def execute(self, request: ExecutionRequest) -> ExecutionResponse:
         process = subprocess.run(
@@ -26,6 +42,7 @@ class AxiomRulesEngine:
             text=True,
             capture_output=True,
             check=False,
+            timeout=self.timeout,
         )
         if process.returncode != 0:
             stderr = process.stderr.strip() or "Axiom Rules Engine executable failed"
@@ -46,6 +63,7 @@ class AxiomRulesEngine:
             text=True,
             capture_output=True,
             check=False,
+            timeout=self.timeout,
         )
         if process.returncode != 0:
             stderr = process.stderr.strip() or "Axiom Rules Engine executable failed"
@@ -67,6 +85,7 @@ class AxiomRulesEngine:
             text=True,
             capture_output=True,
             check=False,
+            timeout=self.timeout,
         )
         if process.returncode != 0:
             stderr = process.stderr.strip() or "Axiom Rules Engine compile failed"

--- a/python/axiom_rules_engine/loader.py
+++ b/python/axiom_rules_engine/loader.py
@@ -19,7 +19,14 @@ def _looks_like_rulespec(spec: dict) -> bool:
     )
 
 
-def _compile_program(path: Path, binary_path: str | Path | None = None) -> Program:
+DEFAULT_TIMEOUT_SECONDS = 600.0
+
+
+def _compile_program(
+    path: Path,
+    binary_path: str | Path | None = None,
+    timeout: float | None = DEFAULT_TIMEOUT_SECONDS,
+) -> Program:
     binary = (
         Path(binary_path)
         if binary_path is not None
@@ -39,6 +46,7 @@ def _compile_program(path: Path, binary_path: str | Path | None = None) -> Progr
             text=True,
             capture_output=True,
             check=False,
+            timeout=timeout,
         )
         if process.returncode != 0:
             stderr = process.stderr.strip() or "Axiom Rules Engine compile failed"
@@ -47,8 +55,17 @@ def _compile_program(path: Path, binary_path: str | Path | None = None) -> Progr
         return Program.model_validate(artifact["program"])
 
 
-def load_program(path: str | Path, *, binary_path: str | Path | None = None) -> Program:
-    """Load a RuleSpec module from RuleSpec YAML."""
+def load_program(
+    path: str | Path,
+    *,
+    binary_path: str | Path | None = None,
+    timeout: float | None = DEFAULT_TIMEOUT_SECONDS,
+) -> Program:
+    """Load a RuleSpec module from RuleSpec YAML.
+
+    ``timeout`` bounds the compile subprocess in seconds; ``None`` disables
+    the bound. On expiry ``subprocess.TimeoutExpired`` is raised.
+    """
     path = Path(path)
     spec: dict = yaml.safe_load(path.read_text()) or {}
     if not _looks_like_rulespec(spec):
@@ -56,4 +73,4 @@ def load_program(path: str | Path, *, binary_path: str | Path | None = None) -> 
             f"{path} is not RuleSpec YAML; expected format: rulespec/v1 "
             "or schema: axiom.rules.*"
         )
-    return _compile_program(path, binary_path=binary_path)
+    return _compile_program(path, binary_path=binary_path, timeout=timeout)

--- a/python/axiom_rules_engine/models.py
+++ b/python/axiom_rules_engine/models.py
@@ -79,6 +79,8 @@ class CompiledProgramMetadata(BaseModel):
 
 
 class CompiledProgram(BaseModel):
+    artifact_format_version: int = 0
+    engine_version: str | None = None
     program: Program
     metadata: CompiledProgramMetadata
 

--- a/python/tests/test_client_timeout.py
+++ b/python/tests/test_client_timeout.py
@@ -1,0 +1,69 @@
+"""The engine wrapper must bound subprocess time so a hung engine cannot
+hang the caller (web apps, microsim batches)."""
+from __future__ import annotations
+
+import stat
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from axiom_rules_engine.client import DEFAULT_TIMEOUT_SECONDS, AxiomRulesEngine
+from axiom_rules_engine.models import (
+    CompiledProgram,
+    Dataset,
+    ExecutionQuery,
+    ExecutionRequest,
+    Period,
+    Program,
+)
+
+
+def _hanging_binary(tmp_path: Path) -> Path:
+    binary = tmp_path / "hanging-engine"
+    binary.write_text("#!/bin/sh\nsleep 60\n")
+    binary.chmod(binary.stat().st_mode | stat.S_IEXEC)
+    return binary
+
+
+def _minimal_request() -> ExecutionRequest:
+    period = Period(period_kind="Month", start="2026-01-01", end="2026-01-31")
+    return ExecutionRequest(
+        mode="explain",
+        program=Program(),
+        dataset=Dataset(),
+        queries=[ExecutionQuery(entity_id="h1", period=period, outputs=[])],
+    )
+
+
+def test_execute_times_out_instead_of_hanging(tmp_path: Path) -> None:
+    engine = AxiomRulesEngine(binary_path=_hanging_binary(tmp_path), timeout=0.5)
+    with pytest.raises(subprocess.TimeoutExpired):
+        engine.execute(_minimal_request())
+
+
+def test_compile_times_out_instead_of_hanging(tmp_path: Path) -> None:
+    engine = AxiomRulesEngine(binary_path=_hanging_binary(tmp_path), timeout=0.5)
+    with pytest.raises(subprocess.TimeoutExpired):
+        engine.compile(
+            program_path=tmp_path / "rules.yaml",
+            output_path=tmp_path / "out.json",
+        )
+
+
+def test_timeout_defaults_on_and_is_configurable() -> None:
+    assert AxiomRulesEngine().timeout == DEFAULT_TIMEOUT_SECONDS
+    assert AxiomRulesEngine(timeout=None).timeout is None
+
+
+def test_compiled_program_parses_legacy_artifact_without_version_fields() -> None:
+    legacy = {
+        "program": {"units": [], "relations": [], "parameters": [], "derived": []},
+        "metadata": {
+            "evaluation_order": [],
+            "fast_path": {"strategy": "generic_bulk", "compatible": True},
+        },
+    }
+    parsed = CompiledProgram.model_validate(legacy)
+    assert parsed.artifact_format_version == 0
+    assert parsed.engine_version is None

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -48,10 +48,27 @@ pub enum CompileError {
         "ambiguous RuleSpec module YAML `{path}` has a top-level `rules:` key but no RuleSpec discriminator (`format: rulespec/v1` or `schema: axiom.rules.*`)"
     )]
     AmbiguousRuleSpecYaml { path: String },
+    #[error(
+        "compiled artefact `{path}` has artifact_format_version {found}, but this engine supports up to {supported}; recompile the program with this engine or upgrade the engine"
+    )]
+    UnsupportedArtifactFormatVersion {
+        path: String,
+        found: u32,
+        supported: u32,
+    },
 }
+
+/// Format version stamped into every artifact this engine compiles.
+/// Artifacts with a missing field (version 0) predate stamping and are
+/// accepted; artifacts newer than this are rejected at load.
+pub const ARTIFACT_FORMAT_VERSION: u32 = 1;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct CompiledProgramArtifact {
+    #[serde(default)]
+    pub artifact_format_version: u32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub engine_version: Option<String>,
     pub program: ProgramSpec,
     pub metadata: CompiledProgramMetadata,
 }
@@ -74,12 +91,25 @@ impl CompiledProgramArtifact {
         let evaluation_order = evaluation_order(&program)?;
         let fast_path = fast_path_metadata(&program);
         Ok(Self {
+            artifact_format_version: ARTIFACT_FORMAT_VERSION,
+            engine_version: Some(env!("CARGO_PKG_VERSION").to_string()),
             program,
             metadata: CompiledProgramMetadata {
                 evaluation_order,
                 fast_path,
             },
         })
+    }
+
+    fn check_format_version(self, path: &str) -> Result<Self, CompileError> {
+        if self.artifact_format_version > ARTIFACT_FORMAT_VERSION {
+            return Err(CompileError::UnsupportedArtifactFormatVersion {
+                path: path.to_string(),
+                found: self.artifact_format_version,
+                supported: ARTIFACT_FORMAT_VERSION,
+            });
+        }
+        Ok(self)
     }
 
     pub fn from_rulespec_str(source: &str) -> Result<Self, CompileError> {
@@ -129,10 +159,12 @@ impl CompiledProgramArtifact {
     }
 
     pub fn from_json_str(source: &str) -> Result<Self, CompileError> {
-        serde_json::from_str(source).map_err(|error| CompileError::DeserializeArtifact {
-            path: "<memory>".to_string(),
-            error,
-        })
+        let artifact: Self =
+            serde_json::from_str(source).map_err(|error| CompileError::DeserializeArtifact {
+                path: "<memory>".to_string(),
+                error,
+            })?;
+        artifact.check_format_version("<memory>")
     }
 
     pub fn from_json_file(path: impl AsRef<Path>) -> Result<Self, CompileError> {
@@ -141,10 +173,12 @@ impl CompiledProgramArtifact {
             path: path.display().to_string(),
             error,
         })?;
-        serde_json::from_str(&source).map_err(|error| CompileError::DeserializeArtifact {
-            path: path.display().to_string(),
-            error,
-        })
+        let artifact: Self =
+            serde_json::from_str(&source).map_err(|error| CompileError::DeserializeArtifact {
+                path: path.display().to_string(),
+                error,
+            })?;
+        artifact.check_format_version(&path.display().to_string())
     }
 
     pub fn write_json_file(&self, path: impl AsRef<Path>) -> Result<(), CompileError> {
@@ -654,6 +688,13 @@ pub fn compile_program_file_to_json(
 
 pub fn compile_summary_lines(artifact: &CompiledProgramArtifact) -> BTreeMap<String, String> {
     let mut lines = BTreeMap::new();
+    lines.insert(
+        "artifact_format_version".to_string(),
+        artifact.artifact_format_version.to_string(),
+    );
+    if let Some(engine_version) = &artifact.engine_version {
+        lines.insert("engine_version".to_string(), engine_version.clone());
+    }
     lines.insert(
         "derived_outputs".to_string(),
         artifact.program.derived.len().to_string(),

--- a/tests/artifact_version.rs
+++ b/tests/artifact_version.rs
@@ -1,0 +1,102 @@
+use axiom_rules_engine::compile::{ARTIFACT_FORMAT_VERSION, CompileError, CompiledProgramArtifact};
+
+const SIMPLE_RULESPEC: &str = r#"
+format: rulespec/v1
+rules:
+  - name: base_amount
+    kind: parameter
+    dtype: Money
+    unit: USD
+    versions:
+      - effective_from: 2026-01-01
+        formula: "10"
+  - name: adjusted_amount
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    versions:
+      - effective_from: 2026-01-01
+        formula: amount + base_amount
+"#;
+
+#[test]
+fn compile_stamps_format_and_engine_versions() {
+    let artifact = CompiledProgramArtifact::from_rulespec_str(SIMPLE_RULESPEC)
+        .expect("RuleSpec module compiles from YAML");
+    assert_eq!(artifact.artifact_format_version, ARTIFACT_FORMAT_VERSION);
+    assert_eq!(
+        artifact.engine_version.as_deref(),
+        Some(env!("CARGO_PKG_VERSION"))
+    );
+
+    let json = serde_json::to_string(&artifact).expect("artifact serialises");
+    let reloaded = CompiledProgramArtifact::from_json_str(&json)
+        .expect("stamped artifact round-trips through JSON");
+    assert_eq!(reloaded.artifact_format_version, ARTIFACT_FORMAT_VERSION);
+    assert_eq!(
+        reloaded.engine_version.as_deref(),
+        Some(env!("CARGO_PKG_VERSION"))
+    );
+}
+
+#[test]
+fn legacy_artifact_without_version_fields_still_loads() {
+    let artifact = CompiledProgramArtifact::from_rulespec_str(SIMPLE_RULESPEC)
+        .expect("RuleSpec module compiles from YAML");
+    let mut value = serde_json::to_value(&artifact).expect("artifact serialises");
+    let object = value.as_object_mut().expect("artifact is a JSON object");
+    object.remove("artifact_format_version");
+    object.remove("engine_version");
+    let legacy_json = serde_json::to_string(&value).expect("legacy JSON serialises");
+
+    let reloaded = CompiledProgramArtifact::from_json_str(&legacy_json)
+        .expect("legacy artifact without version fields loads");
+    assert_eq!(reloaded.artifact_format_version, 0);
+    assert_eq!(reloaded.engine_version, None);
+}
+
+#[test]
+fn artifact_from_newer_format_is_rejected() {
+    let artifact = CompiledProgramArtifact::from_rulespec_str(SIMPLE_RULESPEC)
+        .expect("RuleSpec module compiles from YAML");
+    let mut value = serde_json::to_value(&artifact).expect("artifact serialises");
+    let object = value.as_object_mut().expect("artifact is a JSON object");
+    object.insert(
+        "artifact_format_version".to_string(),
+        serde_json::json!(ARTIFACT_FORMAT_VERSION + 1),
+    );
+    let future_json = serde_json::to_string(&value).expect("future JSON serialises");
+
+    let error = CompiledProgramArtifact::from_json_str(&future_json)
+        .expect_err("artifact from a newer format version is rejected");
+    match error {
+        CompileError::UnsupportedArtifactFormatVersion {
+            found, supported, ..
+        } => {
+            assert_eq!(found, ARTIFACT_FORMAT_VERSION + 1);
+            assert_eq!(supported, ARTIFACT_FORMAT_VERSION);
+        }
+        other => panic!("expected UnsupportedArtifactFormatVersion, got {other:?}"),
+    }
+}
+
+#[test]
+fn artifact_file_round_trip_preserves_versions() {
+    let artifact = CompiledProgramArtifact::from_rulespec_str(SIMPLE_RULESPEC)
+        .expect("RuleSpec module compiles from YAML");
+    let dir = std::env::temp_dir().join(format!(
+        "axiom-rules-engine-artifact-version-{}",
+        std::process::id()
+    ));
+    std::fs::create_dir_all(&dir).expect("temp dir creates");
+    let path = dir.join("program.compiled.json");
+    artifact.write_json_file(&path).expect("artifact writes");
+
+    let reloaded =
+        CompiledProgramArtifact::from_json_file(&path).expect("artifact loads from file");
+    assert_eq!(reloaded.artifact_format_version, ARTIFACT_FORMAT_VERSION);
+
+    std::fs::remove_dir_all(&dir).ok();
+}


### PR DESCRIPTION
Two provenance/safety gaps from the 2026-06-09 architecture review, both additive.

## Compiled artifact versioning

`CompiledProgramArtifact` had no version field, so an engine loading an artifact from a different generation would fail late or silently miscalculate. Now:

- `compile()` stamps `artifact_format_version` (currently **1**) and `engine_version` (`CARGO_PKG_VERSION`).
- `from_json_str` / `from_json_file` reject artifacts whose format version is **newer** than the engine supports, with a clear error naming both versions.
- Legacy artifacts without the fields deserialize as version 0 and still load — nothing already shipped (finbot/microsim/demo artifacts) breaks.
- `compile` CLI summary lines report both versions.
- Future IR-breaking changes bump `ARTIFACT_FORMAT_VERSION` so mismatches fail loudly at load instead of guessing.

## Python subprocess timeouts

`AxiomRulesEngine.execute/execute_compiled/compile` and `loader.load_program` ran `subprocess.run` with no timeout — a pathological or hung engine process blocked callers forever (finbot's Modal service and microsim batches sit on this path). All engine subprocesses are now bounded by a configurable timeout (default 600 s; `None` disables). On expiry the process is killed and `subprocess.TimeoutExpired` propagates.

`CompiledProgram` (pydantic) mirrors the new artifact fields with backward-compatible defaults.

## Tests

- `tests/artifact_version.rs`: stamp + round-trip, legacy load, newer-version rejection, file round-trip (4 new; full suite 72 pass).
- `python/tests/test_client_timeout.py`: hang → `TimeoutExpired` for execute and compile, default/configurable timeout, legacy `CompiledProgram` parse (4 new; suite 25 pass).
- `python-ext` (PyO3 dense crate) still checks clean against the changed structs.

Also logged in DECISIONS.md per house convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
