### PR TITLE
Resolve jurisdiction imports in country-monorepo layout

### DIFF
--- a/docs/rulespec.md
+++ b/docs/rulespec.md
@@ -150,9 +150,19 @@ imports:
 ```
 
 The canonical form is `<jurisdiction>:<relative path without extension>`.
-`us:` resolves to the `rulespec-us` repository, `us-co:` resolves to
-`rulespec-us-co`, and so on. The loader searches sibling checkouts and any roots
-listed in `AXIOM_RULESPEC_REPO_ROOTS`.
+A jurisdiction prefix resolves against either layout, with the same durable
+ids in both:
+
+- **Country monorepo** — a repo named `rulespec-<country>` holding one
+  directory per jurisdiction: `us:` → `rulespec-us/us/…`, `us-co:` →
+  `rulespec-us/us-co/…`.
+- **Legacy standalone repo** — `us-co:` → a sibling checkout named
+  `rulespec-us-co` with content at its root. Legacy candidates are tried
+  first, so existing sibling checkouts keep their precedence.
+
+The loader searches sibling checkouts and any roots listed in
+`AXIOM_RULESPEC_REPO_ROOTS` (each entry may be a jurisdiction repo, a
+country monorepo, or a directory containing either).
 
 Executable rules loaded from jurisdiction repos receive a durable id of
 `<canonical file target>#<rule name>`, for example

--- a/src/rulespec.rs
+++ b/src/rulespec.rs
@@ -489,8 +489,7 @@ fn resolve_canonical_rulespec_import(
         });
     }
 
-    let repo_name = format!("rulespec-{prefix}");
-    for root in candidate_rule_repo_roots(importer_path, &repo_name) {
+    for root in candidate_rule_repo_roots(importer_path, prefix) {
         let target_path = root.join(&relative_path);
         if target_path.exists() {
             return Ok(target_path);
@@ -511,12 +510,28 @@ fn canonical_rulespec_target(path: &Path) -> Option<String> {
     let repo_index = components
         .iter()
         .rposition(|component| component.starts_with("rulespec-"))?;
-    let prefix = components[repo_index].strip_prefix("rulespec-")?;
-    if prefix.is_empty() || repo_index + 1 >= components.len() {
+    let repo_prefix = components[repo_index].strip_prefix("rulespec-")?;
+    if repo_prefix.is_empty() || repo_index + 1 >= components.len() {
+        return None;
+    }
+    // Country-monorepo layout: a repo named rulespec-<country> holds one
+    // directory per jurisdiction (rulespec-us/us/…, rulespec-us/us-ca/…).
+    // A first component equal to the country code or extending it with a
+    // dash is the jurisdiction prefix; anything else is legacy layout where
+    // content sits at the repo root.
+    let next = components[repo_index + 1].as_str();
+    let is_jurisdiction_dir = next == repo_prefix
+        || (next.starts_with(repo_prefix) && next.as_bytes().get(repo_prefix.len()) == Some(&b'-'));
+    let (prefix, content_start) = if is_jurisdiction_dir {
+        (next.to_string(), repo_index + 2)
+    } else {
+        (repo_prefix.to_string(), repo_index + 1)
+    };
+    if content_start >= components.len() {
         return None;
     }
     let mut relative = PathBuf::new();
-    for component in &components[repo_index + 1..] {
+    for component in &components[content_start..] {
         relative.push(component);
     }
     let mut relative = relative.to_string_lossy().replace('\\', "/");
@@ -559,7 +574,16 @@ fn is_absolute_rulespec_ref(value: &str) -> bool {
         && !value.chars().any(char::is_whitespace)
 }
 
-fn candidate_rule_repo_roots(importer_path: &Path, repo_name: &str) -> Vec<PathBuf> {
+fn candidate_rule_repo_roots(importer_path: &Path, prefix: &str) -> Vec<PathBuf> {
+    // A jurisdiction's content root is either a legacy standalone repo
+    // named rulespec-<prefix> (content at its root), or the <prefix>/
+    // directory inside a country monorepo named rulespec-<country>
+    // (rulespec-us containing us/, us-ca/, …). Legacy candidates come
+    // first so existing sibling checkouts keep their precedence.
+    let repo_name = format!("rulespec-{prefix}");
+    let country = prefix.split('-').next().unwrap_or(prefix);
+    let monorepo_name = format!("rulespec-{country}");
+
     let mut candidates = Vec::new();
     let mut seen = HashSet::new();
     let mut add = |candidate: PathBuf| {
@@ -570,27 +594,45 @@ fn candidate_rule_repo_roots(importer_path: &Path, repo_name: &str) -> Vec<PathB
 
     if let Some(env_roots) = env::var_os("AXIOM_RULESPEC_REPO_ROOTS") {
         for raw_root in env::split_paths(&env_roots) {
-            if raw_root.file_name().is_some_and(|name| name == repo_name) {
-                add(raw_root);
+            if raw_root.file_name().is_some_and(|name| name == repo_name.as_str()) {
+                add(raw_root.clone());
             } else {
-                add(raw_root.join(repo_name));
+                add(raw_root.join(&repo_name));
+            }
+            if raw_root
+                .file_name()
+                .is_some_and(|name| name == monorepo_name.as_str())
+            {
+                add(raw_root.join(prefix));
+            } else {
+                add(raw_root.join(&monorepo_name).join(prefix));
             }
         }
     }
 
     for ancestor in importer_path.ancestors() {
-        if ancestor.file_name().is_some_and(|name| name == repo_name) {
+        if ancestor.file_name().is_some_and(|name| name == repo_name.as_str()) {
             add(ancestor.to_path_buf());
         }
-        if let Some(parent) = ancestor.parent() {
-            add(parent.join(repo_name));
+        if ancestor
+            .file_name()
+            .is_some_and(|name| name == monorepo_name.as_str())
+        {
+            add(ancestor.join(prefix));
         }
-        add(ancestor.join("_axiom").join(repo_name));
+        if let Some(parent) = ancestor.parent() {
+            add(parent.join(&repo_name));
+            add(parent.join(&monorepo_name).join(prefix));
+        }
+        add(ancestor.join("_axiom").join(&repo_name));
+        add(ancestor.join("_axiom").join(&monorepo_name).join(prefix));
     }
 
     if let Ok(cwd) = env::current_dir() {
-        add(cwd.join(repo_name));
-        add(cwd.join("_axiom").join(repo_name));
+        add(cwd.join(&repo_name));
+        add(cwd.join(&monorepo_name).join(prefix));
+        add(cwd.join("_axiom").join(&repo_name));
+        add(cwd.join("_axiom").join(&monorepo_name).join(prefix));
     }
     candidates
 }

--- a/tests/monorepo_env_resolution.rs
+++ b/tests/monorepo_env_resolution.rs
@@ -1,0 +1,72 @@
+//! AXIOM_RULESPEC_REPO_ROOTS may point at a country monorepo root (or its
+//! parent); jurisdiction content resolves through the <prefix>/ directory.
+//! Kept in its own integration-test binary because it mutates process env.
+
+use axiom_rules_engine::compile::compile_program_file_to_json;
+
+#[test]
+fn env_root_at_monorepo_resolves_jurisdiction_dirs() {
+    let temp_root = std::env::temp_dir().join(format!(
+        "axiom-rules-engine-monorepo-env-{}",
+        std::process::id()
+    ));
+    let monorepo = temp_root.join("checkouts").join("rulespec-us");
+    let us_path = monorepo.join("us/policies/base.yaml");
+    // Importer lives OUTSIDE the monorepo, so only the env root can find it.
+    let program_path = temp_root.join("elsewhere/program.yaml");
+    let artifact_path = temp_root.join("program.compiled.json");
+
+    std::fs::create_dir_all(us_path.parent().expect("us parent")).expect("us dir");
+    std::fs::create_dir_all(program_path.parent().expect("program parent"))
+        .expect("program dir");
+    std::fs::write(
+        &us_path,
+        r#"
+format: rulespec/v1
+rules:
+  - name: base_amount
+    kind: parameter
+    dtype: Money
+    unit: USD
+    versions:
+      - effective_from: 2026-01-01
+        formula: "10"
+"#,
+    )
+    .expect("federal module is written");
+    std::fs::write(
+        &program_path,
+        r#"
+format: rulespec/v1
+imports:
+  - us:policies/base
+rules:
+  - name: adjusted_amount
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    versions:
+      - effective_from: 2026-01-01
+        formula: base_amount + amount
+"#,
+    )
+    .expect("program is written");
+
+    // Point at the monorepo root itself; resolution should try <root>/us/.
+    unsafe { std::env::set_var("AXIOM_RULESPEC_REPO_ROOTS", &monorepo) };
+    let result = compile_program_file_to_json(&program_path, &artifact_path);
+    unsafe { std::env::remove_var("AXIOM_RULESPEC_REPO_ROOTS") };
+
+    let artifact = result.expect("env monorepo root resolves us: imports");
+    assert!(
+        artifact
+            .program
+            .parameters
+            .iter()
+            .any(|parameter| parameter.name == "base_amount")
+    );
+
+    std::fs::remove_dir_all(&temp_root).ok();
+}

--- a/tests/monorepo_resolution.rs
+++ b/tests/monorepo_resolution.rs
@@ -1,0 +1,113 @@
+//! Country-monorepo layout: one repo named rulespec-<country> holding a
+//! directory per jurisdiction (us/, us-co/, …). Durable IDs must be
+//! identical to the legacy sibling-checkout layout.
+
+use axiom_rules_engine::compile::compile_program_file_to_json;
+
+const FEDERAL_MODULE: &str = r#"
+format: rulespec/v1
+rules:
+  - name: snap_maximum_allotment_table
+    kind: parameter
+    dtype: Money
+    unit: USD
+    indexed_by: household_size
+    versions:
+      - effective_from: 2025-10-01
+        values:
+          1: 298
+          2: 546
+  - name: snap_maximum_allotment
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    versions:
+      - effective_from: 2025-10-01
+        formula: snap_maximum_allotment_table[household_size]
+"#;
+
+const STATE_MODULE: &str = r#"
+format: rulespec/v1
+imports:
+  - us:policies/usda/snap/fy-2026-cola/maximum-allotments
+rules:
+  - name: snap_household_food_contribution_rate
+    kind: parameter
+    dtype: Rate
+    versions:
+      - effective_from: 2025-10-01
+        formula: "0.30"
+  - name: snap_regular_month_allotment
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    versions:
+      - effective_from: 2025-10-01
+        formula: floor(snap_maximum_allotment - (net_income * snap_household_food_contribution_rate))
+"#;
+
+#[test]
+fn monorepo_jurisdiction_dirs_resolve_with_unchanged_ids() {
+    let temp_root = std::env::temp_dir().join(format!(
+        "axiom-rules-engine-monorepo-resolution-{}",
+        std::process::id()
+    ));
+    let us_path = temp_root
+        .join("rulespec-us")
+        .join("us/policies/usda/snap/fy-2026-cola/maximum-allotments.yaml");
+    let co_path = temp_root
+        .join("rulespec-us")
+        .join("us-co/policies/cdhs/snap/fy-2026-benefit.yaml");
+    let artifact_path = temp_root.join("benefit.compiled.json");
+
+    std::fs::create_dir_all(us_path.parent().expect("us parent")).expect("us dir");
+    std::fs::create_dir_all(co_path.parent().expect("co parent")).expect("co dir");
+    std::fs::write(&us_path, FEDERAL_MODULE).expect("federal module is written");
+    std::fs::write(&co_path, STATE_MODULE).expect("state module is written");
+
+    let artifact = compile_program_file_to_json(&co_path, &artifact_path)
+        .expect("state module inside a country monorepo resolves federal imports");
+
+    assert!(artifact.program.parameters.iter().any(|parameter| {
+        parameter.id.as_deref()
+            == Some(
+                "us:policies/usda/snap/fy-2026-cola/maximum-allotments#snap_maximum_allotment_table",
+            )
+    }));
+    assert!(artifact.program.derived.iter().any(|derived| {
+        derived.id.as_deref()
+            == Some("us-co:policies/cdhs/snap/fy-2026-benefit#snap_regular_month_allotment")
+    }));
+
+    std::fs::remove_dir_all(&temp_root).ok();
+}
+
+#[test]
+fn federal_content_under_country_dir_keeps_us_prefix() {
+    let temp_root = std::env::temp_dir().join(format!(
+        "axiom-rules-engine-monorepo-federal-{}",
+        std::process::id()
+    ));
+    let us_module = temp_root
+        .join("rulespec-us")
+        .join("us/policies/usda/snap/fy-2026-cola/maximum-allotments.yaml");
+    let artifact_path = temp_root.join("federal.compiled.json");
+
+    std::fs::create_dir_all(us_module.parent().expect("us parent")).expect("us dir");
+    std::fs::write(&us_module, FEDERAL_MODULE).expect("federal module is written");
+
+    let artifact = compile_program_file_to_json(&us_module, &artifact_path)
+        .expect("federal module compiles under monorepo layout");
+    assert!(artifact.program.parameters.iter().any(|parameter| {
+        parameter.id.as_deref()
+            == Some(
+                "us:policies/usda/snap/fy-2026-cola/maximum-allotments#snap_maximum_allotment_table",
+            )
+    }));
+
+    std::fs::remove_dir_all(&temp_root).ok();
+}


### PR DESCRIPTION
Groundwork for the country-monorepo consolidation (one repo per sovereign system: rulespec-us holding us/, us-al/…us-tx/, rulespec-uk holding uk/ + councils).

- `candidate_rule_repo_roots` now also tries `<rulespec-country>/<prefix>/` everywhere it previously tried sibling `rulespec-<prefix>` checkouts (env roots, ancestors, `_axiom/`, cwd). Legacy candidates keep precedence.
- `canonical_rulespec_target` recognizes the jurisdiction directory, so durable ids are byte-identical across layouts (`us-co:policies/...#rule` regardless of where the file lives).
- docs/rulespec.md documents both layouts.
- 3 new integration tests (monorepo resolution, federal-under-country-dir ids, env-root-at-monorepo — the env test isolated in its own binary); full suite 75 pass, all legacy tests untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)