### PR TITLE
Reserve the assessment-time axis (bitemporal design + query field)

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -4,6 +4,50 @@ Short decision log for architecture choices. Publicly and internally, this is
 the Axiom Rules Engine; the Rust crate and executable are `axiom-rules-engine`. One
 entry per decision, most recent first.
 
+## 2026-06-10 — Reserve the assessment-time axis before content depends on it
+
+**Decision.** The engine is bitemporal by design: valid time (the benefit
+period the law governs — the existing `period` / `effective_from` axis) and
+decision/assessment time (when the determination is made) are separate axes.
+`ExecutionQuery` reserves an optional `assessment_date` on both the direct and
+compiled request paths, mirrored in the Python models and echoed on each
+`QueryResult`. For now it is parsed and validated only — it must be on or
+after `period.start` — and has no effect on evaluation. RuleSpec versions will
+grow optional `enacted_on` / `known_from` alongside `effective_from`;
+`assessment_date` will select which enactments are visible while `period`
+keeps selecting which visible version applies. `docs/bitemporal.md` is the
+full design.
+
+**Why.**
+
+- Retroactive amendments (ARPA's 2021-03-11 enactment effective for tax year
+  2020), retroactive COLA corrections, SNAP retro-certification and restored
+  benefits (7 CFR 273.10, 273.17), and appeals all separate "law in force
+  during the period" from "law as known at assessment". One axis cannot
+  represent a correct-when-made determination once an encoding absorbs a
+  retroactive enactment.
+- Among versions sharing an `effective_from`, selection currently falls
+  through to document order — an accident of file layout. The assessment axis
+  turns that into a principled rule: the latest-enacted visible version wins.
+- Reserving the query field now lets requests, stored results, and callers
+  carry assessment dates before any encoding depends on the semantics, instead
+  of retrofitting the wire format later.
+
+**Consequences.**
+
+- Absent fields mean "known since forever": versions without
+  `enacted_on`/`known_from` are visible at every assessment date, so selection
+  reduces exactly to today's `effective_from` rule. Existing encodings,
+  requests, artifacts, and responses are unchanged; unset fields are omitted
+  from the wire.
+- Queries with `assessment_date` before the period start are rejected;
+  assessing a period before it begins is projection, which stays out of scope.
+- When the engine starts honoring visibility dates, `ARTIFACT_FORMAT_VERSION`
+  must bump (per the 2026-06-09 decision) and the evaluation cache key gains
+  an assessment dimension.
+- Explicitly out of scope: retro recalculation workflow, cross-period
+  corrections/claims ledgers, and knowledge time for input data.
+
 ## 2026-06-09 — Compiled artifacts carry a format version and are bounded subprocesses
 
 **Decision.** `CompiledProgramArtifact` stamps `artifact_format_version`

--- a/docs/bitemporal.md
+++ b/docs/bitemporal.md
@@ -1,0 +1,201 @@
+# Bitemporal semantics: valid time and assessment time
+
+The engine currently has one time axis. Parameter and derived rules carry
+`versions[]` with `effective_from`, and the query's `period` selects whichever
+version is live for the period being calculated. That single axis answers one
+question — "what does the law say about this benefit period?" — while silently
+assuming a second answer: that the assessor knows every enactment that will
+ever touch that period.
+
+Real eligibility systems cannot make that assumption. A determination is made
+*at a moment in time*, under the law *as known at that moment*. Retroactive
+amendments, corrections, appeals, and retro-certification all separate the
+period a determination covers from the date the determination is made. This
+document defines the two axes, reserves the schema and query surface for the
+second one, and states exactly what is and is not implemented today.
+
+## The two axes
+
+- **Valid time** — the benefit period the law governs. This is the existing
+  axis: the query's `period`, matched against each version's
+  `effective_from`. It answers: *which version of the rule was in force for
+  the period being calculated?*
+- **Decision/assessment time** — when the determination is made. This is the
+  new axis: the query's `assessment_date`, matched against each version's
+  enactment/knowledge date. It answers: *which enactments were visible to the
+  assessor when the determination was made?*
+
+| | Valid time | Assessment time |
+|---|---|---|
+| Query field | `period` | `assessment_date` |
+| Version field | `effective_from` | `enacted_on` / `known_from` |
+| Question | law in force during the period | law as known at determination |
+
+Today the engine conflates the two: selecting a version by
+`effective_from <= period.start` implicitly evaluates every query as an
+omniscient, end-of-history assessment. For a single point-in-time snapshot of
+the law that is correct. The moment an encoding contains a retroactive
+enactment — two versions claiming the same valid time, enacted at different
+moments — the single axis cannot say which one a March determination should
+have used.
+
+## Why eligibility systems need both
+
+**Amendments with retroactive effective dates.** The American Rescue Plan Act
+(Pub. L. 117-2) was enacted on 2021-03-11 and excluded up to $10,200 of
+unemployment compensation from federal taxable income *for tax year 2020* —
+an effective date more than fourteen months before enactment. A tax-year-2020
+determination made on 2021-02-15 (an early filer) correctly applied pre-ARPA
+law; the same period determined on 2021-04-15 correctly applied the
+exclusion. Same `period`, different `assessment_date`, both determinations
+right when made. Encoded bitemporally, the new version carries
+`effective_from: 2020-01-01` and `enacted_on: 2021-03-11`.
+
+**Retroactive COLA corrections.** SNAP maximum allotments adjust each October
+1 (7 U.S.C. 2012(u), 2017(a)); FNS publishes the tables in a summer COLA
+memo. Suppose FNS issues a December correction revising an allotment cell,
+retroactive to October 1. The encoding then holds two versions with the same
+`effective_from: <fy>-10-01` and different enactment dates. A November
+determination used the original cell; a January re-determination of that same
+November month uses the corrected one. Today the engine cannot even represent
+this case faithfully: among versions sharing an `effective_from`, selection
+falls through to document order (`max_by_key` keeps the last maximum), which
+is an accident of file layout rather than a statement about enactment. The
+assessment axis turns that tie-break into a principled rule: the
+latest-enacted version *visible at the assessment date* wins.
+
+**SNAP retro-certification.** Initial-month benefits run from the date of
+application (7 CFR 273.10(a)(1)(ii)), and certification may lawfully complete
+up to 30 days later (7 CFR 273.2(g)). An April certification of a household
+that applied March 30 computes the March allotment: valid time is March,
+assessment time is April. Restored benefits reach further — agency errors and
+fair-hearing reversals are corrected with up to twelve months of restoration
+(7 CFR 273.17, 273.15), so a determination made in June routinely computes a
+benefit month from the previous year, under that month's rules, including any
+enactments that retroactively reached it in the meantime.
+
+**Appeals and audits.** Reproducing what a caseworker *should have decided*
+on a given date requires pinning both axes: the benefit period under review
+and the assessment date of the original decision. Quality-control reviews
+(7 CFR 275) ask exactly this question. Without assessment time, an encoding
+that has since absorbed a retroactive amendment can no longer reproduce the
+original, correct-when-made determination.
+
+## How RuleSpec grows
+
+Versions gain two optional dates alongside `effective_from`:
+
+```yaml
+rules:
+  - name: unemployment_compensation_exclusion_cap
+    kind: parameter
+    dtype: Money
+    unit: USD
+    versions:
+      - effective_from: 2020-01-01
+        enacted_on: 2021-03-11
+        formula: "10200"
+```
+
+- `enacted_on` — when the legal act creating this version was enacted or
+  promulgated. This is both provenance and the default visibility date for
+  assessment-time selection.
+- `known_from` — when the version became visible to the assessing system, if
+  that differs from enactment. State manuals routinely publish federal changes
+  weeks after the federal notice; `known_from` lets an encoding model the
+  administrative lag without misstating the enactment date. When present it
+  overrides `enacted_on` for selection only.
+
+A version's **visibility date** is `known_from`, else `enacted_on`, else
+negative infinity. Both fields apply to `parameter` and `derived` versions
+alike. They are RuleSpec authoring fields first; `ProgramSpec` and the
+compiled artifact grow matching fields only when the engine starts honoring
+them.
+
+## Query semantics
+
+`assessment_date` is an optional field on `ExecutionQuery`, available on both
+the direct and the compiled request paths, with one value per query (it
+scopes the whole determination, not individual outputs). The two fields
+divide the work:
+
+- `assessment_date` selects which enactments are **visible**: versions whose
+  visibility date is on or before the assessment date.
+- `period` selects which visible version **applies**: the latest
+  `effective_from` at or before `period.start`, exactly as today.
+
+Normatively, once implemented:
+
+1. visible = versions where `visibility_date <= assessment_date`
+2. applicable = visible where `effective_from <= period.start`
+3. select the maximum by (`effective_from`, then visibility date, then
+   document order)
+
+An omitted `assessment_date` means every version is visible — the law as
+currently encoded, which is today's behavior unchanged and the right default
+for policy analysis and microsimulation.
+
+`assessment_date` must be on or after `period.start`. Assessing a period
+before it begins is a projection, not a determination — prospective
+certifications are modeled as assessments made when each benefit month is
+issued — and projection semantics (with their own questions, such as
+forecasting indexed parameters) are deliberately out of scope. The constraint
+is a validation, so relaxing it later is backward compatible.
+
+Each `QueryResult` echoes the query's `assessment_date`, so a stored result
+remains self-describing about the assessment it was computed under.
+
+**Implemented today:** the field is parsed, validated against `period.start`,
+and echoed (`src/api.rs`; mirrored in
+`python/axiom_rules_engine/models.py`). It has **no effect on evaluation**.
+Version selection still considers every version
+(`src/engine.rs`, `src/bulk.rs`, `src/dense.rs` all select by
+`effective_from` only). The point of reserving the field now is that requests,
+stored results, and calling code can start carrying assessment dates before
+any encoding depends on the semantics.
+
+## Migration story
+
+Absent fields mean "known since forever": a version without `enacted_on` or
+`known_from` has a visibility date of negative infinity, is visible at every
+assessment date, and the selection rule above reduces exactly to today's
+`effective_from` rule — with or without an `assessment_date` on the query.
+Every existing encoding, request, artifact, and response is therefore
+unaffected:
+
+- Requests: `assessment_date` is optional and omitted from the wire when
+  unset, so requests that do not use it are byte-identical to before.
+- Responses: the echo is likewise omitted when unset.
+- Encodings: `enacted_on`/`known_from` are optional; existing rule files are
+  valid and mean what they always meant.
+- Compiled artifacts: today's engines ignore unknown fields, so an artifact
+  carrying visibility dates would *silently evaluate omnisciently* on an old
+  engine. When the engine starts honoring visibility dates,
+  `ARTIFACT_FORMAT_VERSION` must bump so older engines reject such artifacts
+  loudly (see the 2026-06-09 decision in `DECISIONS.md`).
+
+One known implementation consequence for later: the evaluation cache keys on
+(derived, entity, period). Honoring assessment time adds a dimension —
+results may differ across assessment dates for the same period — so the cache
+key (or the engine instance scope) must grow with it.
+
+## Out of scope now
+
+- **Honoring `assessment_date` in version selection.** The field is reserved,
+  validated, and echoed only. Selection semantics land together with
+  `enacted_on`/`known_from` support in the loader, IR, and all three
+  execution paths.
+- **A retro recalculation engine.** Detecting that a retroactive enactment
+  changes past determinations, finding affected cases, and re-running them is
+  workflow built on top of the engine. The engine stays a pure function of
+  (rules, data, period, assessment date).
+- **A cross-period corrections ledger.** Computing underpayment/overpayment
+  deltas between an original and a corrected determination, claims
+  establishment, and recoupment (7 CFR 273.18) are downstream products of
+  running the same period at two assessment dates — not engine features.
+- **Knowledge time for data.** `assessment_date` governs visibility of *law*.
+  What evidence the assessor had is already the caller's responsibility: the
+  dataset is caller-supplied, so callers reconstruct the evidence as-of the
+  assessment themselves. `InputRecord` does not grow a `known_from`.
+- **Projection.** `assessment_date < period.start` stays an error.
+- **Per-output assessment overrides.** One assessment date per query.

--- a/python/axiom_rules_engine/models.py
+++ b/python/axiom_rules_engine/models.py
@@ -58,6 +58,12 @@ class ExecutionQuery(BaseModel):
     entity_id: str
     period: Period
     outputs: list[str]
+    # Decision/assessment time: the date the determination is made, as opposed
+    # to `period` (valid time — the benefit period the law governs). Reserved
+    # for the bitemporal semantics in docs/bitemporal.md. The engine parses and
+    # validates it (it must be on or after `period.start`) but it has NO effect
+    # on evaluation yet.
+    assessment_date: date | None = None
 
 
 class ExecutionRequest(BaseModel):
@@ -142,6 +148,8 @@ DerivedTraceNode = Annotated[
 class QueryResult(BaseModel):
     entity_id: str
     period: Period
+    # Echo of the query's `assessment_date` (see docs/bitemporal.md).
+    assessment_date: date | None = None
     outputs: dict[str, OutputValue]
     trace: dict[str, DerivedTraceNode] = Field(default_factory=dict)
 

--- a/python/tests/test_assessment_date.py
+++ b/python/tests/test_assessment_date.py
@@ -1,0 +1,73 @@
+"""`assessment_date` is a reserved bitemporal field (see docs/bitemporal.md):
+it must round-trip through the wire models without changing the request shape
+for callers that do not use it."""
+from __future__ import annotations
+
+import json
+from datetime import date
+
+from axiom_rules_engine.models import (
+    Dataset,
+    ExecutionQuery,
+    ExecutionRequest,
+    ExecutionResponse,
+    Period,
+    Program,
+)
+
+
+def _query(assessment_date: date | None = None) -> ExecutionQuery:
+    period = Period(period_kind="Month", start="2026-01-01", end="2026-01-31")
+    return ExecutionQuery(
+        entity_id="household-1",
+        period=period,
+        outputs=["adjusted_amount"],
+        assessment_date=assessment_date,
+    )
+
+
+def test_assessment_date_round_trips() -> None:
+    query = _query(assessment_date=date(2026, 3, 15))
+    request = ExecutionRequest(
+        mode="explain", program=Program(), dataset=Dataset(), queries=[query]
+    )
+
+    # Serialise the way the client does and parse back.
+    payload = json.loads(request.model_dump_json(exclude_none=True))
+    assert payload["queries"][0]["assessment_date"] == "2026-03-15"
+    reparsed = ExecutionRequest.model_validate(payload)
+    assert reparsed.queries[0].assessment_date == date(2026, 3, 15)
+
+
+def test_unset_assessment_date_is_absent_from_the_wire() -> None:
+    request = ExecutionRequest(
+        mode="explain", program=Program(), dataset=Dataset(), queries=[_query()]
+    )
+    payload = json.loads(request.model_dump_json(exclude_none=True))
+    assert "assessment_date" not in payload["queries"][0]
+
+
+def test_responses_parse_with_and_without_the_echo() -> None:
+    base_result = {
+        "entity_id": "household-1",
+        "period": {
+            "period_kind": "Month",
+            "start": "2026-01-01",
+            "end": "2026-01-31",
+        },
+        "outputs": {},
+    }
+    metadata = {"requested_mode": "explain", "actual_mode": "explain"}
+
+    legacy = ExecutionResponse.model_validate(
+        {"metadata": metadata, "results": [base_result]}
+    )
+    assert legacy.results[0].assessment_date is None
+
+    echoed = ExecutionResponse.model_validate(
+        {
+            "metadata": metadata,
+            "results": [{**base_result, "assessment_date": "2026-03-15"}],
+        }
+    )
+    assert echoed.results[0].assessment_date == date(2026, 3, 15)

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,5 +1,6 @@
 use std::collections::BTreeMap;
 
+use chrono::NaiveDate;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
@@ -37,6 +38,17 @@ pub struct ExecutionQuery {
     pub entity_id: String,
     pub period: PeriodSpec,
     pub outputs: Vec<String>,
+    /// Decision/assessment time: the date the determination is made, as
+    /// opposed to `period`, which is valid time — the benefit period the law
+    /// governs. Reserved for the bitemporal version-selection semantics in
+    /// `docs/bitemporal.md`.
+    ///
+    /// Today this field is parsed and validated only: when present it must be
+    /// on or after `period.start`, and it has NO effect on evaluation yet.
+    /// Version selection still considers every version, exactly as if the
+    /// assessment had full knowledge of all enactments.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub assessment_date: Option<NaiveDate>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -56,6 +68,10 @@ pub struct ExecutionMetadata {
 pub struct QueryResult {
     pub entity_id: String,
     pub period: PeriodSpec,
+    /// Echo of the query's `assessment_date`, so callers can tie a result to
+    /// the assessment it was requested under. See `docs/bitemporal.md`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub assessment_date: Option<NaiveDate>,
     pub outputs: BTreeMap<String, OutputValue>,
     #[serde(default)]
     pub trace: BTreeMap<String, DerivedTraceNode>,
@@ -117,9 +133,35 @@ pub enum ApiError {
     Eval(#[from] EvalError),
     #[error(transparent)]
     Spec(#[from] crate::spec::SpecError),
+    #[error(
+        "assessment_date {assessment_date} is before the query period start {period_start}; a determination cannot be assessed before the period it covers begins (see docs/bitemporal.md)"
+    )]
+    AssessmentDateBeforePeriodStart {
+        assessment_date: NaiveDate,
+        period_start: NaiveDate,
+    },
+}
+
+/// Reject queries whose `assessment_date` predates the period they assess.
+/// Assessing a period before it starts would be a projection, not a
+/// determination; projection semantics are explicitly out of scope for now
+/// (see docs/bitemporal.md).
+fn validate_assessment_dates(queries: &[ExecutionQuery]) -> Result<(), ApiError> {
+    for query in queries {
+        if let Some(assessment_date) = query.assessment_date {
+            if assessment_date < query.period.start {
+                return Err(ApiError::AssessmentDateBeforePeriodStart {
+                    assessment_date,
+                    period_start: query.period.start,
+                });
+            }
+        }
+    }
+    Ok(())
 }
 
 pub fn execute_request(request: ExecutionRequest) -> Result<ExecutionResponse, ApiError> {
+    validate_assessment_dates(&request.queries)?;
     let requested_mode = request.mode.clone();
     let program = request.program.to_program()?;
     let dataset = request.dataset.to_dataset_for_program(&program)?;
@@ -236,6 +278,7 @@ fn execute_explain(
         results.push(QueryResult {
             entity_id: query.entity_id,
             period: query.period,
+            assessment_date: query.assessment_date,
             outputs,
             trace,
         });

--- a/src/bulk.rs
+++ b/src/bulk.rs
@@ -163,6 +163,7 @@ pub fn try_execute(
                 start: query.period.start,
                 end: query.period.end,
             },
+            assessment_date: query.assessment_date,
             outputs,
             trace: BTreeMap::new(),
         });

--- a/tests/dense.rs
+++ b/tests/dense.rs
@@ -221,6 +221,7 @@ fn dense_flat_tax_matches_explain_mode() {
         queries: people
             .iter()
             .map(|(person_id, _)| ExecutionQuery {
+                assessment_date: None,
                 entity_id: (*person_id).to_string(),
                 period: period.clone(),
                 outputs: vec![
@@ -346,6 +347,7 @@ fn dense_family_allowance_matches_explain_mode() {
         queries: households
             .iter()
             .map(|(household_id, _)| ExecutionQuery {
+                assessment_date: None,
                 entity_id: (*household_id).to_string(),
                 period: period.clone(),
                 outputs: vec![
@@ -517,6 +519,7 @@ fn dense_filtered_entity_scope_matches_explain_mode() {
         queries: ["household-1", "household-2"]
             .into_iter()
             .map(|entity_id| ExecutionQuery {
+                assessment_date: None,
                 entity_id: entity_id.to_string(),
                 period: period.clone(),
                 outputs: vec![
@@ -653,6 +656,7 @@ fn dense_filtered_entity_membership_can_depend_on_current_entity_predicates() {
         queries: ["household-1", "household-2"]
             .into_iter()
             .map(|entity_id| ExecutionQuery {
+                assessment_date: None,
                 entity_id: entity_id.to_string(),
                 period: period.clone(),
                 outputs: vec!["snap_unit_size".to_string()],
@@ -779,6 +783,7 @@ fn dense_filtered_entities_can_compose_source_relations() {
             ],
         },
         queries: vec![ExecutionQuery {
+            assessment_date: None,
             entity_id: "household-1".to_string(),
             period: period.clone(),
             outputs: vec!["adult_snap_unit_size".to_string()],
@@ -857,6 +862,7 @@ fn dense_child_benefit_responsibility_matches_explain_mode() {
             .cases
             .iter()
             .map(|case| ExecutionQuery {
+                assessment_date: None,
                 entity_id: case.child_id.clone(),
                 period: case.period.clone(),
                 outputs: outputs.to_vec(),
@@ -1024,6 +1030,7 @@ fn dense_scottish_ctr_max_matches_explain_mode() {
             .cases
             .iter()
             .map(|case| ExecutionQuery {
+                assessment_date: None,
                 entity_id: case.dwelling_id.clone(),
                 period: case.period.clone(),
                 outputs: outputs.to_vec(),
@@ -1199,6 +1206,7 @@ fn dense_child_benefit_rates_matches_explain_mode() {
             .cases
             .iter()
             .map(|case| ExecutionQuery {
+                assessment_date: None,
                 entity_id: case.claimant_id.clone(),
                 period: case.period.clone(),
                 outputs: outputs.to_vec(),
@@ -1375,6 +1383,7 @@ fn dense_auto_enrolment_matches_explain_mode() {
             .cases
             .iter()
             .map(|case| ExecutionQuery {
+                assessment_date: None,
                 entity_id: case.jobholder_id.clone(),
                 period: case.period.clone(),
                 outputs: outputs.to_vec(),
@@ -1527,6 +1536,7 @@ fn dense_ated_matches_explain_mode() {
             .cases
             .iter()
             .map(|case| ExecutionQuery {
+                assessment_date: None,
                 entity_id: case.interest_id.clone(),
                 period: case.period.clone(),
                 outputs: outputs.to_vec(),
@@ -1695,6 +1705,7 @@ fn dense_ct_marginal_relief_matches_explain_mode() {
             .cases
             .iter()
             .map(|case| ExecutionQuery {
+                assessment_date: None,
                 entity_id: case.company_id.clone(),
                 period: case.period.clone(),
                 outputs: outputs.to_vec(),
@@ -1889,6 +1900,7 @@ fn dense_state_pension_transitional_matches_explain_mode() {
             .cases
             .iter()
             .map(|case| ExecutionQuery {
+                assessment_date: None,
                 entity_id: case.person_id.clone(),
                 period: case.period.clone(),
                 outputs: outputs.to_vec(),
@@ -2035,6 +2047,7 @@ fn dense_universal_credit_matches_explain_mode() {
             .cases
             .iter()
             .map(|case| ExecutionQuery {
+                assessment_date: None,
                 entity_id: case.benefit_unit_id.clone(),
                 period: case.period.clone(),
                 outputs: outputs.to_vec(),
@@ -2498,6 +2511,7 @@ fn dense_date_add_days_matches_explain_mode() {
         queries: part_weeks
             .iter()
             .map(|(id, _)| ExecutionQuery {
+                assessment_date: None,
                 entity_id: id.to_string(),
                 period: period.clone(),
                 outputs: outputs.to_vec(),
@@ -2703,6 +2717,7 @@ fn dense_notional_capital_matches_explain_mode() {
         queries: applicants
             .iter()
             .map(|applicant| ExecutionQuery {
+                assessment_date: None,
                 entity_id: applicant.id.to_string(),
                 period: period.clone(),
                 outputs: outputs.to_vec(),

--- a/tests/execution.rs
+++ b/tests/execution.rs
@@ -207,6 +207,7 @@ fn fast_mode_coerces_integer_and_decimal_if_branches() {
     let queries = ["household-1", "household-2"]
         .into_iter()
         .map(|entity_id| ExecutionQuery {
+            assessment_date: None,
             entity_id: entity_id.to_string(),
             period: period.clone(),
             outputs: vec!["benefit".to_string()],
@@ -330,6 +331,7 @@ fn fast_mode_falls_back_to_explain_when_bulk_support_is_missing() {
         ],
     };
     let queries = vec![ExecutionQuery {
+        assessment_date: None,
         entity_id: "household-1".to_string(),
         period,
         outputs: vec!["household_income".to_string()],
@@ -435,6 +437,7 @@ fn fast_mode_falls_back_for_filtered_relation_counts() {
         }],
     };
     let queries = vec![ExecutionQuery {
+        assessment_date: None,
         entity_id: "household-1".to_string(),
         period,
         outputs: vec!["has_elderly_or_disabled_member".to_string()],
@@ -571,6 +574,7 @@ rules:
         program,
         dataset,
         queries: vec![ExecutionQuery {
+            assessment_date: None,
             entity_id: "household-1".to_string(),
             period,
             outputs: vec![
@@ -717,6 +721,7 @@ rules:
         program,
         dataset,
         queries: vec![ExecutionQuery {
+            assessment_date: None,
             entity_id: "household-1".to_string(),
             period,
             outputs: vec![
@@ -854,11 +859,13 @@ rules:
         dataset,
         queries: vec![
             ExecutionQuery {
+                assessment_date: None,
                 entity_id: "household-1".to_string(),
                 period: period.clone(),
                 outputs: vec!["snap_unit_size".to_string()],
             },
             ExecutionQuery {
+                assessment_date: None,
                 entity_id: "household-2".to_string(),
                 period,
                 outputs: vec!["snap_unit_size".to_string()],
@@ -1021,6 +1028,7 @@ rules:
         program,
         dataset,
         queries: vec![ExecutionQuery {
+            assessment_date: None,
             entity_id: "household-1".to_string(),
             period,
             outputs: vec!["adult_snap_unit_size".to_string()],
@@ -1156,6 +1164,131 @@ fn cli_compile_and_run_compiled_round_trip() {
     std::fs::remove_dir(temp_root).ok();
 }
 
+// `assessment_date` is a reserved bitemporal field (see docs/bitemporal.md):
+// it is parsed, validated, and echoed, but must not affect evaluation yet.
+#[test]
+fn assessment_date_round_trips_and_evaluates_identically() {
+    let program = axiom_rules_engine::rulespec::lower_rulespec_str(SIMPLE_RULESPEC)
+        .expect("program fixture parses");
+    let period = simple_period();
+    let assessment_date = chrono::NaiveDate::from_ymd_opt(2026, 3, 15).expect("valid date");
+
+    let without = simple_execution_request(ExecutionMode::Explain, program.clone());
+    let mut with = without.clone();
+    for query in &mut with.queries {
+        query.assessment_date = Some(assessment_date);
+    }
+
+    // Wire shape: the field is omitted when unset, so existing request JSON
+    // is unchanged, and legacy JSON without the field still deserializes.
+    let without_json = serde_json::to_value(&without).expect("request serialises");
+    assert!(
+        without_json["queries"][0].get("assessment_date").is_none(),
+        "unset assessment_date must not appear on the wire"
+    );
+    let with_json = serde_json::to_string(&with).expect("request serialises");
+    let reparsed: ExecutionRequest =
+        serde_json::from_str(&with_json).expect("request with assessment_date parses");
+    assert_eq!(reparsed.queries[0].assessment_date, Some(assessment_date));
+    let legacy: ExecutionQuery = serde_json::from_value(without_json["queries"][0].clone())
+        .expect("legacy query without assessment_date parses");
+    assert_eq!(legacy.assessment_date, None);
+
+    // Evaluation is identical with and without the field, in both modes.
+    for mode in [ExecutionMode::Explain, ExecutionMode::Fast] {
+        let mut without_request = without.clone();
+        without_request.mode = mode.clone();
+        let mut with_request = with.clone();
+        with_request.mode = mode;
+
+        let without_response =
+            execute_request(without_request).expect("request without assessment_date succeeds");
+        let with_response =
+            execute_request(with_request).expect("request with assessment_date succeeds");
+
+        assert_eq!(
+            serde_json::to_value(&without_response.metadata).expect("metadata serialises"),
+            serde_json::to_value(&with_response.metadata).expect("metadata serialises"),
+        );
+        assert_eq!(without_response.results.len(), with_response.results.len());
+        for (without_result, with_result) in without_response
+            .results
+            .iter()
+            .zip(with_response.results.iter())
+        {
+            assert_eq!(
+                serde_json::to_value(&without_result.outputs).expect("outputs serialise"),
+                serde_json::to_value(&with_result.outputs).expect("outputs serialise"),
+            );
+            assert_eq!(
+                serde_json::to_value(&without_result.trace).expect("trace serialises"),
+                serde_json::to_value(&with_result.trace).expect("trace serialises"),
+            );
+            // The response echoes the assessment the result was computed under.
+            assert_eq!(without_result.assessment_date, None);
+            assert_eq!(with_result.assessment_date, Some(assessment_date));
+        }
+    }
+
+    // The compiled-request path accepts and echoes the field identically.
+    let artifact = CompiledProgramArtifact::from_rulespec_str(SIMPLE_RULESPEC)
+        .expect("RuleSpec module compiles from YAML");
+    let mut compiled_queries = simple_queries(&period);
+    for query in &mut compiled_queries {
+        query.assessment_date = Some(assessment_date);
+    }
+    let compiled_response = execute_compiled_request(
+        artifact,
+        CompiledExecutionRequest {
+            mode: ExecutionMode::Fast,
+            dataset: simple_dataset(&period),
+            queries: compiled_queries,
+        },
+    )
+    .expect("compiled request with assessment_date succeeds");
+    assert_eq!(
+        compiled_response.results[0].assessment_date,
+        Some(assessment_date)
+    );
+    assert_eq!(
+        decimal_output(
+            compiled_response.results[0]
+                .outputs
+                .get("adjusted_amount")
+                .expect("adjusted amount output")
+        ),
+        decimal("25")
+    );
+
+    // Boundary: an assessment on the first day of the period is allowed.
+    let mut boundary = without.clone();
+    for query in &mut boundary.queries {
+        query.assessment_date = Some(period.start);
+    }
+    execute_request(boundary).expect("assessment on the period start date is valid");
+}
+
+#[test]
+fn assessment_date_before_period_start_errors() {
+    let program = axiom_rules_engine::rulespec::lower_rulespec_str(SIMPLE_RULESPEC)
+        .expect("program fixture parses");
+    let before_period = chrono::NaiveDate::from_ymd_opt(2025, 12, 31).expect("valid date");
+
+    for mode in [ExecutionMode::Explain, ExecutionMode::Fast] {
+        let mut request = simple_execution_request(mode, program.clone());
+        request.queries[1].assessment_date = Some(before_period);
+
+        let error = execute_request(request)
+            .expect_err("assessment_date before the period start must be rejected");
+        let message = error.to_string();
+        assert!(
+            message.contains("assessment_date 2025-12-31")
+                && message.contains("period start 2026-01-01"),
+            "unexpected error message: {message}"
+        );
+    }
+}
+
 fn simple_period() -> PeriodSpec {
     PeriodSpec {
         kind: PeriodKindSpec::Month,
@@ -1194,6 +1327,7 @@ fn simple_queries(period: &PeriodSpec) -> Vec<ExecutionQuery> {
     ["household-1", "household-2"]
         .into_iter()
         .map(|entity_id| ExecutionQuery {
+            assessment_date: None,
             entity_id: entity_id.to_string(),
             period: period.clone(),
             outputs: vec!["adjusted_amount".to_string()],

--- a/tests/rulespec.rs
+++ b/tests/rulespec.rs
@@ -230,6 +230,7 @@ rules:
             relations: Vec::new(),
         },
         queries: vec![ExecutionQuery {
+            assessment_date: None,
             entity_id: "household-1".to_string(),
             period,
             outputs: vec!["max_allotment".to_string()],
@@ -349,6 +350,7 @@ rules:
             relations: Vec::new(),
         },
         queries: vec![ExecutionQuery {
+            assessment_date: None,
             entity_id: "household-1".to_string(),
             period,
             outputs: vec!["us:statutes/7/2017/a#snap_regular_month_allotment".to_string()],
@@ -419,6 +421,7 @@ rules:
             relations: Vec::new(),
         },
         queries: vec![ExecutionQuery {
+            assessment_date: None,
             entity_id: "household-1".to_string(),
             period,
             outputs: vec![output_id.clone()],
@@ -502,6 +505,7 @@ rules:
             relations: Vec::new(),
         },
         queries: vec![ExecutionQuery {
+            assessment_date: None,
             entity_id: "tax-unit-1".to_string(),
             period,
             outputs: vec![output_id.clone()],
@@ -596,6 +600,7 @@ rules:
             relations: Vec::new(),
         },
         queries: vec![ExecutionQuery {
+            assessment_date: None,
             entity_id: "household-1".to_string(),
             period,
             outputs: vec![output_id.clone()],
@@ -683,6 +688,7 @@ rules:
             }],
         },
         queries: vec![ExecutionQuery {
+            assessment_date: None,
             entity_id: "household-1".to_string(),
             period,
             outputs: vec![output_id.clone()],
@@ -777,6 +783,7 @@ rules:
             }],
         },
         queries: vec![ExecutionQuery {
+            assessment_date: None,
             entity_id: "household-1".to_string(),
             period,
             outputs: vec![output_id.clone()],
@@ -900,6 +907,7 @@ rules:
             }],
         },
         queries: vec![ExecutionQuery {
+            assessment_date: None,
             entity_id: "household-1".to_string(),
             period,
             outputs: vec![output_id.clone()],
@@ -1041,6 +1049,7 @@ rules:
             }],
         },
         queries: vec![ExecutionQuery {
+            assessment_date: None,
             entity_id: "tax-unit-1".to_string(),
             period,
             outputs: vec![output_id.clone()],
@@ -1165,6 +1174,7 @@ rules: []
             ],
         },
         queries: vec![ExecutionQuery {
+            assessment_date: None,
             entity_id: "tax-unit-1".to_string(),
             period,
             outputs: vec![ctc_output.clone(), standard_deduction_output.clone()],
@@ -2175,6 +2185,7 @@ rules:
             relations: Vec::new(),
         },
         queries: vec![ExecutionQuery {
+            assessment_date: None,
             entity_id: "household-1".to_string(),
             period,
             outputs: vec![output_id.clone()],


### PR DESCRIPTION
Reserves the second time axis before content depends on it — design doc plus a parsed-and-validated `assessment_date` query field with NO evaluation effect yet.

- `docs/bitemporal.md`: valid time (`period`/`effective_from`) vs assessment time; statutory examples (retroactive ARPA UI exclusion, SNAP COLA corrections, 7 CFR 273.17 restored benefits); growth path (`versions[].enacted_on`/`known_from`, visibility = known_from ?? enacted_on ?? −∞); omitted field = omniscient current-law evaluation (today's behavior, right default for policy analysis); `assessment_date < period.start` rejected (projection ≠ determination).
- `ExecutionQuery.assessment_date` (Rust + Python mirrors), response echo, up-front validation with a dedicated error; absent-on-wire when unset.
- DECISIONS.md entry in house style. Honoring the field in selection lands later with `enacted_on` content + an ARTIFACT_FORMAT_VERSION bump.
- 74 Rust + 28 Python tests pass; evaluation proven identical with/without the field in explain and fast modes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)