### PR TITLE
Core: module resolution behind ModuleSource; wasm32 check target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,23 @@ jobs:
       - name: cargo build --release
         run: cargo build --release --verbose
 
+  wasm:
+    name: wasm32 core check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6.0.2
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Cache cargo registry and build
+        uses: Swatinem/rust-cache@v2.9.1
+
+      - name: cargo check (wasm32-unknown-unknown, no default features)
+        run: cargo check --target wasm32-unknown-unknown --no-default-features --verbose
+
   python:
     name: Python package tests
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,15 +14,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "android_system_properties"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -118,16 +109,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
-name = "cc"
-version = "1.2.60"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
-dependencies = [
- "find-msvc-tools",
- "shlex",
-]
-
-[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -145,31 +126,15 @@ version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
- "iana-time-zone",
- "js-sys",
  "num-traits",
  "serde",
- "wasm-bindgen",
- "windows-link",
 ]
-
-[[package]]
-name = "core-foundation-sys"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
-
-[[package]]
-name = "find-msvc-tools"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "funty"
@@ -204,30 +169,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
-name = "iana-time-zone"
-version = "0.1.65"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
-dependencies = [
- "android_system_properties",
- "core-foundation-sys",
- "iana-time-zone-haiku",
- "js-sys",
- "log",
- "wasm-bindgen",
- "windows-core",
-]
-
-[[package]]
-name = "iana-time-zone-haiku"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -258,12 +199,6 @@ name = "libc"
 version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
-
-[[package]]
-name = "log"
-version = "0.4.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "memchr"
@@ -518,12 +453,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "shlex"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
-
-[[package]]
 name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -700,65 +629,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.62.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
-dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-link",
- "windows-result",
- "windows-strings",
-]
-
-[[package]]
-name = "windows-implement"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "windows-interface"
-version = "0.59.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "windows-link"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
-
-[[package]]
-name = "windows-result"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
-dependencies = [
- "windows-link",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
-dependencies = [
- "windows-link",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,8 +5,23 @@ edition = "2024"
 license = "Apache-2.0"
 description = "Prototype temporal-relational Axiom Rules Engine in Rust"
 
+[features]
+default = ["fs"]
+# Filesystem-backed module resolution (FsModuleSource, the *_file loading and
+# artifact APIs, AXIOM_RULESPEC_REPO_ROOTS) and the CLI binary. With this
+# feature off, the core has no std::fs / std::env usage and checks cleanly for
+# wasm32-unknown-unknown; hosts supply modules through source::ModuleSource.
+fs = []
+
+[[bin]]
+name = "axiom-rules-engine"
+path = "src/main.rs"
+required-features = ["fs"]
+
 [dependencies]
-chrono = { version = "0.4.42", features = ["serde"] }
+# Default features off: the `clock` feature (wall-clock reads) stays out of
+# the core, which never reads the current time and must not on wasm hosts.
+chrono = { version = "0.4.42", default-features = false, features = ["serde", "std"] }
 rust_decimal = { version = "1.39.0", features = ["maths", "serde"] }
 rust_decimal_macros = "1.39.0"
 serde = { version = "1.0.228", features = ["derive"] }

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -4,6 +4,46 @@ Short decision log for architecture choices. Publicly and internally, this is
 the Axiom Rules Engine; the Rust crate and executable are `axiom-rules-engine`. One
 entry per decision, most recent first.
 
+## 2026-06-10 — Module resolution is a host concern behind `ModuleSource`
+
+**Decision.** The core engine is a pure function over (modules, dataset):
+lowering, compilation, and execution never touch a filesystem, environment
+variable, or wall clock. Finding module text for a canonical target
+(`us:statutes/7/2015/e`) goes behind the `source::ModuleSource` trait
+(`load(target) -> Result<Option<String>, SourceError>`);
+`load_rulespec_with_source` and `CompiledProgramArtifact::from_rulespec_with_source`
+are the pure entry points. Resolving relative imports to canonical targets is
+pure string logic on the importer's canonical target and stays in the core
+(`resolve_import_target`). The existing filesystem resolution
+(sibling checkouts, country monorepos, `AXIOM_RULESPEC_REPO_ROOTS`) becomes
+`FsModuleSource` plus the unchanged `*_file` APIs, all behind a default-on
+`fs` feature; the CLI binary requires it. wasm32-unknown-unknown is a
+supported check target: CI runs
+`cargo check --target wasm32-unknown-unknown --no-default-features`.
+
+**Why.**
+
+- Running benefit calculations in the browser keeps household PII on-device —
+  zero round-trip. That requires the core to compile for wasm32 with no
+  filesystem assumptions.
+- Servers with modules in memory, registry clients, and test harnesses all
+  want to supply module text directly instead of staging checkouts on disk.
+- Splitting "resolve an import to a canonical target" (pure, in core) from
+  "find and read the text" (host) keeps durable ids identical across hosts:
+  an in-memory host and a checkout produce byte-identical programs.
+
+**Consequences.**
+
+- Default builds are unchanged: `fs` is on, the CLI, `load_rulespec_file`,
+  `from_rulespec_file`, and artifact file I/O behave exactly as before.
+- With `--no-default-features` the crate has no `std::fs` / `std::env` usage
+  and no clock reads; chrono is pinned `default-features = false` (no `clock`
+  feature) so wall-clock reads cannot creep into core paths unnoticed.
+- Hosts own availability semantics: `Ok(None)` means "no such module"
+  (reported with importer context), `Err(SourceError)` means the host failed.
+- Module identity, import cycles, and deduplication key on canonical targets
+  rather than canonicalized paths in the source-driven loader.
+
 ## 2026-06-10 — Reserve the assessment-time axis before content depends on it
 
 **Decision.** The engine is bitemporal by design: valid time (the benefit

--- a/docs/rulespec.md
+++ b/docs/rulespec.md
@@ -164,6 +164,17 @@ The loader searches sibling checkouts and any roots listed in
 `AXIOM_RULESPEC_REPO_ROOTS` (each entry may be a jurisdiction repo, a
 country monorepo, or a directory containing either).
 
+Filesystem search is one host strategy, not part of the core. A host can
+instead supply module text directly through the `source::ModuleSource` trait
+and the `load_rulespec_with_source` /
+`CompiledProgramArtifact::from_rulespec_with_source` entry points — for
+example a browser (wasm) bundle, a server holding modules in memory, or a
+registry client. Relative imports still resolve against the importing
+module's canonical target (pure string logic in the core), the host only
+answers "what is the YAML text for `us:statutes/7/2015/e`?", and durable ids
+come out identical to the filesystem layouts. The filesystem behavior above
+is packaged as `FsModuleSource` behind the default-on `fs` cargo feature.
+
 Executable rules loaded from jurisdiction repos receive a durable id of
 `<canonical file target>#<rule name>`, for example
 `us:statutes/7/2017/a#snap_regular_month_allotment`. Formula strings may still

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -1,5 +1,7 @@
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
+#[cfg(feature = "fs")]
 use std::fs;
+#[cfg(feature = "fs")]
 use std::path::Path;
 
 use serde::{Deserialize, Serialize};
@@ -13,6 +15,7 @@ use crate::spec::{
 pub enum CompileError {
     #[error(transparent)]
     Spec(#[from] crate::spec::SpecError),
+    #[cfg(feature = "fs")]
     #[error("failed to read compiled artefact `{path}`: {error}")]
     ReadArtifactFile { path: String, error: std::io::Error },
     #[error("unknown derived dependency `{dependency}` referenced from `{derived}`")]
@@ -28,8 +31,10 @@ pub enum CompileError {
     },
     #[error("cyclic relation dependency detected involving: {cycle}")]
     CyclicRelationDependency { cycle: String },
+    #[cfg(feature = "fs")]
     #[error("failed to read program file `{path}`: {error}")]
     ReadProgramFile { path: String, error: std::io::Error },
+    #[cfg(feature = "fs")]
     #[error("failed to write compiled artefact `{path}`: {error}")]
     WriteArtifactFile { path: String, error: std::io::Error },
     #[error("failed to serialise compiled artefact: {0}")]
@@ -133,6 +138,24 @@ impl CompiledProgramArtifact {
         })
     }
 
+    /// Compile the module at `root_target` (canonical form, for example
+    /// `us:statutes/7/2015/e`), resolving every module through a
+    /// host-supplied [`crate::source::ModuleSource`]. The pure counterpart of
+    /// [`Self::from_rulespec_file`]: no filesystem or environment access.
+    pub fn from_rulespec_with_source(
+        root_target: &str,
+        source: &dyn crate::source::ModuleSource,
+    ) -> Result<Self, CompileError> {
+        let program = crate::rulespec::load_rulespec_with_source(root_target, source).map_err(
+            |error| CompileError::RuleSpec {
+                path: root_target.to_string(),
+                error,
+            },
+        )?;
+        Self::compile(program)
+    }
+
+    #[cfg(feature = "fs")]
     pub fn from_rulespec_file(path: impl AsRef<Path>) -> Result<Self, CompileError> {
         let p = path.as_ref();
         let source = fs::read_to_string(p).map_err(|error| CompileError::ReadProgramFile {
@@ -167,6 +190,7 @@ impl CompiledProgramArtifact {
         artifact.check_format_version("<memory>")
     }
 
+    #[cfg(feature = "fs")]
     pub fn from_json_file(path: impl AsRef<Path>) -> Result<Self, CompileError> {
         let path = path.as_ref();
         let source = fs::read_to_string(path).map_err(|error| CompileError::ReadArtifactFile {
@@ -181,6 +205,7 @@ impl CompiledProgramArtifact {
         artifact.check_format_version(&path.display().to_string())
     }
 
+    #[cfg(feature = "fs")]
     pub fn write_json_file(&self, path: impl AsRef<Path>) -> Result<(), CompileError> {
         let path = path.as_ref();
         let json = serde_json::to_string_pretty(self).map_err(CompileError::SerializeArtifact)?;
@@ -676,6 +701,7 @@ fn collect_relation_members_from_judgment(
     }
 }
 
+#[cfg(feature = "fs")]
 pub fn compile_program_file_to_json(
     program_path: impl AsRef<Path>,
     output_path: impl AsRef<Path>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,4 +6,5 @@ pub mod engine;
 mod formula;
 pub mod model;
 pub mod rulespec;
+pub mod source;
 pub mod spec;

--- a/src/rulespec.rs
+++ b/src/rulespec.rs
@@ -1,11 +1,16 @@
 use std::collections::{BTreeMap, HashMap, HashSet};
+#[cfg(feature = "fs")]
 use std::env;
+#[cfg(feature = "fs")]
 use std::fs;
+#[cfg(feature = "fs")]
 use std::path::{Path, PathBuf};
 
 use chrono::NaiveDate;
 use serde::Deserialize;
 use thiserror::Error;
+
+use crate::source::ModuleSource;
 
 use crate::spec::{
     DerivedSemanticsSpec, IndexedParameterSpec, JudgmentExprSpec, ParameterVersionSpec,
@@ -19,12 +24,21 @@ pub enum RuleSpecError {
     Yaml(#[from] serde_yaml::Error),
     #[error("RuleSpec requires `format: rulespec/v1` or `schema: axiom.rules.*`")]
     MissingDiscriminator,
+    #[cfg(feature = "fs")]
     #[error("failed to read RuleSpec file `{path}`: {error}")]
     ReadFile { path: String, error: std::io::Error },
     #[error("RuleSpec import `{target}` in `{path}` could not be resolved")]
     UnresolvedImport { path: String, target: String },
     #[error("RuleSpec import cycle detected at `{path}`")]
     ImportCycle { path: String },
+    #[error(
+        "`{target}` is not a canonical RuleSpec module target of the form `<jurisdiction>:<relative path without extension>`"
+    )]
+    InvalidModuleTarget { target: String },
+    #[error("module source has no module for `{target}`")]
+    ModuleNotFound { target: String },
+    #[error(transparent)]
+    Source(#[from] crate::source::SourceError),
     #[error("failed to parse RuleSpec formula: {0}")]
     Formula(#[from] crate::formula::FormulaError),
     #[error("RuleSpec rule `{name}` uses unsupported kind `{kind}`")]
@@ -360,6 +374,7 @@ pub fn lower_rulespec_str(source: &str) -> Result<ProgramSpec, RuleSpecError> {
     document.to_program_spec()
 }
 
+#[cfg(feature = "fs")]
 pub fn load_rulespec_file(path: impl AsRef<Path>) -> Result<ProgramSpec, RuleSpecError> {
     let path = path.as_ref();
     let mut context = RuleSpecLoadContext::default();
@@ -367,12 +382,190 @@ pub fn load_rulespec_file(path: impl AsRef<Path>) -> Result<ProgramSpec, RuleSpe
     document.to_program_spec()
 }
 
+/// Load and lower the module at `root_target` (canonical form, for example
+/// `us:statutes/7/2015/e`), resolving every import through a host-supplied
+/// [`ModuleSource`]. No filesystem or environment access happens here: the
+/// core treats the program as a pure function over (modules, dataset), and
+/// where module text comes from is the host's concern.
+///
+/// Imports are resolved to canonical targets with [`resolve_import_target`]
+/// (relative imports resolve against the importing module's canonical
+/// target), then fetched from `source`. Module identity, deduplication,
+/// cycle detection, and durable rule ids all use the canonical target.
+pub fn load_rulespec_with_source(
+    root_target: &str,
+    source: &dyn ModuleSource,
+) -> Result<ProgramSpec, RuleSpecError> {
+    let root_target = normalize_module_target(root_target)?;
+    let mut context = SourceLoadContext::default();
+    let document = load_rulespec_document_from_source(&root_target, source, &mut context)?;
+    document.to_program_spec()
+}
+
+#[derive(Default)]
+struct SourceLoadContext {
+    stack: Vec<String>,
+    loaded: HashSet<String>,
+}
+
+fn load_rulespec_document_from_source(
+    target: &str,
+    source: &dyn ModuleSource,
+    context: &mut SourceLoadContext,
+) -> Result<RulesDocument, RuleSpecError> {
+    if context.stack.iter().any(|loading| loading == target) {
+        return Err(RuleSpecError::ImportCycle {
+            path: target.to_string(),
+        });
+    }
+    if context.loaded.contains(target) {
+        return Ok(RulesDocument::default());
+    }
+    let text = source
+        .load(target)?
+        .ok_or_else(|| RuleSpecError::ModuleNotFound {
+            target: target.to_string(),
+        })?;
+    if !looks_like_rulespec_yaml(&text) {
+        return Err(RuleSpecError::MissingDiscriminator);
+    }
+    context.stack.push(target.to_string());
+    let mut document: RulesDocument = serde_yaml::from_str(&text)?;
+    document.assign_origin_target(Some(target.to_string()));
+    let mut combined = RulesDocument::default();
+
+    if let Some(extends) = document.extends.as_deref() {
+        let base_target = resolve_import_target(target, extends)?;
+        let base = load_rulespec_document_from_source(&base_target, source, context)?;
+        combined = merge_rules_documents(combined, base);
+    }
+
+    for import in &document.imports {
+        let import_target = resolve_import_target(target, import)?;
+        let imported = load_rulespec_document_from_source(&import_target, source, context)?;
+        combined = merge_rules_documents(combined, imported);
+    }
+
+    combined = merge_rules_documents(combined, document.without_dependency_directives());
+    context.loaded.insert(target.to_string());
+    context.stack.pop();
+    Ok(combined)
+}
+
+/// Normalize a canonical module target: strip surrounding quotes, a
+/// `#fragment`, and a `.yaml`/`.yml` extension, and validate the
+/// `<jurisdiction>:<relative path>` shape. Pure string logic.
+pub fn normalize_module_target(target: &str) -> Result<String, RuleSpecError> {
+    let trimmed = target.trim().trim_matches(['"', '\'']);
+    let without_fragment = trimmed
+        .split_once('#')
+        .map(|(base, _)| base)
+        .unwrap_or(trimmed)
+        .trim();
+    let Some((prefix, relative)) = without_fragment.split_once(':') else {
+        return Err(RuleSpecError::InvalidModuleTarget {
+            target: target.to_string(),
+        });
+    };
+    if !is_canonical_repo_prefix(prefix) {
+        return Err(RuleSpecError::InvalidModuleTarget {
+            target: target.to_string(),
+        });
+    }
+    let relative = strip_module_extension(relative.trim().trim_matches('/'));
+    let mut segments = Vec::new();
+    for segment in relative.split('/') {
+        match segment {
+            "" | "." => continue,
+            ".." => {
+                return Err(RuleSpecError::InvalidModuleTarget {
+                    target: target.to_string(),
+                });
+            }
+            segment => segments.push(segment),
+        }
+    }
+    if segments.is_empty() {
+        return Err(RuleSpecError::InvalidModuleTarget {
+            target: target.to_string(),
+        });
+    }
+    Ok(format!("{prefix}:{}", segments.join("/")))
+}
+
+/// Resolve an import string to a canonical module target, given the
+/// IMPORTING module's canonical target. Canonical imports
+/// (`us:statutes/7/2015/e`) pass through normalized; relative imports
+/// (`../d`, `e/6/A`, `./sibling.yaml`) resolve against the importer's
+/// directory within the same jurisdiction, mirroring how filesystem loading
+/// resolves relative imports from the importing file's directory. Pure
+/// string logic — no filesystem.
+pub fn resolve_import_target(
+    importer_target: &str,
+    import: &str,
+) -> Result<String, RuleSpecError> {
+    let unresolved = || RuleSpecError::UnresolvedImport {
+        path: importer_target.to_string(),
+        target: import.to_string(),
+    };
+    let trimmed = import.trim().trim_matches(['"', '\'']);
+    let without_fragment = trimmed
+        .split_once('#')
+        .map(|(base, _)| base)
+        .unwrap_or(trimmed)
+        .trim();
+    if without_fragment.is_empty() {
+        return Err(unresolved());
+    }
+    if let Some((prefix, _)) = without_fragment.split_once(':') {
+        if is_canonical_repo_prefix(prefix) {
+            return normalize_module_target(without_fragment).map_err(|_| unresolved());
+        }
+    }
+    // Relative import: resolve against the importer's directory. Absolute
+    // filesystem paths have no meaning without a filesystem.
+    if without_fragment.starts_with('/') {
+        return Err(unresolved());
+    }
+    let importer = normalize_module_target(importer_target)?;
+    let (prefix, importer_path) = importer
+        .split_once(':')
+        .expect("normalized targets contain a prefix");
+    let mut segments = importer_path.split('/').collect::<Vec<&str>>();
+    segments.pop(); // The importer module itself; imports resolve from its directory.
+    let relative = strip_module_extension(without_fragment);
+    for segment in relative.split('/') {
+        match segment {
+            "" | "." => continue,
+            ".." => {
+                if segments.pop().is_none() {
+                    return Err(unresolved());
+                }
+            }
+            segment => segments.push(segment),
+        }
+    }
+    if segments.is_empty() {
+        return Err(unresolved());
+    }
+    Ok(format!("{prefix}:{}", segments.join("/")))
+}
+
+fn strip_module_extension(target: &str) -> &str {
+    target
+        .strip_suffix(".yaml")
+        .or_else(|| target.strip_suffix(".yml"))
+        .unwrap_or(target)
+}
+
+#[cfg(feature = "fs")]
 #[derive(Default)]
 struct RuleSpecLoadContext {
     stack: Vec<PathBuf>,
     loaded: HashSet<PathBuf>,
 }
 
+#[cfg(feature = "fs")]
 fn load_rulespec_document_inner(
     path: &Path,
     context: &mut RuleSpecLoadContext,
@@ -417,6 +610,7 @@ fn load_rulespec_document_inner(
     Ok(combined)
 }
 
+#[cfg(feature = "fs")]
 fn load_extended_document(
     path: &Path,
     context: &mut RuleSpecLoadContext,
@@ -440,6 +634,7 @@ fn merge_rules_documents(mut base: RulesDocument, extension: RulesDocument) -> R
     base
 }
 
+#[cfg(feature = "fs")]
 fn resolve_rulespec_import(importer_path: &Path, import: &str) -> Result<PathBuf, RuleSpecError> {
     let target = import.trim().trim_matches(['"', '\'']);
     let target_without_fragment = target
@@ -471,6 +666,7 @@ fn resolve_rulespec_import(importer_path: &Path, import: &str) -> Result<PathBuf
     })
 }
 
+#[cfg(feature = "fs")]
 fn resolve_canonical_rulespec_import(
     importer_path: &Path,
     prefix: &str,
@@ -501,6 +697,7 @@ fn resolve_canonical_rulespec_import(
     })
 }
 
+#[cfg(feature = "fs")]
 fn canonical_rulespec_target(path: &Path) -> Option<String> {
     let resolved_path = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
     let components = resolved_path
@@ -547,6 +744,7 @@ fn canonical_rulespec_target(path: &Path) -> Option<String> {
     }
 }
 
+#[cfg(feature = "fs")]
 fn import_target_to_rulespec_path(target: &str) -> PathBuf {
     let normalized = target.trim().trim_matches(['"', '\'']);
     let path = PathBuf::from(normalized);
@@ -557,7 +755,7 @@ fn import_target_to_rulespec_path(target: &str) -> PathBuf {
     }
 }
 
-fn is_canonical_repo_prefix(prefix: &str) -> bool {
+pub(crate) fn is_canonical_repo_prefix(prefix: &str) -> bool {
     !prefix.is_empty()
         && prefix
             .chars()
@@ -574,7 +772,8 @@ fn is_absolute_rulespec_ref(value: &str) -> bool {
         && !value.chars().any(char::is_whitespace)
 }
 
-fn candidate_rule_repo_roots(importer_path: &Path, prefix: &str) -> Vec<PathBuf> {
+#[cfg(feature = "fs")]
+pub(crate) fn candidate_rule_repo_roots(importer_path: &Path, prefix: &str) -> Vec<PathBuf> {
     // A jurisdiction's content root is either a legacy standalone repo
     // named rulespec-<prefix> (content at its root), or the <prefix>/
     // directory inside a country monorepo named rulespec-<country>

--- a/src/source.rs
+++ b/src/source.rs
@@ -1,0 +1,106 @@
+//! Host-supplied module resolution.
+//!
+//! The core engine is a pure function over (modules, dataset): given RuleSpec
+//! module text for every canonical target a program needs, it can lower,
+//! compile, and execute without touching a filesystem. `ModuleSource` is the
+//! seam where a host supplies that text — from disk, from memory, from a
+//! registry, or from a browser bundle.
+//!
+//! Resolution of relative imports to canonical targets is pure string logic on
+//! the importer's canonical target and stays in `crate::rulespec`
+//! (`resolve_import_target`). Only "find and read the module text" lives
+//! behind this trait.
+
+use thiserror::Error;
+
+/// A host failure while loading module text (I/O error, network error, …).
+///
+/// "Module not found" is not an error: `ModuleSource::load` returns
+/// `Ok(None)` for unknown targets so the loader can report an unresolved
+/// import with importer context.
+#[derive(Debug, Error)]
+#[error("module source failed to load `{target}`: {message}")]
+pub struct SourceError {
+    /// The canonical target whose load failed.
+    pub target: String,
+    /// Host-specific failure description.
+    pub message: String,
+}
+
+impl SourceError {
+    pub fn new(target: impl Into<String>, message: impl Into<String>) -> Self {
+        Self {
+            target: target.into(),
+            message: message.into(),
+        }
+    }
+}
+
+/// Supplies RuleSpec module YAML text for canonical targets.
+///
+/// `target` is always the canonical form `<jurisdiction>:<relative path
+/// without extension>`, for example `us:statutes/7/2015/e`. The loader
+/// normalizes targets (quotes, fragments, `.yaml`/`.yml` extensions, relative
+/// imports) before calling `load`, so implementations only translate a
+/// canonical target into module text.
+pub trait ModuleSource {
+    /// Return the module YAML text for `target`, `Ok(None)` if this source
+    /// has no module for it, or `Err` for a host-level failure.
+    fn load(&self, target: &str) -> Result<Option<String>, SourceError>;
+}
+
+/// Filesystem-backed `ModuleSource`: the jurisdiction-repo resolution the
+/// engine has always used (legacy sibling checkouts, country monorepos,
+/// `AXIOM_RULESPEC_REPO_ROOTS`), anchored at a path.
+///
+/// Candidate repo roots are discovered from the anchor's ancestors plus the
+/// environment, exactly like `load_rulespec_file` discovers them from an
+/// importing file's path.
+#[cfg(feature = "fs")]
+pub struct FsModuleSource {
+    anchor: std::path::PathBuf,
+}
+
+#[cfg(feature = "fs")]
+impl FsModuleSource {
+    /// Create a source anchored at `anchor` — typically the root module file
+    /// or the directory the host is working in. Repo-root discovery walks the
+    /// anchor's ancestors.
+    pub fn new(anchor: impl Into<std::path::PathBuf>) -> Self {
+        Self {
+            anchor: anchor.into(),
+        }
+    }
+}
+
+#[cfg(feature = "fs")]
+impl ModuleSource for FsModuleSource {
+    fn load(&self, target: &str) -> Result<Option<String>, SourceError> {
+        let Some((prefix, relative)) = target.split_once(':') else {
+            return Ok(None);
+        };
+        if !crate::rulespec::is_canonical_repo_prefix(prefix) {
+            return Ok(None);
+        }
+        let relative_path = std::path::PathBuf::from(format!(
+            "{}.yaml",
+            relative.trim().trim_matches('/')
+        ));
+        if relative_path.is_absolute()
+            || relative_path
+                .components()
+                .any(|component| matches!(component, std::path::Component::ParentDir))
+        {
+            return Ok(None);
+        }
+        for root in crate::rulespec::candidate_rule_repo_roots(&self.anchor, prefix) {
+            let candidate = root.join(&relative_path);
+            if candidate.exists() {
+                return std::fs::read_to_string(&candidate)
+                    .map(Some)
+                    .map_err(|error| SourceError::new(target, error.to_string()));
+            }
+        }
+        Ok(None)
+    }
+}

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -19,6 +19,7 @@ pub enum SpecError {
     InvalidDecimal { literal: String },
     #[error("yaml parse error: {0}")]
     Yaml(#[from] serde_yaml::Error),
+    #[cfg(feature = "fs")]
     #[error("failed to read program file `{path}`: {error}")]
     ReadFile { path: String, error: std::io::Error },
     #[error("duplicate {kind} `{name}` when merging extended program")]
@@ -57,6 +58,7 @@ impl ProgramSpec {
     /// have their versions concatenated, preserving effective_from order; the
     /// engine picks whichever version is live for the query period. Units,
     /// relations, and derived outputs are additive with duplicate-name errors.
+    #[cfg(feature = "fs")]
     pub fn from_yaml_file(path: impl AsRef<std::path::Path>) -> Result<Self, SpecError> {
         let path = path.as_ref();
         let source = std::fs::read_to_string(path).map_err(|error| SpecError::ReadFile {

--- a/tests/module_source.rs
+++ b/tests/module_source.rs
@@ -1,0 +1,465 @@
+//! Host-supplied module resolution: full compile + execute over modules held
+//! in an in-memory map, with zero filesystem access. Durable ids must be
+//! identical to the filesystem jurisdiction-repo layouts.
+
+use std::collections::HashMap;
+
+use axiom_rules_engine::api::{
+    ExecutionMode, ExecutionQuery, ExecutionRequest, OutputValue, execute_request,
+};
+use axiom_rules_engine::compile::CompiledProgramArtifact;
+use axiom_rules_engine::rulespec::{
+    RuleSpecError, load_rulespec_with_source, resolve_import_target,
+};
+use axiom_rules_engine::source::{ModuleSource, SourceError};
+use axiom_rules_engine::spec::{
+    DatasetSpec, InputRecordSpec, IntervalSpec, PeriodKindSpec, PeriodSpec, ScalarValueSpec,
+};
+
+/// A `ModuleSource` over an in-memory map: the shape a wasm host, a server
+/// holding modules in memory, or a registry client would implement.
+struct InMemoryModuleSource {
+    modules: HashMap<String, String>,
+}
+
+impl InMemoryModuleSource {
+    fn new(modules: &[(&str, &str)]) -> Self {
+        Self {
+            modules: modules
+                .iter()
+                .map(|(target, text)| (target.to_string(), text.to_string()))
+                .collect(),
+        }
+    }
+}
+
+impl ModuleSource for InMemoryModuleSource {
+    fn load(&self, target: &str) -> Result<Option<String>, SourceError> {
+        Ok(self.modules.get(target).cloned())
+    }
+}
+
+const FEDERAL_MODULE: &str = r#"
+format: rulespec/v1
+rules:
+  - name: snap_maximum_allotment_table
+    kind: parameter
+    dtype: Money
+    unit: USD
+    indexed_by: household_size
+    versions:
+      - effective_from: 2025-10-01
+        values:
+          1: 298
+          2: 546
+  - name: snap_maximum_allotment
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    versions:
+      - effective_from: 2025-10-01
+        formula: snap_maximum_allotment_table[household_size]
+"#;
+
+const STATE_MODULE: &str = r#"
+format: rulespec/v1
+imports:
+  - us:policies/usda/snap/fy-2026-cola/maximum-allotments
+rules:
+  - name: snap_household_food_contribution_rate
+    kind: parameter
+    dtype: Rate
+    versions:
+      - effective_from: 2025-10-01
+        formula: "0.30"
+  - name: snap_regular_month_allotment
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    versions:
+      - effective_from: 2025-10-01
+        formula: floor(snap_maximum_allotment - (net_income * snap_household_food_contribution_rate))
+"#;
+
+#[test]
+fn in_memory_module_source_compiles_and_executes_without_filesystem() {
+    let source = InMemoryModuleSource::new(&[
+        (
+            "us:policies/usda/snap/fy-2026-cola/maximum-allotments",
+            FEDERAL_MODULE,
+        ),
+        ("us-co:policies/cdhs/snap/fy-2026-benefit", STATE_MODULE),
+    ]);
+
+    let program = load_rulespec_with_source("us-co:policies/cdhs/snap/fy-2026-benefit", &source)
+        .expect("in-memory modules load and lower");
+    assert!(program.parameters.iter().any(|parameter| {
+        parameter.id.as_deref()
+            == Some(
+                "us:policies/usda/snap/fy-2026-cola/maximum-allotments#snap_maximum_allotment_table",
+            )
+    }));
+
+    let artifact =
+        CompiledProgramArtifact::from_rulespec_with_source(
+            "us-co:policies/cdhs/snap/fy-2026-benefit",
+            &source,
+        )
+        .expect("in-memory modules compile");
+    let output_id =
+        "us-co:policies/cdhs/snap/fy-2026-benefit#snap_regular_month_allotment".to_string();
+    assert!(
+        artifact
+            .program
+            .derived
+            .iter()
+            .any(|derived| derived.id.as_deref() == Some(output_id.as_str()))
+    );
+
+    let period = PeriodSpec {
+        kind: PeriodKindSpec::Month,
+        start: "2026-01-01".parse().expect("valid date"),
+        end: "2026-01-31".parse().expect("valid date"),
+    };
+    let response = execute_request(ExecutionRequest {
+        mode: ExecutionMode::Explain,
+        program: artifact.program,
+        dataset: DatasetSpec {
+            inputs: vec![
+                InputRecordSpec {
+                    name:
+                        "us:policies/usda/snap/fy-2026-cola/maximum-allotments#input.household_size"
+                            .to_string(),
+                    entity: "Household".to_string(),
+                    entity_id: "household-1".to_string(),
+                    interval: IntervalSpec {
+                        start: period.start,
+                        end: period.end,
+                    },
+                    value: ScalarValueSpec::Integer { value: 1 },
+                },
+                InputRecordSpec {
+                    name: "us-co:policies/cdhs/snap/fy-2026-benefit#input.net_income".to_string(),
+                    entity: "Household".to_string(),
+                    entity_id: "household-1".to_string(),
+                    interval: IntervalSpec {
+                        start: period.start,
+                        end: period.end,
+                    },
+                    value: ScalarValueSpec::Decimal {
+                        value: "100".to_string(),
+                    },
+                },
+            ],
+            relations: Vec::new(),
+        },
+        queries: vec![ExecutionQuery {
+            assessment_date: None,
+            entity_id: "household-1".to_string(),
+            period,
+            outputs: vec![output_id.clone()],
+        }],
+    })
+    .expect("in-memory program executes");
+
+    let OutputValue::Scalar { name, id, value, .. } = response.results[0]
+        .outputs
+        .get(&output_id)
+        .expect("snap_regular_month_allotment output")
+    else {
+        panic!("expected scalar output");
+    };
+    assert_eq!(name, "snap_regular_month_allotment");
+    assert_eq!(id.as_deref(), Some(output_id.as_str()));
+    let ScalarValueSpec::Decimal { value } = value else {
+        panic!("expected decimal scalar");
+    };
+    assert_eq!(value, "268");
+}
+
+#[test]
+fn relative_imports_resolve_against_the_importers_canonical_target() {
+    let source = InMemoryModuleSource::new(&[
+        (
+            "us:statutes/7/2015/e",
+            r#"
+format: rulespec/v1
+imports:
+  - ../2014/base
+  - ./peer.yaml
+rules:
+  - name: total_amount
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    versions:
+      - effective_from: 2026-01-01
+        formula: base_amount * peer_rate
+"#,
+        ),
+        (
+            "us:statutes/7/2014/base",
+            r#"
+format: rulespec/v1
+rules:
+  - name: base_amount
+    kind: parameter
+    dtype: Money
+    unit: USD
+    versions:
+      - effective_from: 2026-01-01
+        formula: "10"
+"#,
+        ),
+        (
+            "us:statutes/7/2015/peer",
+            r#"
+format: rulespec/v1
+rules:
+  - name: peer_rate
+    kind: parameter
+    dtype: Rate
+    versions:
+      - effective_from: 2026-01-01
+        formula: "2"
+"#,
+        ),
+    ]);
+
+    let program = load_rulespec_with_source("us:statutes/7/2015/e", &source)
+        .expect("relative imports resolve through the importer's canonical target");
+    assert!(program.parameters.iter().any(|parameter| {
+        parameter.id.as_deref() == Some("us:statutes/7/2014/base#base_amount")
+    }));
+    assert!(program.parameters.iter().any(|parameter| {
+        parameter.id.as_deref() == Some("us:statutes/7/2015/peer#peer_rate")
+    }));
+    assert!(program.derived.iter().any(|derived| {
+        derived.id.as_deref() == Some("us:statutes/7/2015/e#total_amount")
+    }));
+}
+
+#[test]
+fn diamond_imports_load_each_module_once() {
+    let shared = r#"
+format: rulespec/v1
+rules:
+  - name: shared_amount
+    kind: parameter
+    dtype: Money
+    unit: USD
+    versions:
+      - effective_from: 2026-01-01
+        formula: "5"
+"#;
+    let source = InMemoryModuleSource::new(&[
+        (
+            "us:policies/root",
+            r#"
+format: rulespec/v1
+imports:
+  - us:policies/left
+  - us:policies/right
+rules:
+  - name: combined
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    versions:
+      - effective_from: 2026-01-01
+        formula: left_amount + right_amount
+"#,
+        ),
+        (
+            "us:policies/left",
+            r#"
+format: rulespec/v1
+imports:
+  - us:policies/shared
+rules:
+  - name: left_amount
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    versions:
+      - effective_from: 2026-01-01
+        formula: shared_amount + 1
+"#,
+        ),
+        (
+            "us:policies/right",
+            r#"
+format: rulespec/v1
+imports:
+  - us:policies/shared
+rules:
+  - name: right_amount
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    versions:
+      - effective_from: 2026-01-01
+        formula: shared_amount + 2
+"#,
+        ),
+        ("us:policies/shared", shared),
+    ]);
+
+    // A duplicated `shared` module would produce duplicate parameter
+    // definitions; compilation succeeding proves the diamond deduplicated.
+    let artifact = CompiledProgramArtifact::from_rulespec_with_source("us:policies/root", &source)
+        .expect("diamond imports compile once each");
+    assert_eq!(
+        artifact
+            .program
+            .parameters
+            .iter()
+            .filter(|parameter| parameter.name == "shared_amount")
+            .count(),
+        1
+    );
+}
+
+#[test]
+fn import_cycles_are_detected_without_filesystem() {
+    let source = InMemoryModuleSource::new(&[
+        (
+            "us:policies/a",
+            r#"
+format: rulespec/v1
+imports:
+  - us:policies/b
+rules:
+  - name: a_amount
+    kind: parameter
+    dtype: Money
+    versions:
+      - effective_from: 2026-01-01
+        formula: "1"
+"#,
+        ),
+        (
+            "us:policies/b",
+            r#"
+format: rulespec/v1
+imports:
+  - us:policies/a
+rules:
+  - name: b_amount
+    kind: parameter
+    dtype: Money
+    versions:
+      - effective_from: 2026-01-01
+        formula: "2"
+"#,
+        ),
+    ]);
+
+    let error = load_rulespec_with_source("us:policies/a", &source)
+        .expect_err("cyclic imports are rejected");
+    assert!(matches!(error, RuleSpecError::ImportCycle { .. }), "{error}");
+}
+
+#[test]
+fn missing_modules_are_reported_with_importer_context() {
+    let source = InMemoryModuleSource::new(&[(
+        "us:policies/root",
+        r#"
+format: rulespec/v1
+imports:
+  - us:policies/absent
+rules:
+  - name: amount
+    kind: parameter
+    dtype: Money
+    versions:
+      - effective_from: 2026-01-01
+        formula: "1"
+"#,
+    )]);
+
+    let error = load_rulespec_with_source("us:policies/root", &source)
+        .expect_err("missing imported module errors");
+    let RuleSpecError::ModuleNotFound { target } = &error else {
+        panic!("expected ModuleNotFound, got {error}");
+    };
+    assert_eq!(target, "us:policies/absent");
+
+    let error = load_rulespec_with_source("us:policies/never-written", &source)
+        .expect_err("missing root module errors");
+    assert!(matches!(error, RuleSpecError::ModuleNotFound { .. }), "{error}");
+}
+
+/// `FsModuleSource` + the pure loader must agree with the path-based loader
+/// on the same country-monorepo checkout.
+#[cfg(feature = "fs")]
+#[test]
+fn fs_module_source_matches_file_loading_on_a_monorepo_checkout() {
+    use axiom_rules_engine::source::FsModuleSource;
+
+    let temp_root = std::env::temp_dir().join(format!(
+        "axiom-rules-engine-fs-module-source-{}",
+        std::process::id()
+    ));
+    let us_path = temp_root
+        .join("rulespec-us")
+        .join("us/policies/usda/snap/fy-2026-cola/maximum-allotments.yaml");
+    let co_path = temp_root
+        .join("rulespec-us")
+        .join("us-co/policies/cdhs/snap/fy-2026-benefit.yaml");
+    std::fs::create_dir_all(us_path.parent().expect("us parent")).expect("us dir");
+    std::fs::create_dir_all(co_path.parent().expect("co parent")).expect("co dir");
+    std::fs::write(&us_path, FEDERAL_MODULE).expect("federal module is written");
+    std::fs::write(&co_path, STATE_MODULE).expect("state module is written");
+
+    let source = FsModuleSource::new(&co_path);
+    let from_source =
+        load_rulespec_with_source("us-co:policies/cdhs/snap/fy-2026-benefit", &source)
+            .expect("FsModuleSource resolves the monorepo checkout");
+    let from_file = axiom_rules_engine::rulespec::load_rulespec_file(&co_path)
+        .expect("path-based loading resolves the monorepo checkout");
+
+    assert_eq!(
+        serde_json::to_value(&from_source).expect("source program serialises"),
+        serde_json::to_value(&from_file).expect("file program serialises"),
+    );
+
+    std::fs::remove_dir_all(&temp_root).ok();
+}
+
+#[test]
+fn import_targets_resolve_as_pure_string_logic() {
+    // Canonical imports pass through normalized: fragments and extensions drop.
+    assert_eq!(
+        resolve_import_target("us:statutes/7/2015/e", "us-co:policy/x.yaml#fragment")
+            .expect("canonical import resolves"),
+        "us-co:policy/x"
+    );
+    // Relative imports resolve against the importer's directory.
+    assert_eq!(
+        resolve_import_target("us:statutes/7/2015/e", "../2014/base")
+            .expect("parent-relative import resolves"),
+        "us:statutes/7/2014/base"
+    );
+    assert_eq!(
+        resolve_import_target("us:statutes/7/2015/e", "./6/A.yaml")
+            .expect("dot-relative import resolves"),
+        "us:statutes/7/2015/6/A"
+    );
+    // Escaping above the jurisdiction root is rejected.
+    assert!(resolve_import_target("us:statutes/e", "../../escape").is_err());
+    // Absolute filesystem paths have no meaning without a filesystem.
+    assert!(resolve_import_target("us:statutes/e", "/etc/passwd").is_err());
+}


### PR DESCRIPTION
## What

Makes the engine core embeddable: the core is a pure function over (modules, dataset), and "find and read module text" becomes a host concern behind a trait. The library now checks cleanly for `wasm32-unknown-unknown` — the strategic groundwork for running benefit calculations in the browser with zero PII round-trip.

## How

**`ModuleSource` trait (`src/source.rs`)**
- `fn load(&self, target: &str) -> Result<Option<String>, SourceError>` over canonical targets (`us:statutes/7/2015/e`), returning module YAML text. `Ok(None)` means "no such module" (reported with importer context); `Err` means the host failed.
- `FsModuleSource` packages the existing behavior — legacy sibling checkouts, country monorepos, `AXIOM_RULESPEC_REPO_ROOTS`, via the same `candidate_rule_repo_roots` walk — anchored at a path.

**Pure entry points**
- `rulespec::load_rulespec_with_source(root_target, &dyn ModuleSource) -> ProgramSpec`
- `CompiledProgramArtifact::from_rulespec_with_source(root_target, &dyn ModuleSource)`
- Resolution of relative imports to canonical targets stays in `rulespec.rs` as pure string logic on the importer's canonical target (`resolve_import_target`, `normalize_module_target`), so durable ids come out identical to the filesystem layouts (covered by a parity test).

**`fs` cargo feature (default ON)**
Gates everything that touches `std::fs` / `std::env`:
- `FsModuleSource`
- `rulespec::load_rulespec_file` + the path-based import resolution (`candidate_rule_repo_roots`, `AXIOM_RULESPEC_REPO_ROOTS`)
- `CompiledProgramArtifact::{from_rulespec_file, from_json_file, write_json_file}`, `compile_program_file_to_json`
- `ProgramSpec::from_yaml_file`
- the file-I/O error variants carrying `std::io::Error`
- the CLI binary (`required-features = ["fs"]`)

Default builds are byte-for-byte the same behavior; all existing tests pass untouched.

**wasm32 / dependency audit**
- chrono drops default features (`serde` + `std` only): the `clock` feature is off, so no wall-clock reads can creep into core paths, and the lockfile loses `iana-time-zone` / `windows-*` / clock transitive deps (Cargo.lock diff is 130 pure deletions).
- serde_yaml / serde_json / rust_decimal / thiserror are wasm-fine as-is.
- `cargo check --target wasm32-unknown-unknown --no-default-features` passes with zero warnings and runs in CI as a new `wasm` job.

**Tests (`tests/module_source.rs`)**
- `in_memory_module_source_compiles_and_executes_without_filesystem` — a HashMap-backed `ModuleSource` with two modules (state module importing the federal allotment table by canonical target), full compile + execute with ZERO filesystem, asserting durable ids and the 268 allotment result that the fs-based tests assert.
- Relative-import resolution against the importer's canonical target, diamond-import dedup, cycle detection, missing-module errors (root and import), pure `resolve_import_target` edge cases, and `FsModuleSource` ≡ `load_rulespec_file` parity on a monorepo checkout.

**Docs**
- DECISIONS.md entry (2026-06-10): core is a pure function over (modules, dataset); resolution is a host concern; wasm32 is a supported check target.
- docs/rulespec.md import-resolution section: paragraph on host-supplied sources.

## Verification

- `cargo test` — 84 tests green (77 pre-existing untouched + 7 new)
- `cargo check --target wasm32-unknown-unknown --no-default-features` — clean, no warnings
- `cargo check --no-default-features --lib` (host) — clean
- `cargo build` (default) — clean
- Python wrapper: 28 passed
- `cd python-ext && cargo check` — clean

## Notes

One intentional semantic difference in the source-driven loader: relative imports that escape above the jurisdiction root (`../../…` past the prefix) are rejected, where the filesystem loader would happily traverse the disk. Canonical targets have no meaning above their root, and a host has no disk to traverse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
