### PR TITLE
Schema: source_sha256 pinning + encoding provenance + validation status (optional, inert)

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -43,6 +43,49 @@ targets: `--target web` (browser ESM) into `wasm/pkg-web/` and
 - JS-side ergonomics (typed wrappers, Web Worker hosting, module fetching)
   live with consuming apps, not in this crate; the exported surface stays
   four functions.
+## 2026-06-10 — Source pinning, encoding provenance, and validation status are module content
+
+**Decision.** The RuleSpec `module:` block grows three optional, inert
+fields: `source_verification.source_sha256` (the SHA-256 hex digest of the
+exact corpus provision text the module was encoded from),
+`encoding_provenance` (optional `encoder`, `model`, `run_id`, `reviewed_by`
+strings; unknown subfields rejected), and `validation` (a list of
+`{oracle, status, last_run}` records with `status` one of
+`matches` / `mismatches` / `pending`). The engine validates shape at load —
+a malformed sha fails with an error naming the module file — carries the
+merged root module's metadata on `ProgramSpec.module`, and passes it
+through compiled-artifact JSON. Nothing in lowering, compilation, or
+execution reads any of it.
+
+**Why.**
+
+- Modules ground to legal text through
+  `module.source_verification.corpus_citation_path`, but not to a content
+  hash of the exact text version encoded. When eCFR republishes a section
+  there is no mechanical "this module is stale" signal; pinning
+  `source_sha256` makes staleness a hash comparison
+  (`axiom-encode check-source-staleness`).
+- Encoding provenance (tool, model, run id, reviewer) lives in a
+  side-channel telemetry DB today. Provenance should travel with the
+  content it describes so review and audit need only the module file.
+- Oracle-validation status lives nowhere in content; consumers cannot tell
+  a validated module from a pending one without external systems.
+
+**Consequences.**
+
+- Every field is optional; absent means exactly today's behavior. Existing
+  modules and fixtures are untouched, and artifacts without module
+  metadata serialize byte-identically to before.
+- Artifacts gain an optional `program.module` pass-through. No
+  `ARTIFACT_FORMAT_VERSION` bump: the field is additive, ignored by older
+  engines, and evaluation semantics are unchanged.
+- Malformed `source_sha256` values (not 64 hex characters), unknown
+  `encoding_provenance` subfields, and unknown `validation[].status`
+  values are rejected at load instead of passing silently.
+- Unmodeled `source_verification` subfields (for example
+  `corpus_citation_paths`) are preserved verbatim for tooling.
+- axiom-encode owns stamping the blocks at encode time and the staleness
+  checker that compares pinned hashes against the current corpus.
 
 ## 2026-06-10 — Module resolution is a host concern behind `ModuleSource`
 

--- a/docs/rulespec.md
+++ b/docs/rulespec.md
@@ -286,6 +286,49 @@ rules:
         delegation: us:regulations/7-cfr/273/9#state_utility_allowance_delegation
 ```
 
+## Source pinning and provenance
+
+The `module:` block can carry optional metadata that grounds the module in
+source text and records how the encoding was produced and checked. Every
+field is optional and inert: absent fields mean exactly today's behavior,
+and nothing in lowering, compilation, or execution reads them. The lowered
+`ProgramSpec` keeps the (merged) root module's metadata on `program.module`,
+and compiled artifacts pass it through their JSON, so tooling can read it
+from a loaded module or artifact without re-parsing the YAML.
+
+```yaml
+module:
+  id: us:statutes/7/2017/a
+  source_verification:
+    corpus_citation_path: us/statute/7/2017/a
+    source_sha256: 9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08
+  encoding_provenance:
+    encoder: axiom-encode/0.2.645
+    model: claude-fable-5
+    run_id: run-2026-06-10-001
+    reviewed_by: human-reviewer
+  validation:
+    - oracle: policyengine-us
+      status: matches
+      last_run: 2026-06-09
+```
+
+- `source_verification.source_sha256` pins the SHA-256 hex digest of the
+  exact corpus provision text the module was encoded from. When the source
+  republishes (for example an eCFR update), recomputing the hash gives a
+  mechanical "this module is stale" signal; `axiom-encode
+  check-source-staleness` does exactly that. The value must be 64
+  hexadecimal characters — anything else is rejected at load with an error
+  naming the module file. Other `source_verification` subfields (such as
+  `corpus_citation_path`) are preserved verbatim.
+- `encoding_provenance` records the encoding tool (`encoder`, for example
+  `axiom-encode/0.2.645`), `model`, `run_id`, and human `reviewed_by` — all
+  optional strings. Unknown subfields are rejected so typos cannot pass for
+  provenance.
+- `validation` lists oracle-validation results: `oracle` (string), `status`
+  (one of `matches`, `mismatches`, `pending`), and optional `last_run`
+  (ISO date). Unknown statuses are rejected.
+
 Known hard gaps:
 
 - Formula strings are parsed by the internal `crate::formula` parser and

--- a/src/rulespec.rs
+++ b/src/rulespec.rs
@@ -7,7 +7,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use chrono::NaiveDate;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use crate::source::ModuleSource;
@@ -105,6 +105,10 @@ pub enum RuleSpecError {
         existing: usize,
         new: usize,
     },
+    #[error(
+        "RuleSpec module `{path}` declares source_verification.source_sha256 `{value}`, which is not a 64-character hexadecimal SHA-256 digest"
+    )]
+    InvalidSourceSha256 { path: String, value: String },
     #[error("failed to load extended RuleSpec module: {0}")]
     Extended(#[from] crate::spec::SpecError),
 }
@@ -129,16 +133,102 @@ pub struct RulesDocument {
     pub rules: Vec<RuleDefinition>,
 }
 
-#[derive(Clone, Debug, Default, Deserialize)]
+/// Module-level metadata block of a RuleSpec document. Every field is
+/// optional; the whole block is descriptive and inert — it never affects
+/// lowering output names, compilation, or execution. The lowered
+/// [`ProgramSpec`] keeps the (merged) root module's metadata so tooling
+/// reading a loaded module or a compiled artifact can see it.
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct ModuleMetadata {
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub title: Option<String>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub summary: Option<String>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub status: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_verification: Option<SourceVerification>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub encoding_provenance: Option<EncodingProvenance>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub validation: Vec<ValidationRecord>,
+}
+
+impl ModuleMetadata {
+    /// Validate the shape of declared metadata. `path` names the module for
+    /// error reporting: the file path for filesystem loads, the canonical
+    /// target for source-backed loads, or the module id / `<memory>` for
+    /// in-memory strings.
+    fn validate(&self, path: &str) -> Result<(), RuleSpecError> {
+        if let Some(sha) = self
+            .source_verification
+            .as_ref()
+            .and_then(|verification| verification.source_sha256.as_deref())
+        {
+            if sha.len() != 64 || !sha.chars().all(|ch| ch.is_ascii_hexdigit()) {
+                return Err(RuleSpecError::InvalidSourceSha256 {
+                    path: path.to_string(),
+                    value: sha.to_string(),
+                });
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Grounding of a module in legal source text. `corpus_citation_path`
+/// addresses the provision in the Axiom corpus; `source_sha256` pins the
+/// SHA-256 hex digest of the exact provision text the module was encoded
+/// from, so tooling can detect mechanically when the published source has
+/// changed out from under the encoding. Additional subfields (for example
+/// `corpus_citation_paths`) are preserved verbatim.
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+pub struct SourceVerification {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub corpus_citation_path: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_sha256: Option<String>,
+    #[serde(flatten)]
+    pub extra: BTreeMap<String, serde_yaml::Value>,
+}
+
+/// Who and what produced the encoding: tool (`encoder`, for example
+/// `axiom-encode/0.2.645`), `model`, `run_id`, and human `reviewed_by`.
+/// All fields optional; unknown subfields are rejected so typos do not
+/// silently pass for provenance.
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct EncodingProvenance {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub encoder: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub run_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reviewed_by: Option<String>,
+}
+
+/// One oracle-validation result for the module: which oracle, whether the
+/// encoding currently matches it, and when it last ran.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct ValidationRecord {
+    pub oracle: String,
+    pub status: ValidationStatus,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_run: Option<NaiveDate>,
+}
+
+/// Outcome of an oracle validation run. Any other status string is
+/// rejected at parse time.
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ValidationStatus {
+    Matches,
+    Mismatches,
+    Pending,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -370,6 +460,7 @@ pub fn lower_rulespec_str(source: &str) -> Result<ProgramSpec, RuleSpecError> {
         .module
         .as_ref()
         .and_then(|module| module.id.clone());
+    document.validate_module_metadata(origin_target.as_deref().unwrap_or("<memory>"))?;
     document.assign_origin_target(origin_target);
     document.to_program_spec()
 }
@@ -431,6 +522,7 @@ fn load_rulespec_document_from_source(
     }
     context.stack.push(target.to_string());
     let mut document: RulesDocument = serde_yaml::from_str(&text)?;
+    document.validate_module_metadata(target)?;
     document.assign_origin_target(Some(target.to_string()));
     let mut combined = RulesDocument::default();
 
@@ -589,6 +681,7 @@ fn load_rulespec_document_inner(
     }
     context.stack.push(resolved_path.clone());
     let mut document: RulesDocument = serde_yaml::from_str(&source)?;
+    document.validate_module_metadata(&path.display().to_string())?;
     document.assign_origin_target(canonical_rulespec_target(path));
     let mut combined = RulesDocument::default();
 
@@ -837,6 +930,13 @@ pub(crate) fn candidate_rule_repo_roots(importer_path: &Path, prefix: &str) -> V
 }
 
 impl RulesDocument {
+    fn validate_module_metadata(&self, path: &str) -> Result<(), RuleSpecError> {
+        match &self.module {
+            Some(module) => module.validate(path),
+            None => Ok(()),
+        }
+    }
+
     fn assign_origin_target(&mut self, origin_target: Option<String>) {
         for rule in &mut self.rules {
             rule.origin_target = origin_target.clone();
@@ -953,6 +1053,9 @@ impl RulesDocument {
         append_missing_units(&mut program, &self.units);
         append_missing_relations(&mut program, &explicit_relations)?;
         rewrite_filtered_entity_member_aliases(&mut program);
+        // Carried for tooling and artifact pass-through only; nothing in
+        // compilation or execution reads it.
+        program.module = self.module.clone();
         Ok(program)
     }
 

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -38,6 +38,11 @@ pub enum SpecError {
 pub struct ProgramSpec {
     #[serde(default)]
     pub extends: Option<String>,
+    /// Module-level metadata (source pinning, encoding provenance,
+    /// validation status) carried through RuleSpec lowering for tooling and
+    /// artifact pass-through. Compilation and execution never read it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub module: Option<crate::rulespec::ModuleMetadata>,
     #[serde(default)]
     pub units: Vec<UnitSpec>,
     #[serde(default)]
@@ -873,6 +878,9 @@ pub fn merge_programs(
     mut base: ProgramSpec,
     extension: ProgramSpec,
 ) -> Result<ProgramSpec, SpecError> {
+    if extension.module.is_some() {
+        base.module = extension.module;
+    }
     for unit in extension.units {
         if base.units.iter().any(|u| u.name == unit.name) {
             continue;

--- a/tests/rulespec.rs
+++ b/tests/rulespec.rs
@@ -4,7 +4,7 @@ use axiom_rules_engine::api::{
 use axiom_rules_engine::compile::{
     CompileError, CompiledProgramArtifact, compile_program_file_to_json,
 };
-use axiom_rules_engine::rulespec::{RuleSpecError, lower_rulespec_str};
+use axiom_rules_engine::rulespec::{RuleSpecError, ValidationStatus, lower_rulespec_str};
 use axiom_rules_engine::spec::{
     DatasetSpec, DerivedSemanticsSpec, InputRecordSpec, IntervalSpec, PeriodKindSpec, PeriodSpec,
     ScalarExprSpec, ScalarValueSpec,
@@ -2210,4 +2210,248 @@ rules:
     assert_eq!(value, "268");
 
     std::fs::remove_dir_all(temp_root).expect("temp dir is removed");
+}
+
+#[test]
+fn rulespec_module_provenance_round_trips_into_artifact() {
+    let rulespec = r#"
+format: rulespec/v1
+module:
+  id: us:statutes/7/2017/a
+  title: SNAP allotment
+  source_verification:
+    corpus_citation_path: us/statute/7/2017/a
+    corpus_citation_paths:
+      - us/statute/7/2017/a
+    source_sha256: 9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08
+  encoding_provenance:
+    encoder: axiom-encode/0.2.645
+    model: claude-fable-5
+    run_id: run-2026-06-10-001
+    reviewed_by: human-reviewer
+  validation:
+    - oracle: policyengine-us
+      status: matches
+      last_run: 2026-06-09
+    - oracle: snapscreener
+      status: pending
+rules:
+  - name: flat_amount
+    kind: parameter
+    dtype: Money
+    unit: USD
+    versions:
+      - effective_from: 2025-01-01
+        formula: "10"
+"#;
+
+    let artifact = CompiledProgramArtifact::from_rulespec_str(rulespec)
+        .expect("RuleSpec with provenance metadata compiles");
+    assert_eq!(artifact.program.parameters.len(), 1);
+
+    let json = serde_json::to_string(&artifact).expect("artifact serializes");
+    let artifact = CompiledProgramArtifact::from_json_str(&json).expect("artifact round-trips");
+
+    let module = artifact
+        .program
+        .module
+        .as_ref()
+        .expect("module metadata survives lowering and the artifact round trip");
+    assert_eq!(module.id.as_deref(), Some("us:statutes/7/2017/a"));
+
+    let verification = module
+        .source_verification
+        .as_ref()
+        .expect("source verification block survives");
+    assert_eq!(
+        verification.corpus_citation_path.as_deref(),
+        Some("us/statute/7/2017/a")
+    );
+    assert_eq!(
+        verification.source_sha256.as_deref(),
+        Some("9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08")
+    );
+    assert!(
+        verification.extra.contains_key("corpus_citation_paths"),
+        "unmodeled source_verification subfields are preserved verbatim"
+    );
+
+    let provenance = module
+        .encoding_provenance
+        .as_ref()
+        .expect("encoding provenance survives");
+    assert_eq!(provenance.encoder.as_deref(), Some("axiom-encode/0.2.645"));
+    assert_eq!(provenance.model.as_deref(), Some("claude-fable-5"));
+    assert_eq!(provenance.run_id.as_deref(), Some("run-2026-06-10-001"));
+    assert_eq!(provenance.reviewed_by.as_deref(), Some("human-reviewer"));
+
+    assert_eq!(module.validation.len(), 2);
+    assert_eq!(module.validation[0].oracle, "policyengine-us");
+    assert_eq!(module.validation[0].status, ValidationStatus::Matches);
+    assert_eq!(
+        module.validation[0]
+            .last_run
+            .expect("last_run parses as a date")
+            .to_string(),
+        "2026-06-09"
+    );
+    assert_eq!(module.validation[1].oracle, "snapscreener");
+    assert_eq!(module.validation[1].status, ValidationStatus::Pending);
+    assert_eq!(module.validation[1].last_run, None);
+}
+
+#[test]
+fn rulespec_artifact_omits_module_key_when_metadata_absent() {
+    let rulespec = r#"
+format: rulespec/v1
+rules:
+  - name: flat_amount
+    kind: parameter
+    dtype: Money
+    unit: USD
+    versions:
+      - effective_from: 2025-01-01
+        formula: "10"
+"#;
+
+    let artifact = CompiledProgramArtifact::from_rulespec_str(rulespec).expect("compiles");
+    let json = serde_json::to_string(&artifact).expect("artifact serializes");
+    assert!(
+        !json.contains("\"module\""),
+        "artifacts without module metadata stay byte-identical to today's shape"
+    );
+}
+
+#[test]
+fn rulespec_rejects_malformed_source_sha256() {
+    for bad_sha in [
+        "abc123",
+        "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a0", // 63 chars
+        "9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a0g", // non-hex char
+    ] {
+        let rulespec = format!(
+            r#"
+format: rulespec/v1
+module:
+  id: us:statutes/7/2017/a
+  source_verification:
+    corpus_citation_path: us/statute/7/2017/a
+    source_sha256: "{bad_sha}"
+rules:
+  - name: flat_amount
+    kind: parameter
+    dtype: Money
+    unit: USD
+    versions:
+      - effective_from: 2025-01-01
+        formula: "10"
+"#
+        );
+
+        let err = lower_rulespec_str(&rulespec).expect_err("malformed sha should fail");
+        assert!(matches!(
+            &err,
+            RuleSpecError::InvalidSourceSha256 { path, value }
+                if path == "us:statutes/7/2017/a" && value == bad_sha
+        ));
+    }
+}
+
+#[test]
+fn rulespec_malformed_source_sha256_error_names_the_file() {
+    let temp_root = std::env::temp_dir().join(format!(
+        "axiom-rules-engine-source-sha-test-{}",
+        std::process::id()
+    ));
+    let program_path = temp_root.join("rules.yaml");
+    std::fs::create_dir_all(&temp_root).expect("temp dir is created");
+    std::fs::write(
+        &program_path,
+        r#"
+format: rulespec/v1
+module:
+  source_verification:
+    source_sha256: not-a-digest
+rules:
+  - name: flat_amount
+    kind: parameter
+    dtype: Money
+    unit: USD
+    versions:
+      - effective_from: 2025-01-01
+        formula: "10"
+"#,
+    )
+    .expect("RuleSpec fixture is written");
+
+    let err = CompiledProgramArtifact::from_rulespec_file(&program_path)
+        .expect_err("malformed sha should fail");
+    let message = err.to_string();
+    assert!(
+        message.contains("rules.yaml"),
+        "error should name the file, got: {message}"
+    );
+    assert!(
+        message.contains("not-a-digest"),
+        "error should echo the malformed value, got: {message}"
+    );
+    std::fs::remove_dir_all(temp_root).expect("temp dir is removed");
+}
+
+#[test]
+fn rulespec_rejects_unknown_validation_status() {
+    let rulespec = r#"
+format: rulespec/v1
+module:
+  validation:
+    - oracle: policyengine-us
+      status: disputed
+rules:
+  - name: flat_amount
+    kind: parameter
+    dtype: Money
+    unit: USD
+    versions:
+      - effective_from: 2025-01-01
+        formula: "10"
+"#;
+
+    let err = lower_rulespec_str(rulespec).expect_err("unknown validation status should fail");
+    assert!(matches!(err, RuleSpecError::Yaml(_)));
+    let message = err.to_string();
+    assert!(
+        message.contains("disputed"),
+        "error should name the rejected status, got: {message}"
+    );
+    assert!(
+        message.contains("pending"),
+        "error should list the accepted statuses, got: {message}"
+    );
+}
+
+#[test]
+fn rulespec_rejects_unknown_encoding_provenance_field() {
+    let rulespec = r#"
+format: rulespec/v1
+module:
+  encoding_provenance:
+    encoder: axiom-encode/0.2.645
+    vibes: high
+rules:
+  - name: flat_amount
+    kind: parameter
+    dtype: Money
+    unit: USD
+    versions:
+      - effective_from: 2025-01-01
+        formula: "10"
+"#;
+
+    let err = lower_rulespec_str(rulespec).expect_err("unknown provenance field should fail");
+    assert!(matches!(err, RuleSpecError::Yaml(_)));
+    let message = err.to_string();
+    assert!(
+        message.contains("vibes"),
+        "error should name the rejected field, got: {message}"
+    );
 }


### PR DESCRIPTION
## What

Adds three optional, fully backward-compatible blocks to the RuleSpec `module:` schema, with shape validation, lowering pass-through, tests, and docs:

- `module.source_verification.source_sha256` — SHA-256 hex digest (64 hex chars) of the exact corpus provision text the module was encoded from. Malformed digests are rejected at load with an error naming the module file.
- `module.encoding_provenance` — optional `encoder` (e.g. `axiom-encode/0.2.645`), `model`, `run_id`, `reviewed_by` strings. Unknown subfields are rejected.
- `module.validation` — list of `{oracle, status, last_run}` records; `status` is one of `matches` / `mismatches` / `pending` (unknown statuses rejected), `last_run` is an ISO date.

## Why

Modules ground to legal text via `module.source_verification.corpus_citation_path`, but not to a content hash of the exact text version encoded — when eCFR republishes a section there is no mechanical "this module is stale" signal. Encoding provenance lives in a side-channel telemetry DB and oracle-validation status lives nowhere in content. This puts all three in the module itself. The companion PR TheAxiomFoundation/axiom-encode#601 ships the stamping helpers and the `check-source-staleness` checker, and a module stamped by those helpers compiles under this schema with the block landing intact in the artifact's `program.module` JSON (verified end-to-end against a real corpus provision).

## Where the metadata lives

`RulesDocument.module` (`ModuleMetadata` in `src/rulespec.rs`) parses the new typed blocks. Lowering carries the merged root module's metadata on `ProgramSpec.module` (`src/spec.rs`), and compiled artifacts pass it through their JSON as `program.module`. Unmodeled `source_verification` subfields (e.g. `corpus_citation_paths`) are preserved verbatim via a flattened map.

## Inertness

- Nothing in lowering output names, compilation, or execution reads `ProgramSpec.module`.
- Absent fields mean exactly today's behavior; existing fixtures are untouched and pass unchanged.
- Artifacts without module metadata serialize byte-identically (`skip_serializing_if`), and the new field is additive + ignored by older engines, so no `ARTIFACT_FORMAT_VERSION` bump.

## Tests

- Full block round-trips through `from_rulespec_str` → artifact JSON → `from_json_str`, including the flattened extra subfield.
- Artifacts without module metadata contain no `module` key.
- Malformed sha (wrong length, non-hex) rejected with `InvalidSourceSha256` carrying the module id; file-based load error names the file path.
- Unknown `validation[].status` and unknown `encoding_provenance` subfields rejected.

## Verification

- `cargo test` — 11/11 targets green (47 rulespec tests incl. 6 new)
- `cargo check --target wasm32-unknown-unknown --no-default-features` — clean
- Python wrapper: `pytest python/tests` — 28 passed (the wrapper's `Program` pydantic model is `extra="allow"`, so the new `program.module` passes through)

Also adds a "Source pinning and provenance" section to `docs/rulespec.md` and a 2026-06-10 `DECISIONS.md` entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
