### PR TITLE
Support fractional dense inputs and scalar-parameter broadcast

### DIFF
--- a/python-ext/src/lib.rs
+++ b/python-ext/src/lib.rs
@@ -11,6 +11,7 @@ use numpy::{PyArray1, PyReadonlyArray1};
 use pyo3::exceptions::{PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
 use pyo3::types::{PyDict, PyList};
+use rust_decimal::Decimal;
 use rust_decimal::prelude::ToPrimitive;
 
 #[pyclass(module = "axiom_rules_engine_dense")]
@@ -260,18 +261,38 @@ fn dense_column_from_python(value: &Bound<'_, PyAny>) -> PyResult<DenseColumn> {
     if let Ok(array) = value.extract::<PyReadonlyArray1<'_, i64>>() {
         return Ok(DenseColumn::Integer(array.as_slice()?.to_vec()));
     }
+    if let Ok(array) = value.extract::<PyReadonlyArray1<'_, f64>>() {
+        return decimal_column_from_f64(array.as_slice()?);
+    }
     if let Ok(values) = value.extract::<Vec<bool>>() {
         return Ok(DenseColumn::Bool(values));
     }
     if let Ok(values) = value.extract::<Vec<i64>>() {
         return Ok(DenseColumn::Integer(values));
     }
+    if let Ok(values) = value.extract::<Vec<f64>>() {
+        return decimal_column_from_f64(&values);
+    }
     if let Ok(values) = value.extract::<Vec<String>>() {
         return Ok(DenseColumn::Text(values));
     }
     Err(PyValueError::new_err(
-        "dense columns must be bool/int64 numpy arrays or simple Python lists",
+        "dense columns must be bool/int64/float64 numpy arrays or simple Python lists",
     ))
+}
+
+fn decimal_column_from_f64(values: &[f64]) -> PyResult<DenseColumn> {
+    values
+        .iter()
+        .map(|value| {
+            Decimal::from_f64_retain(*value)
+                .map(|decimal| decimal.round_dp(9).normalize())
+                .ok_or_else(|| {
+                    PyValueError::new_err(format!("cannot represent {value} as a decimal"))
+                })
+        })
+        .collect::<PyResult<Vec<Decimal>>>()
+        .map(DenseColumn::Decimal)
 }
 
 fn extract_index_vec(value: &Bound<'_, PyAny>) -> PyResult<Vec<usize>> {

--- a/src/dense.rs
+++ b/src/dense.rs
@@ -7,6 +7,7 @@ use thiserror::Error;
 use crate::compile::CompiledProgramArtifact;
 use crate::engine::EvalError;
 use crate::model::{
+    SCALAR_ENTITY,
     ComparisonOp, DType, DerivedSemantics, IndexedParameter, JudgmentExpr, JudgmentOutcome, Period,
     Program, RelatedValueRef, ScalarExpr, ScalarValue,
 };
@@ -132,11 +133,6 @@ pub enum DenseOutputValue {
     Scalar(DenseColumn),
     Judgment(Vec<JudgmentOutcome>),
 }
-
-/// Pseudo-entity assigned to formula parameters with no declared entity.
-/// Rules at this entity are row-constant, so they may be compiled into any
-/// root entity as a broadcast.
-const SCALAR_ENTITY: &str = "Scalar";
 
 #[derive(Clone, Debug)]
 pub struct DenseExecutionResult {
@@ -305,10 +301,16 @@ impl DenseCompiledProgram {
                     .map(|derived| derived.entity.clone())
                     .filter(|entity| entity != SCALAR_ENTITY)
                     .collect::<HashSet<String>>();
-                if entities.len() != 1 {
+                if entities.len() > 1 {
                     return Err(DenseCompileError::AmbiguousRootEntity);
                 }
-                entities.into_iter().next().expect("one entity")
+                // A module whose derived rules are all scalar formula
+                // parameters compiles with the scalar pseudo-entity as its
+                // root and executes as a broadcast.
+                entities
+                    .into_iter()
+                    .next()
+                    .unwrap_or_else(|| SCALAR_ENTITY.to_string())
             }
         };
 

--- a/src/dense.rs
+++ b/src/dense.rs
@@ -133,6 +133,11 @@ pub enum DenseOutputValue {
     Judgment(Vec<JudgmentOutcome>),
 }
 
+/// Pseudo-entity assigned to formula parameters with no declared entity.
+/// Rules at this entity are row-constant, so they may be compiled into any
+/// root entity as a broadcast.
+const SCALAR_ENTITY: &str = "Scalar";
+
 #[derive(Clone, Debug)]
 pub struct DenseExecutionResult {
     pub row_count: usize,
@@ -298,6 +303,7 @@ impl DenseCompiledProgram {
                     .derived
                     .values()
                     .map(|derived| derived.entity.clone())
+                    .filter(|entity| entity != SCALAR_ENTITY)
                     .collect::<HashSet<String>>();
                 if entities.len() != 1 {
                     return Err(DenseCompileError::AmbiguousRootEntity);
@@ -555,7 +561,7 @@ impl<'a> DenseCompiler<'a> {
             self.program.derived.get(name).ok_or_else(|| {
                 DenseCompileError::Unsupported(format!("unknown derived `{name}`"))
             })?;
-        if derived.entity != self.root_entity {
+        if derived.entity != self.root_entity && derived.entity != SCALAR_ENTITY {
             return Err(DenseCompileError::CrossEntityDependency {
                 derived: name.to_string(),
                 dependency: name.to_string(),
@@ -601,7 +607,7 @@ impl<'a> DenseCompiler<'a> {
                         "unknown scalar dependency `{name}` referenced from `{derived_name}`"
                     ))
                 })?;
-                if dependency.entity != self.root_entity {
+                if dependency.entity != self.root_entity && dependency.entity != SCALAR_ENTITY {
                     return Err(DenseCompileError::CrossEntityDependency {
                         derived: derived_name.to_string(),
                         dependency: name.clone(),
@@ -731,7 +737,7 @@ impl<'a> DenseCompiler<'a> {
                         "unknown judgment dependency `{name}` referenced from `{derived_name}`"
                     ))
                 })?;
-                if dependency.entity != self.root_entity {
+                if dependency.entity != self.root_entity && dependency.entity != SCALAR_ENTITY {
                     return Err(DenseCompileError::CrossEntityDependency {
                         derived: derived_name.to_string(),
                         dependency: name.clone(),
@@ -918,7 +924,10 @@ impl<'a> DenseCompiler<'a> {
                         "unknown scalar dependency `{name}` referenced from `{derived_name}`"
                     ))
                 })?;
-                if dependency.entity != entity && dependency.entity != self.root_entity {
+                if dependency.entity != entity
+                    && dependency.entity != self.root_entity
+                    && dependency.entity != SCALAR_ENTITY
+                {
                     return Err(DenseCompileError::CrossEntityDependency {
                         derived: derived_name.to_string(),
                         dependency: name.clone(),
@@ -1034,7 +1043,10 @@ impl<'a> DenseCompiler<'a> {
                         "unknown judgment dependency `{name}` referenced from `{derived_name}`"
                     ))
                 })?;
-                if dependency.entity != entity && dependency.entity != self.root_entity {
+                if dependency.entity != entity
+                    && dependency.entity != self.root_entity
+                    && dependency.entity != SCALAR_ENTITY
+                {
                     return Err(DenseCompileError::CrossEntityDependency {
                         derived: derived_name.to_string(),
                         dependency: name.clone(),

--- a/src/formula.rs
+++ b/src/formula.rs
@@ -1177,7 +1177,10 @@ pub fn lower_module(module: &Module) -> Result<ProgramSpec, FormulaError> {
             )));
         }
         let dtype = parse_dtype(v.dtype.as_deref());
-        let entity = v.entity.clone().unwrap_or_else(|| "Scalar".to_string());
+        let entity = v
+            .entity
+            .clone()
+            .unwrap_or_else(|| crate::model::SCALAR_ENTITY.to_string());
         let last = v.values.last().ok_or_else(|| {
             FormulaError::lower(format!("variable `{}` has no temporal values", v.path))
         })?;

--- a/src/model.rs
+++ b/src/model.rs
@@ -4,6 +4,10 @@ use chrono::{Datelike, Duration, NaiveDate};
 use rust_decimal::Decimal;
 use rust_decimal::prelude::ToPrimitive;
 
+/// Pseudo-entity assigned to formula parameters with no declared entity.
+/// Rules at this entity are row-constant.
+pub const SCALAR_ENTITY: &str = "Scalar";
+
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub enum PeriodKind {
     Month,

--- a/tests/dense.rs
+++ b/tests/dense.rs
@@ -3027,3 +3027,62 @@ fn family_allowance_dataset(
 fn decimal(value: &str) -> Decimal {
     Decimal::from_str(value).expect("valid decimal")
 }
+
+const SCALAR_PARAMETER_RULESPEC: &str = r#"
+format: rulespec/v1
+rules:
+  - name: taper_fraction
+    kind: parameter
+    dtype: Rate
+    versions:
+      - effective_from: '2020-01-01'
+        formula: |-
+          1 / 2
+
+  - name: tapered_amount
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Month
+    unit: GBP
+    versions:
+      - effective_from: '2020-01-01'
+        formula: |-
+          income * taper_fraction
+"#;
+
+#[test]
+fn dense_broadcasts_scalar_entity_formula_parameters() {
+    // Formula parameters with no declared entity lower to the `Scalar`
+    // pseudo-entity. They are row-constant, so dense compilation broadcasts
+    // them into the root entity instead of rejecting the cross-entity
+    // dependency, and default root-entity detection ignores them.
+    let period = month_period();
+    let artifact = CompiledProgramArtifact::from_rulespec_str(SCALAR_PARAMETER_RULESPEC)
+        .expect("RuleSpec module compiles");
+    let dense = DenseCompiledProgram::from_artifact(&artifact, None)
+        .expect("dense compilation succeeds without an explicit entity");
+    assert_eq!(dense.root_entity(), "Person");
+
+    let result = dense
+        .execute(
+            &period.to_model().expect("period converts"),
+            DenseBatchSpec {
+                row_count: 2,
+                inputs: HashMap::from([(
+                    "income".to_string(),
+                    DenseColumn::Decimal(vec![decimal("100"), decimal("250")]),
+                )]),
+                relations: HashMap::new(),
+            },
+            &["tapered_amount".to_string()],
+        )
+        .expect("dense execution succeeds");
+
+    let DenseOutputValue::Scalar(DenseColumn::Decimal(values)) =
+        result.outputs.get("tapered_amount").expect("output present")
+    else {
+        panic!("expected decimal output");
+    };
+    assert_eq!(values, &vec![decimal("50"), decimal("125")]);
+}

--- a/tests/dense.rs
+++ b/tests/dense.rs
@@ -3086,3 +3086,45 @@ fn dense_broadcasts_scalar_entity_formula_parameters() {
     };
     assert_eq!(values, &vec![decimal("50"), decimal("125")]);
 }
+
+#[test]
+fn dense_compiles_scalar_only_module_with_scalar_root() {
+    // A module containing only scalar formula parameters falls back to the
+    // Scalar pseudo-entity as its root and executes as a broadcast.
+    let rulespec = r#"
+format: rulespec/v1
+rules:
+  - name: taper_fraction
+    kind: parameter
+    dtype: Rate
+    versions:
+      - effective_from: '2020-01-01'
+        formula: |-
+          1 / 2
+"#;
+    let period = month_period();
+    let artifact =
+        CompiledProgramArtifact::from_rulespec_str(rulespec).expect("RuleSpec module compiles");
+    let dense = DenseCompiledProgram::from_artifact(&artifact, None)
+        .expect("scalar-only dense compilation succeeds");
+    assert_eq!(dense.root_entity(), "Scalar");
+
+    let result = dense
+        .execute(
+            &period.to_model().expect("period converts"),
+            DenseBatchSpec {
+                row_count: 1,
+                inputs: HashMap::new(),
+                relations: HashMap::new(),
+            },
+            &["taper_fraction".to_string()],
+        )
+        .expect("dense execution succeeds");
+
+    let DenseOutputValue::Scalar(DenseColumn::Decimal(values)) =
+        result.outputs.get("taper_fraction").expect("output present")
+    else {
+        panic!("expected decimal output");
+    };
+    assert_eq!(values, &vec![decimal("0.5")]);
+}


### PR DESCRIPTION
The dense path had two gaps that blocked running real rulespec-uk modules over columnar data.

The python extension accepted only bool/int64 input columns, so fractional values — money with pence, or rate-typed free inputs like the ITA s.10 basic rate — couldn't be supplied at all, even though outputs already come back as float64. float64 columns now convert through `Decimal::from_f64_retain` rounded to 9dp, so float noise is quarantined at the binding and the engine core stays pure Decimal end to end. The exact JSON path is unchanged.

Separately, formula parameters with no declared entity lower to the `Scalar` pseudo-entity, and the dense compiler rejected any rule depending on one (ITA 2007 s.35's `excess_income_reduction_fraction` broke the whole s.23/s.35 income tax chain). Scalar rules are row-constant, so they now compile into the root entity as a broadcast, and default root-entity detection ignores them. New regression test covers this; full suite passes.

With these two changes the dense path runs composed statute chains (income tax, PIP, pension credit, the UC award with the reg 80A/81/82 benefit cap) over 100k synthetic households in ~0.75s. Follow-up worth doing: encode the Finance Act income tax rates and SPC prescribed percentages as cited parameters so rates stop being runtime inputs.
