### PR TITLE
Dense path: sum_related over related derived values

### DIFF
--- a/src/dense.rs
+++ b/src/dense.rs
@@ -199,9 +199,9 @@ enum CompiledScalarExpr {
         relation: usize,
         predicate: Option<CompiledRelatedJudgmentExpr>,
     },
-    SumRelatedInput {
+    SumRelated {
         relation: usize,
-        input: usize,
+        value: Box<CompiledRelatedScalarExpr>,
         predicate: Option<CompiledRelatedJudgmentExpr>,
     },
     If {
@@ -215,8 +215,47 @@ enum CompiledScalarExpr {
 enum CompiledRelatedScalarExpr {
     Literal(ScalarValue),
     Input(usize),
-    InputOrElse { input: usize, default: ScalarValue },
+    InputOrElse {
+        input: usize,
+        default: ScalarValue,
+    },
     RootScalar(Box<CompiledScalarExpr>),
+    ParameterLookup {
+        parameter: usize,
+        index: Box<CompiledRelatedScalarExpr>,
+    },
+    Add(Vec<CompiledRelatedScalarExpr>),
+    Sub(
+        Box<CompiledRelatedScalarExpr>,
+        Box<CompiledRelatedScalarExpr>,
+    ),
+    Mul(
+        Box<CompiledRelatedScalarExpr>,
+        Box<CompiledRelatedScalarExpr>,
+    ),
+    Div(
+        Box<CompiledRelatedScalarExpr>,
+        Box<CompiledRelatedScalarExpr>,
+    ),
+    Max(Vec<CompiledRelatedScalarExpr>),
+    Min(Vec<CompiledRelatedScalarExpr>),
+    Ceil(Box<CompiledRelatedScalarExpr>),
+    Floor(Box<CompiledRelatedScalarExpr>),
+    PeriodStart,
+    PeriodEnd,
+    DateAddDays {
+        date: Box<CompiledRelatedScalarExpr>,
+        days: Box<CompiledRelatedScalarExpr>,
+    },
+    DaysBetween {
+        from: Box<CompiledRelatedScalarExpr>,
+        to: Box<CompiledRelatedScalarExpr>,
+    },
+    If {
+        condition: Box<CompiledRelatedJudgmentExpr>,
+        then_expr: Box<CompiledRelatedScalarExpr>,
+        else_expr: Box<CompiledRelatedScalarExpr>,
+    },
 }
 
 #[derive(Clone, Debug)]
@@ -692,24 +731,26 @@ impl<'a> DenseCompiler<'a> {
                 related_slot,
                 value,
                 where_clause,
-            } => match value {
-                RelatedValueRef::Input(name) => {
-                    let relation_index = self.relation(relation, *current_slot, *related_slot)?;
-                    let input_index = self.related_input(relation_index, name, false);
-                    let predicate = where_clause
-                        .as_deref()
-                        .map(|inner| self.compile_related_predicate(relation_index, inner))
-                        .transpose()?;
-                    Ok(CompiledScalarExpr::SumRelatedInput {
-                        relation: relation_index,
-                        input: input_index,
-                        predicate,
-                    })
-                }
-                RelatedValueRef::Derived(name) => Err(DenseCompileError::Unsupported(format!(
-                    "sum_related over related derived values (`{name}`)"
-                ))),
-            },
+            } => {
+                let relation_index = self.relation(relation, *current_slot, *related_slot)?;
+                let value = match value {
+                    RelatedValueRef::Input(name) => {
+                        let input_index = self.related_input(relation_index, name, false);
+                        CompiledRelatedScalarExpr::Input(input_index)
+                    }
+                    RelatedValueRef::Derived(name) => self
+                        .compile_related_scalar(relation_index, &ScalarExpr::Derived(name.clone()))?,
+                };
+                let predicate = where_clause
+                    .as_deref()
+                    .map(|inner| self.compile_related_predicate(relation_index, inner))
+                    .transpose()?;
+                Ok(CompiledScalarExpr::SumRelated {
+                    relation: relation_index,
+                    value: Box::new(value),
+                    predicate,
+                })
+            }
             ScalarExpr::If {
                 condition,
                 then_expr,
@@ -870,6 +911,7 @@ impl<'a> DenseCompiler<'a> {
                 let relation = &self.relations[relation_index];
                 if relation.current_entity.as_deref() == Some(derived.entity.as_str())
                     || derived.entity == self.root_entity
+                    || derived.entity == SCALAR_ENTITY
                 {
                     return match &derived.semantics {
                         DerivedSemantics::Scalar(expr) => Ok(CompiledRelatedScalarExpr::RootScalar(
@@ -881,7 +923,7 @@ impl<'a> DenseCompiler<'a> {
                         )),
                         DerivedSemantics::Judgment(_) => Err(DenseCompileError::Unsupported(
                             format!(
-                                "where-clause scalar expressions cannot reference judgment derived values (`{name}`)"
+                                "related scalar expressions cannot reference judgment derived values (`{name}`)"
                             ),
                         )),
                     };
@@ -897,13 +939,76 @@ impl<'a> DenseCompiler<'a> {
                 match &derived.semantics {
                     DerivedSemantics::Scalar(expr) => self.compile_related_scalar(relation_index, expr),
                     DerivedSemantics::Judgment(_) => Err(DenseCompileError::Unsupported(format!(
-                        "where-clause scalar expressions cannot reference judgment derived values (`{name}`)"
+                        "related scalar expressions cannot reference judgment derived values (`{name}`)"
                     ))),
                 }
             }
-            other => Err(DenseCompileError::Unsupported(format!(
-                "where-clause predicates currently only support comparisons between related inputs and literals; got {other:?}"
+            ScalarExpr::ParameterLookup { parameter, index } => {
+                Ok(CompiledRelatedScalarExpr::ParameterLookup {
+                    parameter: self.parameter(parameter)?,
+                    index: Box::new(self.compile_related_scalar(relation_index, index)?),
+                })
+            }
+            ScalarExpr::Add(items) => Ok(CompiledRelatedScalarExpr::Add(
+                items
+                    .iter()
+                    .map(|item| self.compile_related_scalar(relation_index, item))
+                    .collect::<Result<Vec<_>, DenseCompileError>>()?,
+            )),
+            ScalarExpr::Sub(left, right) => Ok(CompiledRelatedScalarExpr::Sub(
+                Box::new(self.compile_related_scalar(relation_index, left)?),
+                Box::new(self.compile_related_scalar(relation_index, right)?),
+            )),
+            ScalarExpr::Mul(left, right) => Ok(CompiledRelatedScalarExpr::Mul(
+                Box::new(self.compile_related_scalar(relation_index, left)?),
+                Box::new(self.compile_related_scalar(relation_index, right)?),
+            )),
+            ScalarExpr::Div(left, right) => Ok(CompiledRelatedScalarExpr::Div(
+                Box::new(self.compile_related_scalar(relation_index, left)?),
+                Box::new(self.compile_related_scalar(relation_index, right)?),
+            )),
+            ScalarExpr::Max(items) => Ok(CompiledRelatedScalarExpr::Max(
+                items
+                    .iter()
+                    .map(|item| self.compile_related_scalar(relation_index, item))
+                    .collect::<Result<Vec<_>, DenseCompileError>>()?,
+            )),
+            ScalarExpr::Min(items) => Ok(CompiledRelatedScalarExpr::Min(
+                items
+                    .iter()
+                    .map(|item| self.compile_related_scalar(relation_index, item))
+                    .collect::<Result<Vec<_>, DenseCompileError>>()?,
+            )),
+            ScalarExpr::Ceil(value) => Ok(CompiledRelatedScalarExpr::Ceil(Box::new(
+                self.compile_related_scalar(relation_index, value)?,
             ))),
+            ScalarExpr::Floor(value) => Ok(CompiledRelatedScalarExpr::Floor(Box::new(
+                self.compile_related_scalar(relation_index, value)?,
+            ))),
+            ScalarExpr::PeriodStart => Ok(CompiledRelatedScalarExpr::PeriodStart),
+            ScalarExpr::PeriodEnd => Ok(CompiledRelatedScalarExpr::PeriodEnd),
+            ScalarExpr::DateAddDays { date, days } => Ok(CompiledRelatedScalarExpr::DateAddDays {
+                date: Box::new(self.compile_related_scalar(relation_index, date)?),
+                days: Box::new(self.compile_related_scalar(relation_index, days)?),
+            }),
+            ScalarExpr::DaysBetween { from, to } => Ok(CompiledRelatedScalarExpr::DaysBetween {
+                from: Box::new(self.compile_related_scalar(relation_index, from)?),
+                to: Box::new(self.compile_related_scalar(relation_index, to)?),
+            }),
+            ScalarExpr::If {
+                condition,
+                then_expr,
+                else_expr,
+            } => Ok(CompiledRelatedScalarExpr::If {
+                condition: Box::new(self.compile_related_predicate(relation_index, condition)?),
+                then_expr: Box::new(self.compile_related_scalar(relation_index, then_expr)?),
+                else_expr: Box::new(self.compile_related_scalar(relation_index, else_expr)?),
+            }),
+            ScalarExpr::CountRelated { relation, .. } | ScalarExpr::SumRelated { relation, .. } => {
+                Err(DenseCompileError::Unsupported(format!(
+                    "aggregation over relation `{relation}` nested inside a related expression"
+                )))
+            }
         }
     }
 
@@ -1442,20 +1547,14 @@ impl<'a> DenseExecutor<'a> {
                     ))
                 }
             }
-            CompiledScalarExpr::SumRelatedInput {
+            CompiledScalarExpr::SumRelated {
                 relation,
-                input,
+                value,
                 predicate,
             } => {
                 let offsets = self.batch.relations[*relation].offsets.clone();
-                let values = self.batch.relations[*relation].inputs[*input]
-                    .as_ref()
-                    .ok_or_else(|| EvalError::MissingInput {
-                        name: format!("related_input[{input}]"),
-                        entity_id: String::new(),
-                        period_start: self.period.start,
-                        period_end: self.period.end,
-                    })?
+                let values = self
+                    .resolve_related_scalar(*relation, value)?
                     .as_decimal_vec()?;
                 let mask = self.relation_mask(*relation, predicate.as_ref())?;
                 let mut totals = Vec::with_capacity(self.batch.row_count);
@@ -1610,6 +1709,142 @@ impl<'a> DenseExecutor<'a> {
                 let offsets = self.batch.relations[relation].offsets.clone();
                 let values = self.eval_scalar_expr(expr)?;
                 project_root_column_to_related(&values, &offsets)
+            }
+            CompiledRelatedScalarExpr::ParameterLookup { parameter, index } => {
+                let keys = self
+                    .resolve_related_scalar(relation, index)?
+                    .as_index_vec()?;
+                lookup_parameter_dense(
+                    &self.program.parameters[*parameter].parameter,
+                    &keys,
+                    self.period,
+                )
+            }
+            CompiledRelatedScalarExpr::Add(items) => {
+                let mut total = vec![Decimal::ZERO; length];
+                for item in items {
+                    let values = self.resolve_related_scalar(relation, item)?.as_decimal_vec()?;
+                    for (index, value) in values.into_iter().enumerate() {
+                        total[index] += value;
+                    }
+                }
+                Ok(DenseColumn::Decimal(total))
+            }
+            CompiledRelatedScalarExpr::Sub(left, right) => {
+                let left = self.resolve_related_scalar(relation, left)?.as_decimal_vec()?;
+                let right = self
+                    .resolve_related_scalar(relation, right)?
+                    .as_decimal_vec()?;
+                Ok(DenseColumn::Decimal(
+                    left.into_iter()
+                        .zip(right)
+                        .map(|(left, right)| left - right)
+                        .collect(),
+                ))
+            }
+            CompiledRelatedScalarExpr::Mul(left, right) => {
+                let left = self.resolve_related_scalar(relation, left)?.as_decimal_vec()?;
+                let right = self
+                    .resolve_related_scalar(relation, right)?
+                    .as_decimal_vec()?;
+                Ok(DenseColumn::Decimal(
+                    left.into_iter()
+                        .zip(right)
+                        .map(|(left, right)| left * right)
+                        .collect(),
+                ))
+            }
+            CompiledRelatedScalarExpr::Div(left, right) => {
+                let left = self.resolve_related_scalar(relation, left)?.as_decimal_vec()?;
+                let right = self
+                    .resolve_related_scalar(relation, right)?
+                    .as_decimal_vec()?;
+                Ok(DenseColumn::Decimal(
+                    left.into_iter()
+                        .zip(right)
+                        .map(|(left, right)| {
+                            if right.is_zero() {
+                                Err(EvalError::DivisionByZero)
+                            } else {
+                                Ok(left / right)
+                            }
+                        })
+                        .collect::<Result<Vec<Decimal>, EvalError>>()?,
+                ))
+            }
+            CompiledRelatedScalarExpr::Max(items) => {
+                let mut values = vec![Decimal::MIN; length];
+                for item in items {
+                    let candidate = self.resolve_related_scalar(relation, item)?.as_decimal_vec()?;
+                    for (index, value) in candidate.into_iter().enumerate() {
+                        if value > values[index] {
+                            values[index] = value;
+                        }
+                    }
+                }
+                Ok(DenseColumn::Decimal(values))
+            }
+            CompiledRelatedScalarExpr::Min(items) => {
+                let mut values = vec![Decimal::MAX; length];
+                for item in items {
+                    let candidate = self.resolve_related_scalar(relation, item)?.as_decimal_vec()?;
+                    for (index, value) in candidate.into_iter().enumerate() {
+                        if value < values[index] {
+                            values[index] = value;
+                        }
+                    }
+                }
+                Ok(DenseColumn::Decimal(values))
+            }
+            CompiledRelatedScalarExpr::Ceil(value) => Ok(DenseColumn::Decimal(
+                self.resolve_related_scalar(relation, value)?
+                    .as_decimal_vec()?
+                    .into_iter()
+                    .map(|value| value.ceil())
+                    .collect(),
+            )),
+            CompiledRelatedScalarExpr::Floor(value) => Ok(DenseColumn::Decimal(
+                self.resolve_related_scalar(relation, value)?
+                    .as_decimal_vec()?
+                    .into_iter()
+                    .map(|value| value.floor())
+                    .collect(),
+            )),
+            CompiledRelatedScalarExpr::PeriodStart => {
+                Ok(DenseColumn::Date(vec![self.period.start; length]))
+            }
+            CompiledRelatedScalarExpr::PeriodEnd => {
+                Ok(DenseColumn::Date(vec![self.period.end; length]))
+            }
+            CompiledRelatedScalarExpr::DateAddDays { date, days } => {
+                let base = self.resolve_related_scalar(relation, date)?.as_date_vec()?;
+                let offset = self.resolve_related_scalar(relation, days)?.as_index_vec()?;
+                Ok(DenseColumn::Date(
+                    base.into_iter()
+                        .zip(offset)
+                        .map(|(base, offset)| base + chrono::Duration::days(offset))
+                        .collect(),
+                ))
+            }
+            CompiledRelatedScalarExpr::DaysBetween { from, to } => {
+                let a = self.resolve_related_scalar(relation, from)?.as_date_vec()?;
+                let b = self.resolve_related_scalar(relation, to)?.as_date_vec()?;
+                Ok(DenseColumn::Integer(
+                    a.into_iter()
+                        .zip(b)
+                        .map(|(a, b)| (b - a).num_days())
+                        .collect(),
+                ))
+            }
+            CompiledRelatedScalarExpr::If {
+                condition,
+                then_expr,
+                else_expr,
+            } => {
+                let condition = self.eval_related_predicate(relation, condition)?;
+                let then_values = self.resolve_related_scalar(relation, then_expr)?;
+                let else_values = self.resolve_related_scalar(relation, else_expr)?;
+                select_related_scalar_column(&condition, then_values, else_values)
             }
         }
     }
@@ -1911,6 +2146,24 @@ fn lookup_parameter_dense(
                 .collect::<Result<Vec<Decimal>, EvalError>>()?,
         ))
     }
+}
+
+fn select_related_scalar_column(
+    condition: &[bool],
+    then_values: DenseColumn,
+    else_values: DenseColumn,
+) -> Result<DenseColumn, EvalError> {
+    let condition = condition
+        .iter()
+        .map(|holds| {
+            if *holds {
+                JudgmentOutcome::Holds
+            } else {
+                JudgmentOutcome::NotHolds
+            }
+        })
+        .collect();
+    select_dense_scalar_column(condition, then_values, else_values)
 }
 
 fn select_dense_scalar_column(

--- a/src/formula.rs
+++ b/src/formula.rs
@@ -1459,13 +1459,20 @@ fn lower_to_scalar(e: &Expr, ctx: &LowerCtx) -> Result<ScalarExprSpec, FormulaEr
                     if let Expr::Var(rel) = obj.as_ref() {
                         ctx.relations.borrow_mut().insert(rel.clone());
                         let (current_slot, related_slot) = infer_slots(rel);
+                        let value = if ctx.derived.contains(field) {
+                            RelatedValueRefSpec::Derived {
+                                name: field.clone(),
+                            }
+                        } else {
+                            RelatedValueRefSpec::Input {
+                                name: field.clone(),
+                            }
+                        };
                         return Ok(ScalarExprSpec::SumRelated {
                             relation: rel.clone(),
                             current_slot,
                             related_slot,
-                            value: RelatedValueRefSpec::Input {
-                                name: field.clone(),
-                            },
+                            value,
                             where_clause: None,
                         });
                     }

--- a/tests/dense.rs
+++ b/tests/dense.rs
@@ -448,6 +448,212 @@ fn dense_family_allowance_matches_explain_mode() {
     }
 }
 
+const PER_CHILD_AWARD_RULESPEC: &str = r#"
+format: rulespec/v1
+rules:
+  - name: member_of_family
+    kind: data_relation
+    data_relation:
+      arity: 2
+  - name: eldest_weekly_rate
+    kind: parameter
+    dtype: Money
+    unit: GBP
+    versions:
+      - effective_from: '2025-01-01'
+        formula: '26.05'
+  - name: other_weekly_rate
+    kind: parameter
+    dtype: Money
+    unit: GBP
+    versions:
+      - effective_from: '2025-01-01'
+        formula: '17.25'
+  - name: other_child_weekly_amount
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Month
+    unit: GBP
+    versions:
+      - effective_from: '2025-01-01'
+        formula: |-
+          if is_eligible_child: other_weekly_rate
+          else: 0
+  - name: child_weekly_amount
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Month
+    unit: GBP
+    versions:
+      - effective_from: '2025-01-01'
+        formula: |-
+          if is_eldest_eligible_child: eldest_weekly_rate
+          else: other_child_weekly_amount
+  - name: family_weekly_award
+    kind: derived
+    entity: Family
+    dtype: Money
+    period: Month
+    unit: GBP
+    versions:
+      - effective_from: '2025-01-01'
+        formula: sum(member_of_family.child_weekly_amount)
+  - name: family_weekly_award_eligible_only
+    kind: derived
+    entity: Family
+    dtype: Money
+    period: Month
+    unit: GBP
+    versions:
+      - effective_from: '2025-01-01'
+        formula: sum_where(member_of_family, child_weekly_amount, is_eligible_child)
+"#;
+
+#[test]
+fn dense_sum_related_over_derived_matches_explain_mode() {
+    // Family-level awards summing a per-child derived amount: the related
+    // expression inlines a derived chain (if/else, parameter references)
+    // instead of requiring the caller to pre-compute it as an input column.
+    let period = month_period();
+    let interval = period_interval(&period);
+    let artifact = CompiledProgramArtifact::from_rulespec_str(PER_CHILD_AWARD_RULESPEC)
+        .expect("RuleSpec module compiles");
+    let dense = DenseCompiledProgram::from_artifact(&artifact, Some("Family"))
+        .expect("dense compilation succeeds");
+
+    // (family, children: (id, is_eldest_eligible_child, is_eligible_child))
+    let families: [(&str, Vec<(&str, bool, bool)>); 4] = [
+        ("family-1", vec![("child-1", true, true)]),
+        (
+            "family-2",
+            vec![
+                ("child-2", true, true),
+                ("child-3", false, true),
+                ("child-4", false, true),
+            ],
+        ),
+        (
+            "family-3",
+            vec![("child-5", false, false), ("child-6", false, true)],
+        ),
+        ("family-4", vec![]),
+    ];
+
+    let mut dataset = DatasetSpec::default();
+    for (family_id, children) in &families {
+        for (child_id, is_eldest, is_eligible) in children {
+            dataset.inputs.push(InputRecordSpec {
+                name: "is_eldest_eligible_child".to_string(),
+                entity: "Person".to_string(),
+                entity_id: (*child_id).to_string(),
+                interval: interval.clone(),
+                value: ScalarValueSpec::Bool { value: *is_eldest },
+            });
+            dataset.inputs.push(InputRecordSpec {
+                name: "is_eligible_child".to_string(),
+                entity: "Person".to_string(),
+                entity_id: (*child_id).to_string(),
+                interval: interval.clone(),
+                value: ScalarValueSpec::Bool { value: *is_eligible },
+            });
+            dataset.relations.push(RelationRecordSpec {
+                name: "member_of_family".to_string(),
+                tuple: vec![(*child_id).to_string(), (*family_id).to_string()],
+                interval: interval.clone(),
+            });
+        }
+    }
+
+    let outputs = vec![
+        "family_weekly_award".to_string(),
+        "family_weekly_award_eligible_only".to_string(),
+    ];
+    let explain = execute_request(ExecutionRequest {
+        mode: ExecutionMode::Explain,
+        program: artifact.program.clone(),
+        dataset,
+        queries: families
+            .iter()
+            .map(|(family_id, _)| ExecutionQuery {
+                assessment_date: None,
+                entity_id: (*family_id).to_string(),
+                period: period.clone(),
+                outputs: outputs.clone(),
+            })
+            .collect(),
+    })
+    .expect("explain execution succeeds");
+
+    let mut offsets = vec![0_usize];
+    let mut is_eldest_column = Vec::new();
+    let mut is_eligible_column = Vec::new();
+    for (_, children) in &families {
+        for (_, is_eldest, is_eligible) in children {
+            is_eldest_column.push(*is_eldest);
+            is_eligible_column.push(*is_eligible);
+        }
+        offsets.push(is_eldest_column.len());
+    }
+
+    let dense_result = dense
+        .execute(
+            &period.to_model().expect("period converts"),
+            DenseBatchSpec {
+                row_count: families.len(),
+                inputs: HashMap::new(),
+                relations: HashMap::from([(
+                    DenseRelationKey {
+                        name: "member_of_family".to_string(),
+                        current_slot: 1,
+                        related_slot: 0,
+                    },
+                    DenseRelationBatchSpec {
+                        offsets,
+                        inputs: HashMap::from([
+                            (
+                                "is_eldest_eligible_child".to_string(),
+                                DenseColumn::Bool(is_eldest_column),
+                            ),
+                            (
+                                "is_eligible_child".to_string(),
+                                DenseColumn::Bool(is_eligible_column),
+                            ),
+                        ]),
+                    },
+                )]),
+            },
+            &outputs,
+        )
+        .expect("dense execution succeeds");
+
+    for row in 0..families.len() {
+        for output in &outputs {
+            compare_scalar(
+                explain.results[row]
+                    .outputs
+                    .get(output)
+                    .expect("explain output"),
+                dense_result.outputs.get(output).expect("dense output"),
+                row,
+            );
+        }
+    }
+
+    // The award values are deterministic, so also pin them down exactly
+    // rather than relying solely on explain-mode agreement.
+    let DenseOutputValue::Scalar(DenseColumn::Decimal(awards)) =
+        dense_result.outputs.get("family_weekly_award").expect("dense award")
+    else {
+        panic!("expected decimal award column");
+    };
+    let expected = ["26.05", "60.55", "17.25", "0"];
+    for (award, expected) in awards.iter().zip(expected) {
+        assert_eq!(award.normalize(), decimal(expected).normalize());
+    }
+}
+
 #[test]
 fn dense_filtered_entity_scope_matches_explain_mode() {
     let period = month_period();


### PR DESCRIPTION
The dense columnar path could only sum related *input* columns: `sum_related` over a derived value errored at compile, so consumers had to evaluate per-child rules in a separate engine call and segment-sum the results outside the engine. That blocked rules the registry already encodes — SSCBA 1992 s.141's `child_benefit_weekly_entitlement` is literally `sum_where(relation, derived_rate, derived_predicate)` and could only run in explain mode.

This generalises the related-expression tree (`CompiledRelatedScalarExpr`) to the full scalar language — arithmetic, if/else, parameter lookups, period bounds and date operations — mirroring the root-context evaluator at related length. `SumRelatedInput` becomes a general `SumRelated` over any related expression (an input reference is just one case), and derived references inline through the same mechanism the where-clause compiler already used. Scalar-entity formula parameters broadcast into related context via the existing root-broadcast projection. One DSL fix rides along: `sum(rel.field)` now classifies a derived field as a derived reference, matching what `sum_where` already did.

The batch format is unchanged, so existing callers are untouched. Nested aggregations inside a related expression stay unsupported with a clear error, as does bulk fast mode's pre-existing blocker for this construct.

Tested with a child-benefit-shaped module (per-child derived rate via parameters and if/else chains, summed to family level, plus a filtered `sum_where` variant) asserting dense agrees with explain mode and pinning the exact decimal awards. Validated end to end on the 100k-household demo: child benefit and the UC s.10 child elements now aggregate in-engine through s.141's own entitlement rule with identical totals and unchanged runtime (~0.7s for 19 engine calls).