### PR TITLE
Lower source-relation sets into parameter bindings

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -383,3 +383,32 @@ facts are consumed by validators, the Axiom app, and trace renderers.
 - A follow-up can teach explain traces to pull graph metadata for rendering.
 - The `source` / `source_url` fields on derived outputs should become arrays to
   support multi-document provenance.
+
+## 2026-06-14 — Parameter `sets` lower into executable bindings
+
+**Decision.** `source_relation.type: sets` remains graph/provenance metadata,
+but parameter-to-parameter `sets` records also lower into executable parameter
+bindings when both sides are present in the merged RuleSpec program. The
+upstream delegated slot stays addressable as the federal parameter; the
+downstream `source_relation.value` parameter supplies that slot's versions.
+
+**Why.**
+
+- Federal formulas should encode the legal structure once, with state modules
+  setting delegated standards rather than duplicating federal eligibility
+  formulas.
+- Keeping the upstream parameter name as the runtime slot preserves stable
+  formula references and public IDs.
+- The `sets` record still carries the legal edge needed for audit and trace
+  rendering.
+
+**Consequences.**
+
+- Upstream sources that delegate a reformable setting should expose that setting
+  as a `kind: parameter` slot.
+- Downstream state modules can import the upstream formula, define the local
+  value parameter, and bind it with `source_relation.type: sets`,
+  `source_relation.target`, `source_relation.value`, and
+  `source_relation.basis.delegation`.
+- Non-parameter source relations, amendments, restatements, and source graph
+  edges without a local `value` remain metadata-only.

--- a/docs/rulespec.md
+++ b/docs/rulespec.md
@@ -258,6 +258,14 @@ changes the target rule's legal effect, encode the executable local rule and add
 a `source_relation.type: sets`, `implements`, or `amends` edge to the upstream
 delegation or target.
 
+For delegated parameter settings, the upstream source should expose the
+reformable slot as a `kind: parameter`. A downstream source relation whose
+`source_relation.type` is `sets` binds the local parameter values into the
+upstream slot during RuleSpec lowering when its `target` points to that
+upstream parameter and its `value` points to a local parameter. This lets
+federal formulas encode the legal structure once while state modules supply the
+delegated standards.
+
 Example delegated parameter setting:
 
 ```yaml

--- a/docs/schema-alignment.md
+++ b/docs/schema-alignment.md
@@ -32,8 +32,9 @@ RuleSpec should make machine-authored structure explicit:
 - Explicit data-relation arity and, in a follow-up, slot names/orientation.
 - Multi-source provenance and source-document anchors.
 - Legal/provenance graph edges such as `restates`, `sets`, `implements`, and
-  `amends` as `source_relation` records that do not lower directly into the
-  executable runtime.
+  `amends` as `source_relation` records. Parameter-to-parameter `sets` edges
+  with `source_relation.value` lower into runtime as delegated parameter
+  bindings; other source relations remain provenance metadata.
 
 ## Current Gaps
 
@@ -43,9 +44,11 @@ schema/runtime gaps are explicit:
 - `derived_relation` lowers into `ProgramSpec` and executes in explain mode,
   bulk fast mode, and the generic dense compiler for related-input predicates,
   current/root predicates, and composed derived-relation source chains.
-- `source_relation` records are validated as provenance metadata and ignored
-  during runtime lowering; the harness/compiler should consume them when
-  resolving imports, amendments, and upstream-first checks.
+- `source_relation` records are validated as provenance metadata.
+  Parameter-to-parameter `sets` records now lower into runtime parameter
+  bindings when both the upstream target and downstream value parameters are
+  present in the merged program; remaining relation types are still metadata for
+  validators, amendments, traces, and upstream-first checks.
 - Downstream jurisdiction repos still need their own migrations to replace
   SNAP approximations with filtered-entity RuleSpec.
 - Formula strings currently support the implemented scalar/judgment expression

--- a/src/rulespec.rs
+++ b/src/rulespec.rs
@@ -1052,6 +1052,7 @@ impl RulesDocument {
         rewrite_relation_references(&mut program, &relation_rewrites, &explicit_relations)?;
         append_missing_units(&mut program, &self.units);
         append_missing_relations(&mut program, &explicit_relations)?;
+        apply_source_relation_sets(&mut program, &self.rules);
         rewrite_filtered_entity_member_aliases(&mut program);
         // Carried for tooling and artifact pass-through only; nothing in
         // compilation or execution reads it.
@@ -1550,6 +1551,56 @@ fn append_missing_relations(
         program.relations.push(relation.clone());
     }
     Ok(())
+}
+
+fn apply_source_relation_sets(program: &mut ProgramSpec, rules: &[RuleDefinition]) {
+    for rule in rules {
+        let Some(source_relation) = rule.source_relation.as_ref() else {
+            continue;
+        };
+        if source_relation.relation_type.as_ref() != Some(&SourceRelationType::Sets) {
+            continue;
+        }
+        let Some(target_ref) = source_relation
+            .target
+            .as_deref()
+            .map(str::trim)
+            .filter(|target| target.contains('#'))
+        else {
+            continue;
+        };
+        let Some(value_ref) = source_relation
+            .value
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| value.contains('#'))
+        else {
+            continue;
+        };
+        if target_ref == value_ref {
+            continue;
+        }
+
+        let Some(value_parameter) = program
+            .parameters
+            .iter()
+            .find(|parameter| parameter.id.as_deref() == Some(value_ref))
+            .cloned()
+        else {
+            continue;
+        };
+        let Some(target_parameter) = program
+            .parameters
+            .iter_mut()
+            .find(|parameter| parameter.id.as_deref() == Some(target_ref))
+        else {
+            continue;
+        };
+
+        target_parameter.unit = value_parameter.unit;
+        target_parameter.indexed_by = value_parameter.indexed_by;
+        target_parameter.versions = value_parameter.versions;
+    }
 }
 
 fn rewrite_filtered_entity_member_aliases(program: &mut ProgramSpec) {

--- a/tests/module_source.rs
+++ b/tests/module_source.rs
@@ -13,7 +13,8 @@ use axiom_rules_engine::rulespec::{
 };
 use axiom_rules_engine::source::{ModuleSource, SourceError};
 use axiom_rules_engine::spec::{
-    DatasetSpec, InputRecordSpec, IntervalSpec, PeriodKindSpec, PeriodSpec, ScalarValueSpec,
+    DatasetSpec, InputRecordSpec, IntervalSpec, JudgmentOutcomeSpec, PeriodKindSpec, PeriodSpec,
+    ScalarValueSpec,
 };
 
 /// A `ModuleSource` over an in-memory map: the shape a wasm host, a server
@@ -83,6 +84,50 @@ rules:
     versions:
       - effective_from: 2025-10-01
         formula: floor(snap_maximum_allotment - (net_income * snap_household_food_contribution_rate))
+"#;
+
+const FEDERAL_MEDICAID_DELEGATED_SLOT_MODULE: &str = r#"
+format: rulespec/v1
+rules:
+  - name: state_plan_child_income_standard_fpl_ratio
+    kind: parameter
+    dtype: Rate
+    source: 42 CFR 435.118(b)
+    versions:
+      - effective_from: 2014-01-01
+        formula: "1.33"
+  - name: child_medicaid_eligible
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    period: Month
+    source: 42 CFR 435.118(b)
+    versions:
+      - effective_from: 2014-01-01
+        formula: household_income_as_fraction_of_fpl <= state_plan_child_income_standard_fpl_ratio
+"#;
+
+const GEORGIA_MEDICAID_SET_SLOT_MODULE: &str = r#"
+format: rulespec/v1
+imports:
+  - us:regulations/42-cfr/435/118
+rules:
+  - name: georgia_child_income_standard_fpl_ratio
+    kind: parameter
+    dtype: Rate
+    source: CMS Medicaid, CHIP, and BHP Eligibility Levels
+    versions:
+      - effective_from: 2023-12-01
+        formula: "1.49"
+  - name: sets_child_income_standard_fpl_ratio
+    kind: source_relation
+    source_relation:
+      type: sets
+      target: us:regulations/42-cfr/435/118#state_plan_child_income_standard_fpl_ratio
+      authority: state
+      value: us-ga:policies/cms/medicaid-eligibility#georgia_child_income_standard_fpl_ratio
+      basis:
+        delegation: us:regulations/42-cfr/435/118#state_plan_child_income_standard_delegation
 "#;
 
 #[test]
@@ -179,6 +224,82 @@ fn in_memory_module_source_compiles_and_executes_without_filesystem() {
         panic!("expected decimal scalar");
     };
     assert_eq!(value, "268");
+}
+
+#[test]
+fn source_relation_sets_bind_state_parameter_into_federal_formula() {
+    let source = InMemoryModuleSource::new(&[
+        (
+            "us:regulations/42-cfr/435/118",
+            FEDERAL_MEDICAID_DELEGATED_SLOT_MODULE,
+        ),
+        (
+            "us-ga:policies/cms/medicaid-eligibility",
+            GEORGIA_MEDICAID_SET_SLOT_MODULE,
+        ),
+    ]);
+
+    let artifact = CompiledProgramArtifact::from_rulespec_with_source(
+        "us-ga:policies/cms/medicaid-eligibility",
+        &source,
+    )
+    .expect("state module compiles with federal delegated slot");
+    let federal_slot = artifact
+        .program
+        .parameters
+        .iter()
+        .find(|parameter| {
+            parameter.id.as_deref()
+                == Some("us:regulations/42-cfr/435/118#state_plan_child_income_standard_fpl_ratio")
+        })
+        .expect("federal slot parameter remains addressable");
+    let ScalarValueSpec::Decimal { value } = &federal_slot.versions[0].values[&0] else {
+        panic!("expected decimal state-set standard");
+    };
+    assert_eq!(value, "1.49");
+
+    let period = PeriodSpec {
+        kind: PeriodKindSpec::Month,
+        start: "2026-01-01".parse().expect("valid date"),
+        end: "2026-01-31".parse().expect("valid date"),
+    };
+    let output_id = "us:regulations/42-cfr/435/118#child_medicaid_eligible".to_string();
+    let response = execute_request(ExecutionRequest {
+        mode: ExecutionMode::Explain,
+        program: artifact.program,
+        dataset: DatasetSpec {
+            inputs: vec![InputRecordSpec {
+                name: "us:regulations/42-cfr/435/118#input.household_income_as_fraction_of_fpl"
+                    .to_string(),
+                entity: "Person".to_string(),
+                entity_id: "child-1".to_string(),
+                interval: IntervalSpec {
+                    start: period.start,
+                    end: period.end,
+                },
+                value: ScalarValueSpec::Decimal {
+                    value: "1.40".to_string(),
+                },
+            }],
+            relations: Vec::new(),
+        },
+        queries: vec![ExecutionQuery {
+            assessment_date: None,
+            entity_id: "child-1".to_string(),
+            period,
+            outputs: vec![output_id.clone()],
+        }],
+    })
+    .expect("program executes with state-set federal slot");
+
+    let OutputValue::Judgment { outcome, .. } = response.results[0]
+        .outputs
+        .get(&output_id)
+        .expect("child_medicaid_eligible output")
+    else {
+        panic!("expected judgment output");
+    };
+    assert_eq!(*outcome, JudgmentOutcomeSpec::Holds);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- lower parameter-to-parameter `source_relation.type: sets` records into executable delegated parameter bindings
- keep the upstream target parameter name/id while copying versions/unit/indexing from the downstream value parameter
- document the new runtime behavior and add an end-to-end source-backed execution test

## Tests
- `cargo test`

## Notes
- This only binds `sets` records when both `source_relation.target` and `source_relation.value` resolve to parameters in the merged RuleSpec program. Other source relations, and `sets` records without a local value parameter, remain provenance metadata.