### PR TITLE
Validate executable source-relation set bindings

### DIFF
--- a/docs/rulespec.md
+++ b/docs/rulespec.md
@@ -60,9 +60,10 @@ Supported rule kinds in the current Rust loader:
 - `derived_relation`: executable runtime predicates computed by filtering a
   source relation with a judgment formula. This supports filtered membership
   sets such as SNAP units, MAGI households, and qualifying-child sets.
-- `source_relation`: non-executable legal/provenance edges. It must declare
-  `source_relation.type` and `source_relation.target` and is ignored during
-  lowering into `ProgramSpec`.
+- `source_relation`: legal/provenance edges. It must declare
+  `source_relation.type` and `source_relation.target`. Most source relations
+  are non-executable metadata; parameter-to-parameter `sets` records with
+  `source_relation.value` lower into delegated parameter bindings.
 
 `kind` describes the record's schema and lowering behavior. Source/legal
 semantics live in `source_relation.type`, not in `kind`. The supported

--- a/src/rulespec.rs
+++ b/src/rulespec.rs
@@ -99,6 +99,30 @@ pub enum RuleSpecError {
         "RuleSpec source relation `{name}` cannot include executable formula, version, table, or runtime relation fields"
     )]
     SourceRelationHasExecutableBody { name: String },
+    #[error(
+        "RuleSpec source relation `{name}` sets target `{target}`, but the target does not resolve to a parameter in the merged program"
+    )]
+    SourceRelationSetTargetNotParameter { name: String, target: String },
+    #[error(
+        "RuleSpec source relation `{name}` sets value `{value}`, but the value does not resolve to a parameter in the merged program"
+    )]
+    SourceRelationSetValueNotParameter { name: String, value: String },
+    #[error(
+        "RuleSpec source relation `{name}` cannot bind `{value}` to `{target}` because their indexed_by values differ"
+    )]
+    SourceRelationSetIndexedByMismatch {
+        name: String,
+        target: String,
+        value: String,
+    },
+    #[error(
+        "RuleSpec source relation `{name}` cannot bind `{value}` to `{target}` because their units differ"
+    )]
+    SourceRelationSetUnitMismatch {
+        name: String,
+        target: String,
+        value: String,
+    },
     #[error("RuleSpec relation `{name}` is declared with conflicting arities {existing} and {new}")]
     RelationArityConflict {
         name: String,
@@ -1052,7 +1076,7 @@ impl RulesDocument {
         rewrite_relation_references(&mut program, &relation_rewrites, &explicit_relations)?;
         append_missing_units(&mut program, &self.units);
         append_missing_relations(&mut program, &explicit_relations)?;
-        apply_source_relation_sets(&mut program, &self.rules);
+        apply_source_relation_sets(&mut program, &self.rules)?;
         rewrite_filtered_entity_member_aliases(&mut program);
         // Carried for tooling and artifact pass-through only; nothing in
         // compilation or execution reads it.
@@ -1553,7 +1577,10 @@ fn append_missing_relations(
     Ok(())
 }
 
-fn apply_source_relation_sets(program: &mut ProgramSpec, rules: &[RuleDefinition]) {
+fn apply_source_relation_sets(
+    program: &mut ProgramSpec,
+    rules: &[RuleDefinition],
+) -> Result<(), RuleSpecError> {
     for rule in rules {
         let Some(source_relation) = rule.source_relation.as_ref() else {
             continue;
@@ -1581,26 +1608,57 @@ fn apply_source_relation_sets(program: &mut ProgramSpec, rules: &[RuleDefinition
             continue;
         }
 
-        let Some(value_parameter) = program
+        let value_parameter_index = program
             .parameters
             .iter()
-            .find(|parameter| parameter.id.as_deref() == Some(value_ref))
-            .cloned()
-        else {
-            continue;
-        };
-        let Some(target_parameter) = program
+            .position(|parameter| parameter.id.as_deref() == Some(value_ref));
+        let target_parameter_index = program
             .parameters
-            .iter_mut()
-            .find(|parameter| parameter.id.as_deref() == Some(target_ref))
+            .iter()
+            .position(|parameter| parameter.id.as_deref() == Some(target_ref));
+
+        let (Some(value_parameter_index), Some(target_parameter_index)) =
+            (value_parameter_index, target_parameter_index)
         else {
-            continue;
+            if value_parameter_index.is_none() && target_parameter_index.is_none() {
+                continue;
+            }
+            if value_parameter_index.is_none() {
+                return Err(RuleSpecError::SourceRelationSetValueNotParameter {
+                    name: rule.name.clone(),
+                    value: value_ref.to_string(),
+                });
+            }
+            return Err(RuleSpecError::SourceRelationSetTargetNotParameter {
+                name: rule.name.clone(),
+                target: target_ref.to_string(),
+            });
         };
 
-        target_parameter.unit = value_parameter.unit;
-        target_parameter.indexed_by = value_parameter.indexed_by;
+        let value_parameter = program.parameters[value_parameter_index].clone();
+        let target_parameter = &mut program.parameters[target_parameter_index];
+
+        if target_parameter.indexed_by != value_parameter.indexed_by {
+            return Err(RuleSpecError::SourceRelationSetIndexedByMismatch {
+                name: rule.name.clone(),
+                target: target_ref.to_string(),
+                value: value_ref.to_string(),
+            });
+        }
+        if target_parameter.unit.is_some()
+            && value_parameter.unit.is_some()
+            && target_parameter.unit != value_parameter.unit
+        {
+            return Err(RuleSpecError::SourceRelationSetUnitMismatch {
+                name: rule.name.clone(),
+                target: target_ref.to_string(),
+                value: value_ref.to_string(),
+            });
+        }
+
         target_parameter.versions = value_parameter.versions;
     }
+    Ok(())
 }
 
 fn rewrite_filtered_entity_member_aliases(program: &mut ProgramSpec) {

--- a/tests/module_source.rs
+++ b/tests/module_source.rs
@@ -92,6 +92,7 @@ rules:
   - name: state_plan_child_income_standard_fpl_ratio
     kind: parameter
     dtype: Rate
+    unit: FPL
     source: 42 CFR 435.118(b)
     versions:
       - effective_from: 2014-01-01
@@ -257,6 +258,7 @@ fn source_relation_sets_bind_state_parameter_into_federal_formula() {
         panic!("expected decimal state-set standard");
     };
     assert_eq!(value, "1.49");
+    assert_eq!(federal_slot.unit.as_deref(), Some("FPL"));
 
     let period = PeriodSpec {
         kind: PeriodKindSpec::Month,
@@ -300,6 +302,69 @@ fn source_relation_sets_bind_state_parameter_into_federal_formula() {
         panic!("expected judgment output");
     };
     assert_eq!(*outcome, JudgmentOutcomeSpec::Holds);
+}
+
+#[test]
+fn source_relation_sets_reject_unresolved_value_parameter() {
+    let state_module = GEORGIA_MEDICAID_SET_SLOT_MODULE.replace(
+        "#georgia_child_income_standard_fpl_ratio",
+        "#misspelled_child_income_standard_fpl_ratio",
+    );
+    let source = InMemoryModuleSource::new(&[
+        (
+            "us:regulations/42-cfr/435/118",
+            FEDERAL_MEDICAID_DELEGATED_SLOT_MODULE,
+        ),
+        (
+            "us-ga:policies/cms/medicaid-eligibility",
+            state_module.as_str(),
+        ),
+    ]);
+
+    let error = load_rulespec_with_source("us-ga:policies/cms/medicaid-eligibility", &source)
+        .expect_err("unresolved executable value parameter is rejected");
+    assert!(
+        matches!(
+            error,
+            RuleSpecError::SourceRelationSetValueNotParameter { ref name, ref value }
+                if name == "sets_child_income_standard_fpl_ratio"
+                    && value == "us-ga:policies/cms/medicaid-eligibility#misspelled_child_income_standard_fpl_ratio"
+        ),
+        "{error}"
+    );
+}
+
+#[test]
+fn source_relation_sets_reject_indexed_by_mismatch() {
+    let state_module = GEORGIA_MEDICAID_SET_SLOT_MODULE.replace(
+        "source: CMS Medicaid, CHIP, and BHP Eligibility Levels\n    versions:",
+        "source: CMS Medicaid, CHIP, and BHP Eligibility Levels\n    indexed_by: household_size\n    versions:",
+    )
+    .replace(
+        "formula: \"1.49\"",
+        "values:\n          1: 1.49\n          2: 1.49",
+    );
+    let source = InMemoryModuleSource::new(&[
+        (
+            "us:regulations/42-cfr/435/118",
+            FEDERAL_MEDICAID_DELEGATED_SLOT_MODULE,
+        ),
+        (
+            "us-ga:policies/cms/medicaid-eligibility",
+            state_module.as_str(),
+        ),
+    ]);
+
+    let error = load_rulespec_with_source("us-ga:policies/cms/medicaid-eligibility", &source)
+        .expect_err("incompatible executable value parameter is rejected");
+    assert!(
+        matches!(
+            error,
+            RuleSpecError::SourceRelationSetIndexedByMismatch { ref name, .. }
+                if name == "sets_child_income_standard_fpl_ratio"
+        ),
+        "{error}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- error when an executable `sets` binding resolves only one side, preventing silent fallback to upstream defaults
- preserve upstream delegated-slot metadata and only copy downstream parameter versions; reject incompatible `indexed_by` or unit shapes
- update the RuleSpec summary docs and add regression coverage for unresolved values, selector mismatches, and metadata preservation

## Review cycle
- First read-only review found silent unresolved bindings, target metadata overwrite, and stale docs
- Follow-up read-only review reported no actionable findings

## Tests
- `cargo test`
- `cargo test source_relation_sets --test module_source`
- `git diff --check`