### PR TITLE
Support derived source-relation set hooks

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -412,3 +412,30 @@ downstream `source_relation.value` parameter supplies that slot's versions.
   `source_relation.basis.delegation`.
 - Non-parameter source relations, amendments, restatements, and source graph
   edges without a local `value` remain metadata-only.
+
+## 2026-06-14 — Derived `sets` lower into delegated formula hooks
+
+**Decision.** `source_relation.type: sets` also lowers same-kind
+derived-to-derived bindings. The upstream target remains the executable hook
+with its federal name and public id; the downstream value derived rule supplies
+the hook's semantics when both sides are present in the merged program.
+
+**Why.**
+
+- Some delegations are not raw parameter settings. Federal law can define the
+  formula surface and state-option category, while state law defines the
+  conditional selection logic that fills that surface.
+- SNAP utility allowances are the motivating case: federal rules define where
+  state standard utility allowances enter the shelter-cost calculation, while
+  state rules define the local HCSUA/LUA/individual allowance logic and amounts.
+- Keeping the upstream hook addressable avoids duplicating federal formulas in
+  every state module.
+
+**Consequences.**
+
+- Upstream formula hooks should be `kind: derived` placeholders with matching
+  entity, dtype, unit, and period.
+- Downstream state modules can bind local derived implementations to those
+  hooks with `source_relation.type: sets` and `source_relation.value`.
+- Lowering rejects cross-kind bindings and incompatible derived hooks instead
+  of silently copying formulas across unlike concepts.

--- a/docs/rulespec.md
+++ b/docs/rulespec.md
@@ -62,8 +62,9 @@ Supported rule kinds in the current Rust loader:
   sets such as SNAP units, MAGI households, and qualifying-child sets.
 - `source_relation`: legal/provenance edges. It must declare
   `source_relation.type` and `source_relation.target`. Most source relations
-  are non-executable metadata; parameter-to-parameter `sets` records with
-  `source_relation.value` lower into delegated parameter bindings.
+  are non-executable metadata; same-kind `sets` records with
+  `source_relation.value` lower into delegated parameter bindings or derived
+  formula hooks.
 
 `kind` describes the record's schema and lowering behavior. Source/legal
 semantics live in `source_relation.type`, not in `kind`. The supported
@@ -267,6 +268,14 @@ upstream parameter and its `value` points to a local parameter. This lets
 federal formulas encode the legal structure once while state modules supply the
 delegated standards.
 
+For delegated formula hooks, the upstream source should expose the hook as a
+`kind: derived` placeholder with the same entity, dtype, unit, and period that
+the upstream formula consumes. A downstream `sets` relation can bind a local
+derived rule into that hook. Lowering copies the local derived semantics into
+the upstream hook while preserving the upstream name, public id, and source
+metadata. This is appropriate when federal law defines where a state option
+enters a formula, but state law defines the option's selection logic.
+
 Example delegated parameter setting:
 
 ```yaml
@@ -293,6 +302,42 @@ rules:
       value: us-co:policy/cdhs/snap/fy-2026#co_snap_heating_cooling_sua_fy_2026
       basis:
         delegation: us:regulations/7-cfr/273/9#state_utility_allowance_delegation
+```
+
+Example delegated formula hook:
+
+```yaml
+rules:
+  - name: snap_standard_utility_allowance_state_option
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    source: 7 CFR 273.9(d)(6)(iii)
+    versions:
+      - effective_from: 2025-10-01
+        formula: "0"
+
+  - name: state_snap_standard_utility_allowance
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    source: State SNAP utility allowance rule
+    versions:
+      - effective_from: 2025-10-01
+        formula: if household_has_qualifying_heating_or_cooling_cost: state_sua_amount else: 0
+
+  - name: state_snap_standard_utility_allowance_sets_federal_hook
+    kind: source_relation
+    source_relation:
+      type: sets
+      target: us:regulations/7-cfr/273/9#snap_standard_utility_allowance_state_option
+      value: us-state:policies/snap/utility-allowance#state_snap_standard_utility_allowance
+      basis:
+        delegation: us:regulations/7-cfr/273/9#snap_state_standard_utility_allowance_delegation
 ```
 
 ## Source pinning and provenance

--- a/docs/schema-alignment.md
+++ b/docs/schema-alignment.md
@@ -32,9 +32,9 @@ RuleSpec should make machine-authored structure explicit:
 - Explicit data-relation arity and, in a follow-up, slot names/orientation.
 - Multi-source provenance and source-document anchors.
 - Legal/provenance graph edges such as `restates`, `sets`, `implements`, and
-  `amends` as `source_relation` records. Parameter-to-parameter `sets` edges
-  with `source_relation.value` lower into runtime as delegated parameter
-  bindings; other source relations remain provenance metadata.
+  `amends` as `source_relation` records. Same-kind `sets` edges with
+  `source_relation.value` lower into runtime as delegated parameter bindings
+  or derived formula hooks; other source relations remain provenance metadata.
 
 ## Current Gaps
 
@@ -45,10 +45,10 @@ schema/runtime gaps are explicit:
   bulk fast mode, and the generic dense compiler for related-input predicates,
   current/root predicates, and composed derived-relation source chains.
 - `source_relation` records are validated as provenance metadata.
-  Parameter-to-parameter `sets` records now lower into runtime parameter
-  bindings when both the upstream target and downstream value parameters are
-  present in the merged program; remaining relation types are still metadata for
-  validators, amendments, traces, and upstream-first checks.
+  Parameter-to-parameter and derived-to-derived `sets` records now lower into
+  runtime bindings when both the upstream target and downstream value concepts
+  are present in the merged program; remaining relation types are still metadata
+  for validators, amendments, traces, and upstream-first checks.
 - Downstream jurisdiction repos still need their own migrations to replace
   SNAP approximations with filtered-entity RuleSpec.
 - Formula strings currently support the implemented scalar/judgment expression

--- a/src/rulespec.rs
+++ b/src/rulespec.rs
@@ -123,6 +123,48 @@ pub enum RuleSpecError {
         target: String,
         value: String,
     },
+    #[error(
+        "RuleSpec source relation `{name}` sets target `{target}`, but the target does not resolve to an executable parameter or derived rule in the merged program"
+    )]
+    SourceRelationSetTargetNotExecutable { name: String, target: String },
+    #[error(
+        "RuleSpec source relation `{name}` sets value `{value}`, but the value does not resolve to an executable parameter or derived rule in the merged program"
+    )]
+    SourceRelationSetValueNotExecutable { name: String, value: String },
+    #[error(
+        "RuleSpec source relation `{name}` cannot bind `{value}` ({value_kind}) to `{target}` ({target_kind})"
+    )]
+    SourceRelationSetKindMismatch {
+        name: String,
+        target: String,
+        value: String,
+        target_kind: String,
+        value_kind: String,
+    },
+    #[error(
+        "RuleSpec source relation `{name}` cannot bind `{value}` to `{target}` because their derived entities differ"
+    )]
+    SourceRelationSetEntityMismatch {
+        name: String,
+        target: String,
+        value: String,
+    },
+    #[error(
+        "RuleSpec source relation `{name}` cannot bind `{value}` to `{target}` because their derived dtypes differ"
+    )]
+    SourceRelationSetDTypeMismatch {
+        name: String,
+        target: String,
+        value: String,
+    },
+    #[error(
+        "RuleSpec source relation `{name}` cannot bind `{value}` to `{target}` because their derived periods differ"
+    )]
+    SourceRelationSetPeriodMismatch {
+        name: String,
+        target: String,
+        value: String,
+    },
     #[error("RuleSpec relation `{name}` is declared with conflicting arities {existing} and {new}")]
     RelationArityConflict {
         name: String,
@@ -1608,57 +1650,172 @@ fn apply_source_relation_sets(
             continue;
         }
 
-        let value_parameter_index = program
-            .parameters
-            .iter()
-            .position(|parameter| parameter.id.as_deref() == Some(value_ref));
-        let target_parameter_index = program
-            .parameters
-            .iter()
-            .position(|parameter| parameter.id.as_deref() == Some(target_ref));
+        let value_binding = find_set_binding(program, value_ref);
+        let target_binding = find_set_binding(program, target_ref);
 
-        let (Some(value_parameter_index), Some(target_parameter_index)) =
-            (value_parameter_index, target_parameter_index)
-        else {
-            if value_parameter_index.is_none() && target_parameter_index.is_none() {
+        let (Some(value_binding), Some(target_binding)) = (value_binding, target_binding) else {
+            if value_binding.is_none() && target_binding.is_none() {
                 continue;
             }
-            if value_parameter_index.is_none() {
-                return Err(RuleSpecError::SourceRelationSetValueNotParameter {
-                    name: rule.name.clone(),
-                    value: value_ref.to_string(),
-                });
+            if value_binding.is_none() {
+                return match target_binding
+                    .expect("target binding is present when value is absent")
+                    .kind
+                {
+                    SetBindingKind::Parameter => {
+                        Err(RuleSpecError::SourceRelationSetValueNotParameter {
+                            name: rule.name.clone(),
+                            value: value_ref.to_string(),
+                        })
+                    }
+                    SetBindingKind::Derived => {
+                        Err(RuleSpecError::SourceRelationSetValueNotExecutable {
+                            name: rule.name.clone(),
+                            value: value_ref.to_string(),
+                        })
+                    }
+                };
             }
-            return Err(RuleSpecError::SourceRelationSetTargetNotParameter {
-                name: rule.name.clone(),
-                target: target_ref.to_string(),
-            });
+            return match value_binding
+                .expect("value binding is present when target is absent")
+                .kind
+            {
+                SetBindingKind::Parameter => {
+                    Err(RuleSpecError::SourceRelationSetTargetNotParameter {
+                        name: rule.name.clone(),
+                        target: target_ref.to_string(),
+                    })
+                }
+                SetBindingKind::Derived => {
+                    Err(RuleSpecError::SourceRelationSetTargetNotExecutable {
+                        name: rule.name.clone(),
+                        target: target_ref.to_string(),
+                    })
+                }
+            };
         };
 
-        let value_parameter = program.parameters[value_parameter_index].clone();
-        let target_parameter = &mut program.parameters[target_parameter_index];
-
-        if target_parameter.indexed_by != value_parameter.indexed_by {
-            return Err(RuleSpecError::SourceRelationSetIndexedByMismatch {
+        if value_binding.kind != target_binding.kind {
+            return Err(RuleSpecError::SourceRelationSetKindMismatch {
                 name: rule.name.clone(),
                 target: target_ref.to_string(),
                 value: value_ref.to_string(),
-            });
-        }
-        if target_parameter.unit.is_some()
-            && value_parameter.unit.is_some()
-            && target_parameter.unit != value_parameter.unit
-        {
-            return Err(RuleSpecError::SourceRelationSetUnitMismatch {
-                name: rule.name.clone(),
-                target: target_ref.to_string(),
-                value: value_ref.to_string(),
+                target_kind: target_binding.kind.as_str().to_string(),
+                value_kind: value_binding.kind.as_str().to_string(),
             });
         }
 
-        target_parameter.versions = value_parameter.versions;
+        match value_binding.kind {
+            SetBindingKind::Parameter => {
+                let value_parameter = program.parameters[value_binding.index].clone();
+                let target_parameter = &mut program.parameters[target_binding.index];
+
+                if target_parameter.indexed_by != value_parameter.indexed_by {
+                    return Err(RuleSpecError::SourceRelationSetIndexedByMismatch {
+                        name: rule.name.clone(),
+                        target: target_ref.to_string(),
+                        value: value_ref.to_string(),
+                    });
+                }
+                if target_parameter.unit.is_some()
+                    && value_parameter.unit.is_some()
+                    && target_parameter.unit != value_parameter.unit
+                {
+                    return Err(RuleSpecError::SourceRelationSetUnitMismatch {
+                        name: rule.name.clone(),
+                        target: target_ref.to_string(),
+                        value: value_ref.to_string(),
+                    });
+                }
+
+                target_parameter.versions = value_parameter.versions;
+            }
+            SetBindingKind::Derived => {
+                let value_derived = program.derived[value_binding.index].clone();
+                let target_derived = &mut program.derived[target_binding.index];
+
+                if target_derived.entity != value_derived.entity {
+                    return Err(RuleSpecError::SourceRelationSetEntityMismatch {
+                        name: rule.name.clone(),
+                        target: target_ref.to_string(),
+                        value: value_ref.to_string(),
+                    });
+                }
+                if target_derived.dtype != value_derived.dtype {
+                    return Err(RuleSpecError::SourceRelationSetDTypeMismatch {
+                        name: rule.name.clone(),
+                        target: target_ref.to_string(),
+                        value: value_ref.to_string(),
+                    });
+                }
+                if target_derived.unit.is_some()
+                    && value_derived.unit.is_some()
+                    && target_derived.unit != value_derived.unit
+                {
+                    return Err(RuleSpecError::SourceRelationSetUnitMismatch {
+                        name: rule.name.clone(),
+                        target: target_ref.to_string(),
+                        value: value_ref.to_string(),
+                    });
+                }
+                if target_derived.period.is_some()
+                    && value_derived.period.is_some()
+                    && target_derived.period != value_derived.period
+                {
+                    return Err(RuleSpecError::SourceRelationSetPeriodMismatch {
+                        name: rule.name.clone(),
+                        target: target_ref.to_string(),
+                        value: value_ref.to_string(),
+                    });
+                }
+
+                target_derived.semantics = value_derived.semantics;
+            }
+        }
     }
     Ok(())
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum SetBindingKind {
+    Parameter,
+    Derived,
+}
+
+impl SetBindingKind {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Parameter => "parameter",
+            Self::Derived => "derived",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+struct SetBinding {
+    kind: SetBindingKind,
+    index: usize,
+}
+
+fn find_set_binding(program: &ProgramSpec, reference: &str) -> Option<SetBinding> {
+    if let Some(index) = program
+        .parameters
+        .iter()
+        .position(|parameter| parameter.id.as_deref() == Some(reference))
+    {
+        return Some(SetBinding {
+            kind: SetBindingKind::Parameter,
+            index,
+        });
+    }
+    program
+        .derived
+        .iter()
+        .position(|derived| derived.id.as_deref() == Some(reference))
+        .map(|index| SetBinding {
+            kind: SetBindingKind::Derived,
+            index,
+        })
 }
 
 fn rewrite_filtered_entity_member_aliases(program: &mut ProgramSpec) {

--- a/tests/module_source.rs
+++ b/tests/module_source.rs
@@ -131,6 +131,71 @@ rules:
         delegation: us:regulations/42-cfr/435/118#state_plan_child_income_standard_delegation
 "#;
 
+const FEDERAL_SNAP_UTILITY_HOOK_MODULE: &str = r#"
+format: rulespec/v1
+rules:
+  - name: snap_state_standard_utility_allowance_delegation
+    kind: source_relation
+    source_relation:
+      type: delegates
+      target: us:regulations/7-cfr/273/9#snap_standard_utility_allowance_state_option
+      authority: federal
+  - name: snap_standard_utility_allowance_state_option
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    source: 7 CFR 273.9(d)(6)(iii)
+    versions:
+      - effective_from: 2025-10-01
+        formula: "0"
+  - name: snap_total_allowable_shelter_expenses
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    source: 7 CFR 273.9(d)(6)
+    versions:
+      - effective_from: 2025-10-01
+        formula: household_shelter_costs_incurred + snap_standard_utility_allowance_state_option
+"#;
+
+const GEORGIA_SNAP_SET_UTILITY_HOOK_MODULE: &str = r#"
+format: rulespec/v1
+imports:
+  - us:regulations/7-cfr/273/9
+rules:
+  - name: georgia_snap_standard_utility_allowance_amount
+    kind: parameter
+    dtype: Money
+    unit: USD
+    source: Georgia SNAP utility allowance table
+    versions:
+      - effective_from: 2025-10-01
+        formula: "200"
+  - name: georgia_snap_standard_utility_allowance
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    source: Georgia SNAP utility allowance table
+    versions:
+      - effective_from: 2025-10-01
+        formula: georgia_snap_standard_utility_allowance_amount + 25
+  - name: sets_snap_standard_utility_allowance_state_option
+    kind: source_relation
+    source_relation:
+      type: sets
+      target: us:regulations/7-cfr/273/9#snap_standard_utility_allowance_state_option
+      authority: state
+      value: us-ga:policies/dfcs/snap-utility-allowance#georgia_snap_standard_utility_allowance
+      basis:
+        delegation: us:regulations/7-cfr/273/9#snap_state_standard_utility_allowance_delegation
+"#;
+
 #[test]
 fn in_memory_module_source_compiles_and_executes_without_filesystem() {
     let source = InMemoryModuleSource::new(&[
@@ -302,6 +367,85 @@ fn source_relation_sets_bind_state_parameter_into_federal_formula() {
         panic!("expected judgment output");
     };
     assert_eq!(*outcome, JudgmentOutcomeSpec::Holds);
+}
+
+#[test]
+fn source_relation_sets_bind_state_derived_into_federal_formula_hook() {
+    let source = InMemoryModuleSource::new(&[
+        (
+            "us:regulations/7-cfr/273/9",
+            FEDERAL_SNAP_UTILITY_HOOK_MODULE,
+        ),
+        (
+            "us-ga:policies/dfcs/snap-utility-allowance",
+            GEORGIA_SNAP_SET_UTILITY_HOOK_MODULE,
+        ),
+    ]);
+
+    let artifact = CompiledProgramArtifact::from_rulespec_with_source(
+        "us-ga:policies/dfcs/snap-utility-allowance",
+        &source,
+    )
+    .expect("state module compiles with federal derived hook");
+    let federal_hook = artifact
+        .program
+        .derived
+        .iter()
+        .find(|derived| {
+            derived.id.as_deref()
+                == Some("us:regulations/7-cfr/273/9#snap_standard_utility_allowance_state_option")
+        })
+        .expect("federal hook derived remains addressable");
+    assert_eq!(
+        federal_hook.name,
+        "snap_standard_utility_allowance_state_option"
+    );
+
+    let period = PeriodSpec {
+        kind: PeriodKindSpec::Month,
+        start: "2026-01-01".parse().expect("valid date"),
+        end: "2026-01-31".parse().expect("valid date"),
+    };
+    let output_id = "us:regulations/7-cfr/273/9#snap_total_allowable_shelter_expenses".to_string();
+    let response = execute_request(ExecutionRequest {
+        mode: ExecutionMode::Explain,
+        program: artifact.program,
+        dataset: DatasetSpec {
+            inputs: vec![InputRecordSpec {
+                name: "us:regulations/7-cfr/273/9#input.household_shelter_costs_incurred"
+                    .to_string(),
+                entity: "Household".to_string(),
+                entity_id: "household-1".to_string(),
+                interval: IntervalSpec {
+                    start: period.start,
+                    end: period.end,
+                },
+                value: ScalarValueSpec::Decimal {
+                    value: "500".to_string(),
+                },
+            }],
+            relations: Vec::new(),
+        },
+        queries: vec![ExecutionQuery {
+            assessment_date: None,
+            entity_id: "household-1".to_string(),
+            period,
+            outputs: vec![output_id.clone()],
+        }],
+    })
+    .expect("program executes with state-set federal derived hook");
+
+    let OutputValue::Scalar { value, .. } = response.results[0]
+        .outputs
+        .get(&output_id)
+        .expect("snap_total_allowable_shelter_expenses output")
+    else {
+        panic!("expected scalar output");
+    };
+    let ScalarValueSpec::Decimal { value } = value else {
+        panic!("expected decimal scalar");
+    };
+    assert_eq!(value, "725");
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- lower same-kind derived-to-derived source_relation.type: sets bindings into executable formula hooks
- preserve the upstream hook name/id/source metadata while copying downstream derived semantics
- add compatibility checks for cross-kind, entity, dtype, unit, and period mismatches
- document delegated formula hooks and add an in-memory SNAP regression

## Tests
- cargo test
- git diff --check