### PR TITLE
Preserve logical RuleSpec paths for source IDs

### DIFF
--- a/src/rulespec.rs
+++ b/src/rulespec.rs
@@ -858,8 +858,7 @@ fn resolve_canonical_rulespec_import(
 
 #[cfg(feature = "fs")]
 fn canonical_rulespec_target(path: &Path) -> Option<String> {
-    let resolved_path = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
-    let components = resolved_path
+    let components = path
         .components()
         .map(|component| component.as_os_str().to_string_lossy().to_string())
         .collect::<Vec<String>>();

--- a/tests/monorepo_resolution.rs
+++ b/tests/monorepo_resolution.rs
@@ -50,6 +50,60 @@ rules:
         formula: floor(snap_maximum_allotment - (net_income * snap_household_food_contribution_rate))
 "#;
 
+const FEDERAL_UTILITY_HOOK_MODULE: &str = r#"
+format: rulespec/v1
+rules:
+  - name: snap_utility_allowance_delegation
+    kind: source_relation
+    source_relation:
+      type: delegates
+      target: us:regulations/7-cfr/273/9#snap_total_allowable_shelter_expenses
+      authority: federal
+  - name: snap_standard_utility_allowance_state_option
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    versions:
+      - effective_from: 2025-10-01
+        formula: "0"
+  - name: snap_total_allowable_shelter_expenses
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    versions:
+      - effective_from: 2025-10-01
+        formula: household_shelter_costs + snap_standard_utility_allowance_state_option
+"#;
+
+const STATE_UTILITY_SET_MODULE: &str = r#"
+format: rulespec/v1
+imports:
+  - us:regulations/7-cfr/273/9
+rules:
+  - name: sets_snap_standard_utility_allowance
+    kind: source_relation
+    source_relation:
+      type: sets
+      target: us:regulations/7-cfr/273/9#snap_standard_utility_allowance_state_option
+      authority: state
+      value: us-co:regulations/10-ccr-2506-1/4.407.31#snap_standard_utility_allowance
+      basis:
+        delegation: us:regulations/7-cfr/273/9#snap_utility_allowance_delegation
+  - name: snap_standard_utility_allowance
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    versions:
+      - effective_from: 2025-10-01
+        formula: "594"
+"#;
+
 #[test]
 fn monorepo_jurisdiction_dirs_resolve_with_unchanged_ids() {
     let temp_root = std::env::temp_dir().join(format!(
@@ -81,6 +135,51 @@ fn monorepo_jurisdiction_dirs_resolve_with_unchanged_ids() {
     assert!(artifact.program.derived.iter().any(|derived| {
         derived.id.as_deref()
             == Some("us-co:policies/cdhs/snap/fy-2026-benefit#snap_regular_month_allotment")
+    }));
+
+    std::fs::remove_dir_all(&temp_root).ok();
+}
+
+#[cfg(unix)]
+#[test]
+fn symlinked_configured_roots_preserve_logical_rulespec_ids() {
+    use std::os::unix::fs::symlink;
+
+    let temp_root = std::env::temp_dir().join(format!(
+        "axiom-rules-engine-symlink-root-{}",
+        std::process::id()
+    ));
+    let physical_federal = temp_root.join("axiom-rulespec-us-main");
+    let configured_parent = temp_root.join("configured-roots");
+    let state_repo = temp_root.join("rulespec-us-co");
+    let federal_module = physical_federal.join("us/regulations/7-cfr/273/9.yaml");
+    let state_module = state_repo.join("regulations/10-ccr-2506-1/4.407.31.yaml");
+    let artifact_path = temp_root.join("utility.compiled.json");
+
+    std::fs::create_dir_all(federal_module.parent().expect("federal parent"))
+        .expect("federal dir");
+    std::fs::create_dir_all(state_module.parent().expect("state parent")).expect("state dir");
+    std::fs::create_dir_all(&configured_parent).expect("configured parent dir");
+    std::fs::write(&federal_module, FEDERAL_UTILITY_HOOK_MODULE)
+        .expect("federal utility hook module is written");
+    std::fs::write(&state_module, STATE_UTILITY_SET_MODULE)
+        .expect("state utility set module is written");
+    symlink(&physical_federal, configured_parent.join("rulespec-us"))
+        .expect("configured rulespec-us symlink is created");
+
+    let previous_roots = std::env::var_os("AXIOM_RULESPEC_REPO_ROOTS");
+    unsafe { std::env::set_var("AXIOM_RULESPEC_REPO_ROOTS", &configured_parent) };
+    let artifact = compile_program_file_to_json(&state_module, &artifact_path)
+        .expect("state sets relation resolves federal hook through symlinked configured root");
+    if let Some(previous_roots) = previous_roots {
+        unsafe { std::env::set_var("AXIOM_RULESPEC_REPO_ROOTS", previous_roots) };
+    } else {
+        unsafe { std::env::remove_var("AXIOM_RULESPEC_REPO_ROOTS") };
+    }
+
+    assert!(artifact.program.derived.iter().any(|derived| {
+        derived.id.as_deref()
+            == Some("us:regulations/7-cfr/273/9#snap_standard_utility_allowance_state_option")
     }));
 
     std::fs::remove_dir_all(&temp_root).ok();


### PR DESCRIPTION
## Summary
- derive filesystem RuleSpec origin IDs from the logical path used to load the file instead of the symlink target
- add a regression for configured RuleSpec roots where `rulespec-us` is a symlink to a physical checkout with a non-canonical name

## Root Cause
`canonical_rulespec_target` canonicalized the loaded file path before deriving public IDs. When `AXIOM_RULESPEC_REPO_ROOTS` pointed at a parent containing `rulespec-us -> axiom-rulespec-us-main`, imported federal rules received IDs under the physical checkout name, so `source_relation.type: sets` could not resolve targets like `us:regulations/...#snap_standard_utility_allowance_state_option`.

## Checks
- `cargo test --test monorepo_resolution -- --nocapture`
- `cargo test --test module_source source_relation_sets_bind_state_derived_into_federal_formula_hook -- --nocapture`
- `cargo fmt --check` was attempted but reports existing rustfmt drift across unrelated files in this repo under the local toolchain; no unrelated formatting changes were made.