### PR TITLE
Cache input slots during dataset conversion

### DIFF
--- a/src/model.rs
+++ b/src/model.rs
@@ -1,8 +1,8 @@
 use std::collections::{BTreeMap, HashMap, HashSet};
 
 use chrono::{Datelike, Duration, NaiveDate};
-use rust_decimal::Decimal;
 use rust_decimal::prelude::ToPrimitive;
+use rust_decimal::Decimal;
 
 /// Pseudo-entity assigned to formula parameters with no declared entity.
 /// Rules at this entity are row-constant.
@@ -363,12 +363,20 @@ impl Program {
     }
 
     pub fn resolve_input_name(&self, reference: &str) -> Option<String> {
+        let input_slots = self.input_slots();
+        self.resolve_input_name_with_slots(reference, &input_slots)
+    }
+
+    pub(crate) fn resolve_input_name_with_slots(
+        &self,
+        reference: &str,
+        input_slots: &HashSet<&str>,
+    ) -> Option<String> {
         if !self.has_public_ids() {
             return Some(reference.to_string());
         }
 
         let public_reference = PublicReference::parse(reference)?;
-        let input_slots = self.input_slots();
         if let Some(input_name) = public_reference.fragment.strip_prefix("input.") {
             if input_slots.contains(input_name) {
                 return Some(input_name.to_string());
@@ -432,7 +440,7 @@ impl Program {
                 .any(|parameter| parameter.id.is_some())
     }
 
-    fn input_slots(&self) -> HashSet<&str> {
+    pub(crate) fn input_slots(&self) -> HashSet<&str> {
         let mut slots = HashSet::new();
         for derived in self.derived.values() {
             collect_input_slots_from_semantics(&derived.semantics, &mut slots);

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -128,10 +128,11 @@ impl DatasetSpec {
     }
 
     pub fn to_dataset_for_program(&self, program: &Program) -> Result<DataSet, SpecError> {
+        let input_slots = program.input_slots();
         let inputs = self
             .inputs
             .iter()
-            .map(|input| input.to_model_for_program(program))
+            .map(|input| input.to_model_for_program(program, &input_slots))
             .collect::<Result<Vec<InputRecord>, SpecError>>()?;
         let relations = self
             .relations
@@ -823,12 +824,16 @@ impl InputRecordSpec {
         })
     }
 
-    fn to_model_for_program(&self, program: &Program) -> Result<InputRecord, SpecError> {
-        let name = program.resolve_input_name(&self.name).ok_or_else(|| {
-            SpecError::InvalidDatasetInputReference {
+    fn to_model_for_program(
+        &self,
+        program: &Program,
+        input_slots: &std::collections::HashSet<&str>,
+    ) -> Result<InputRecord, SpecError> {
+        let name = program
+            .resolve_input_name_with_slots(&self.name, input_slots)
+            .ok_or_else(|| SpecError::InvalidDatasetInputReference {
                 reference: self.name.clone(),
-            }
-        })?;
+            })?;
         Ok(InputRecord {
             name,
             entity: self.entity.clone(),


### PR DESCRIPTION
## Summary
- cache a program's input-slot set once when converting a dataset for a compiled program
- keep the existing public input-name resolver behavior for other call sites
- avoids rebuilding the full slot set for every input record in large Populace comparisons

## Evidence
- Stack sample from a full Medicaid Populace run showed `DatasetSpec::to_dataset_for_program` repeatedly inside `Program::resolve_input_name` / `Program::input_slots` before evaluation.
- `rustfmt --check src/model.rs src/spec.rs`
- `cargo test`
