### PR TITLE
Support versioned derived formulas

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -239,7 +239,13 @@ fn execute_explain(
                 .clone()
                 .unwrap_or_else(|| output_name.to_string());
 
-            match &derived.semantics {
+            let semantics = derived.semantics_at(&period).ok_or_else(|| {
+                EvalError::MissingDerivedFormulaVersion {
+                    derived: output_name.clone(),
+                    at: period.start,
+                }
+            })?;
+            match semantics {
                 DerivedSemantics::Scalar(_) => {
                     let value = engine.evaluate_scalar(&output_name, &query.entity_id, &period)?;
                     outputs.insert(
@@ -295,7 +301,10 @@ fn collect_trace(
 ) -> BTreeMap<String, DerivedTraceNode> {
     let mut trace = BTreeMap::new();
     for derived in program.derived.values() {
-        match &derived.semantics {
+        let Some(semantics) = derived.semantics_at(period) else {
+            continue;
+        };
+        match semantics {
             DerivedSemantics::Scalar(expr) => {
                 if let Some(value) = engine.cached_scalar(&derived.name, entity_id, period) {
                     trace.insert(

--- a/src/bulk.rs
+++ b/src/bulk.rs
@@ -1,7 +1,7 @@
 use std::collections::{BTreeMap, HashMap, HashSet};
 
-use rust_decimal::Decimal;
 use rust_decimal::prelude::ToPrimitive;
+use rust_decimal::Decimal;
 
 use crate::api::{
     ExecutionMetadata, ExecutionMode, ExecutionQuery, ExecutionResponse, OutputValue, QueryResult,
@@ -103,7 +103,13 @@ pub fn try_execute(
 
     for output in &requested {
         let derived = evaluator.get_derived(output)?;
-        let warmup = match &derived.semantics {
+        let semantics = derived.semantics_at(&evaluator.period).ok_or_else(|| {
+            EvalError::MissingDerivedFormulaVersion {
+                derived: output.clone(),
+                at: evaluator.period.start,
+            }
+        })?;
+        let warmup = match semantics {
             DerivedSemantics::Scalar(_) => evaluator.evaluate_scalar(output).map(|_| ()),
             DerivedSemantics::Judgment(_) => evaluator.evaluate_judgment(output).map(|_| ()),
         };
@@ -126,7 +132,13 @@ pub fn try_execute(
                 .id
                 .clone()
                 .unwrap_or_else(|| output_name.to_string());
-            match &derived.semantics {
+            let semantics = derived.semantics_at(&evaluator.period).ok_or_else(|| {
+                EvalError::MissingDerivedFormulaVersion {
+                    derived: output_name.clone(),
+                    at: evaluator.period.start,
+                }
+            })?;
+            match semantics {
                 DerivedSemantics::Scalar(_) => {
                     let column = evaluator.evaluate_scalar(&output_name)?;
                     outputs.insert(
@@ -288,7 +300,13 @@ impl<'a> BulkEvaluator<'a> {
     fn evaluate_scalar(&mut self, name: &str) -> Result<&ScalarColumn, EvalError> {
         if !self.scalar_cache.contains_key(name) {
             let derived = self.get_derived(name)?.clone();
-            let column = match &derived.semantics {
+            let semantics = derived.semantics_at(&self.period).ok_or_else(|| {
+                EvalError::MissingDerivedFormulaVersion {
+                    derived: name.to_string(),
+                    at: self.period.start,
+                }
+            })?;
+            let column = match semantics {
                 DerivedSemantics::Scalar(expr) => self.eval_scalar_expr(expr)?,
                 DerivedSemantics::Judgment(_) => {
                     return Err(EvalError::ExpectedScalar(name.to_string()));
@@ -302,7 +320,13 @@ impl<'a> BulkEvaluator<'a> {
     fn evaluate_judgment(&mut self, name: &str) -> Result<&Vec<JudgmentOutcome>, EvalError> {
         if !self.judgment_cache.contains_key(name) {
             let derived = self.get_derived(name)?.clone();
-            let column = match &derived.semantics {
+            let semantics = derived.semantics_at(&self.period).ok_or_else(|| {
+                EvalError::MissingDerivedFormulaVersion {
+                    derived: name.to_string(),
+                    at: self.period.start,
+                }
+            })?;
+            let column = match semantics {
                 DerivedSemantics::Judgment(expr) => self.eval_judgment_expr(expr)?,
                 DerivedSemantics::Scalar(_) => {
                     return Err(EvalError::ExpectedJudgment(name.to_string()));
@@ -667,9 +691,9 @@ impl<'a> BulkEvaluator<'a> {
                 compare_columns(left, *op, right)
             }
             JudgmentExpr::Derived(name) => Ok(self.evaluate_judgment(name)?.clone()),
-            JudgmentExpr::RelationMember { relation, .. } => Err(EvalError::TypeMismatch(
-                format!("fast mode cannot evaluate relation predicate `{relation}`"),
-            )),
+            JudgmentExpr::RelationMember { relation, .. } => Err(EvalError::TypeMismatch(format!(
+                "fast mode cannot evaluate relation predicate `{relation}`"
+            ))),
             JudgmentExpr::And(items) => {
                 let mut results = vec![JudgmentOutcome::Holds; self.entity_ids.len()];
                 for item in items {
@@ -736,8 +760,11 @@ impl<'a> BulkEvaluator<'a> {
 
         if let Some(derivation) = schema.derivation.clone() {
             let current_id = self.entity_ids[row_index].clone();
-            let source_rows =
-                self.related_rows(&derivation.source_relation, derivation.current_slot, row_index)?;
+            let source_rows = self.related_rows(
+                &derivation.source_relation,
+                derivation.current_slot,
+                row_index,
+            )?;
             for tuple in source_rows {
                 let Some(related_id) = tuple.get(derivation.related_slot) else {
                     continue;
@@ -807,16 +834,20 @@ impl<'a> BulkEvaluator<'a> {
                 } else {
                     related_id
                 };
-                match &derived.semantics {
-                    DerivedSemantics::Judgment(expr) => {
-                        self.eval_related_judgment_expr(
-                            expr,
-                            current_id,
-                            target_id,
-                            current_entity,
-                            related_entity,
-                        )
+                let semantics = derived.semantics_at(&self.period).ok_or_else(|| {
+                    EvalError::MissingDerivedFormulaVersion {
+                        derived: name.to_string(),
+                        at: self.period.start,
                     }
+                })?;
+                match semantics {
+                    DerivedSemantics::Judgment(expr) => self.eval_related_judgment_expr(
+                        expr,
+                        current_id,
+                        target_id,
+                        current_entity,
+                        related_entity,
+                    ),
                     DerivedSemantics::Scalar(_) => Err(EvalError::ExpectedJudgment(name.clone())),
                 }
             }
@@ -824,17 +855,19 @@ impl<'a> BulkEvaluator<'a> {
                 relation,
                 current_slot,
                 related_slot,
-            } => Ok(if self.relation_contains(
-                relation,
-                *current_slot,
-                *related_slot,
-                current_id,
-                related_id,
-            )? {
-                JudgmentOutcome::Holds
-            } else {
-                JudgmentOutcome::NotHolds
-            }),
+            } => Ok(
+                if self.relation_contains(
+                    relation,
+                    *current_slot,
+                    *related_slot,
+                    current_id,
+                    related_id,
+                )? {
+                    JudgmentOutcome::Holds
+                } else {
+                    JudgmentOutcome::NotHolds
+                },
+            ),
             JudgmentExpr::And(items) => {
                 let mut saw_undetermined = false;
                 for item in items {
@@ -877,19 +910,19 @@ impl<'a> BulkEvaluator<'a> {
                     JudgmentOutcome::NotHolds
                 })
             }
-            JudgmentExpr::Not(item) => {
-                Ok(match self.eval_related_judgment_expr(
+            JudgmentExpr::Not(item) => Ok(
+                match self.eval_related_judgment_expr(
                     item,
                     current_id,
                     related_id,
                     current_entity,
                     related_entity,
                 )? {
-                        JudgmentOutcome::Holds => JudgmentOutcome::NotHolds,
-                        JudgmentOutcome::NotHolds => JudgmentOutcome::Holds,
-                        JudgmentOutcome::Undetermined => JudgmentOutcome::Undetermined,
-                    })
-            }
+                    JudgmentOutcome::Holds => JudgmentOutcome::NotHolds,
+                    JudgmentOutcome::NotHolds => JudgmentOutcome::Holds,
+                    JudgmentOutcome::Undetermined => JudgmentOutcome::Undetermined,
+                },
+            ),
         }
     }
 
@@ -920,7 +953,13 @@ impl<'a> BulkEvaluator<'a> {
                 } else {
                     related_id
                 };
-                match &derived.semantics {
+                let semantics = derived.semantics_at(&self.period).ok_or_else(|| {
+                    EvalError::MissingDerivedFormulaVersion {
+                        derived: name.to_string(),
+                        at: self.period.start,
+                    }
+                })?;
+                match semantics {
                     DerivedSemantics::Scalar(expr) => self.eval_related_scalar_expr(
                         expr,
                         current_id,
@@ -943,7 +982,9 @@ impl<'a> BulkEvaluator<'a> {
                             related_entity,
                         )?
                         .as_decimal()
-                        .ok_or_else(|| EvalError::TypeMismatch("expected numeric scalar".to_string()))?;
+                        .ok_or_else(|| {
+                            EvalError::TypeMismatch("expected numeric scalar".to_string())
+                        })?;
                 }
                 Ok(ScalarValue::Decimal(total))
             }
@@ -955,8 +996,8 @@ impl<'a> BulkEvaluator<'a> {
                     current_entity,
                     related_entity,
                 )?
-                    .as_decimal()
-                    .ok_or_else(|| EvalError::TypeMismatch("expected numeric scalar".to_string()))?
+                .as_decimal()
+                .ok_or_else(|| EvalError::TypeMismatch("expected numeric scalar".to_string()))?
                     - self
                         .eval_related_scalar_expr(
                             right,
@@ -966,7 +1007,9 @@ impl<'a> BulkEvaluator<'a> {
                             related_entity,
                         )?
                         .as_decimal()
-                        .ok_or_else(|| EvalError::TypeMismatch("expected numeric scalar".to_string()))?,
+                        .ok_or_else(|| {
+                            EvalError::TypeMismatch("expected numeric scalar".to_string())
+                        })?,
             )),
             ScalarExpr::Mul(left, right) => Ok(ScalarValue::Decimal(
                 self.eval_related_scalar_expr(
@@ -976,8 +1019,8 @@ impl<'a> BulkEvaluator<'a> {
                     current_entity,
                     related_entity,
                 )?
-                    .as_decimal()
-                    .ok_or_else(|| EvalError::TypeMismatch("expected numeric scalar".to_string()))?
+                .as_decimal()
+                .ok_or_else(|| EvalError::TypeMismatch("expected numeric scalar".to_string()))?
                     * self
                         .eval_related_scalar_expr(
                             right,
@@ -987,7 +1030,9 @@ impl<'a> BulkEvaluator<'a> {
                             related_entity,
                         )?
                         .as_decimal()
-                        .ok_or_else(|| EvalError::TypeMismatch("expected numeric scalar".to_string()))?,
+                        .ok_or_else(|| {
+                            EvalError::TypeMismatch("expected numeric scalar".to_string())
+                        })?,
             )),
             ScalarExpr::Div(left, right) => {
                 let divisor = self
@@ -999,7 +1044,9 @@ impl<'a> BulkEvaluator<'a> {
                         related_entity,
                     )?
                     .as_decimal()
-                    .ok_or_else(|| EvalError::TypeMismatch("expected numeric scalar".to_string()))?;
+                    .ok_or_else(|| {
+                        EvalError::TypeMismatch("expected numeric scalar".to_string())
+                    })?;
                 if divisor.is_zero() {
                     return Err(EvalError::DivisionByZero);
                 }
@@ -1011,17 +1058,18 @@ impl<'a> BulkEvaluator<'a> {
                         current_entity,
                         related_entity,
                     )?
-                        .as_decimal()
-                        .ok_or_else(|| EvalError::TypeMismatch("expected numeric scalar".to_string()))?
-                        / divisor,
+                    .as_decimal()
+                    .ok_or_else(|| {
+                        EvalError::TypeMismatch("expected numeric scalar".to_string())
+                    })? / divisor,
                 ))
             }
-            ScalarExpr::Max(_) | ScalarExpr::Min(_) | ScalarExpr::ParameterLookup { .. } => Err(
-                EvalError::TypeMismatch(
+            ScalarExpr::Max(_) | ScalarExpr::Min(_) | ScalarExpr::ParameterLookup { .. } => {
+                Err(EvalError::TypeMismatch(
                     "bulk fast mode does not yet support this related scalar expression"
                         .to_string(),
-                ),
-            ),
+                ))
+            }
             ScalarExpr::Ceil(value) => Ok(ScalarValue::Decimal(
                 self.eval_related_scalar_expr(
                     value,
@@ -1030,9 +1078,9 @@ impl<'a> BulkEvaluator<'a> {
                     current_entity,
                     related_entity,
                 )?
-                    .as_decimal()
-                    .ok_or_else(|| EvalError::TypeMismatch("expected numeric scalar".to_string()))?
-                    .ceil(),
+                .as_decimal()
+                .ok_or_else(|| EvalError::TypeMismatch("expected numeric scalar".to_string()))?
+                .ceil(),
             )),
             ScalarExpr::Floor(value) => Ok(ScalarValue::Decimal(
                 self.eval_related_scalar_expr(
@@ -1042,9 +1090,9 @@ impl<'a> BulkEvaluator<'a> {
                     current_entity,
                     related_entity,
                 )?
-                    .as_decimal()
-                    .ok_or_else(|| EvalError::TypeMismatch("expected numeric scalar".to_string()))?
-                    .floor(),
+                .as_decimal()
+                .ok_or_else(|| EvalError::TypeMismatch("expected numeric scalar".to_string()))?
+                .floor(),
             )),
             ScalarExpr::PeriodStart => Ok(ScalarValue::Date(self.period.start)),
             ScalarExpr::PeriodEnd => Ok(ScalarValue::Date(self.period.end)),
@@ -1093,7 +1141,11 @@ impl<'a> BulkEvaluator<'a> {
         Ok(self
             .related_rows(relation, current_slot, row_index)?
             .iter()
-            .any(|tuple| tuple.get(related_slot).is_some_and(|candidate| candidate == related_id)))
+            .any(|tuple| {
+                tuple
+                    .get(related_slot)
+                    .is_some_and(|candidate| candidate == related_id)
+            }))
     }
 }
 

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -146,12 +146,13 @@ impl CompiledProgramArtifact {
         root_target: &str,
         source: &dyn crate::source::ModuleSource,
     ) -> Result<Self, CompileError> {
-        let program = crate::rulespec::load_rulespec_with_source(root_target, source).map_err(
-            |error| CompileError::RuleSpec {
-                path: root_target.to_string(),
-                error,
-            },
-        )?;
+        let program =
+            crate::rulespec::load_rulespec_with_source(root_target, source).map_err(|error| {
+                CompileError::RuleSpec {
+                    path: root_target.to_string(),
+                    error,
+                }
+            })?;
         Self::compile(program)
     }
 
@@ -289,6 +290,9 @@ fn fast_path_metadata(program: &ProgramSpec) -> FastPathMetadata {
     let mut blockers = Vec::new();
     for derived in &program.derived {
         collect_fast_blockers_from_semantics(&derived.name, &derived.semantics, &mut blockers);
+        for version in &derived.versions {
+            collect_fast_blockers_from_semantics(&derived.name, &version.semantics, &mut blockers);
+        }
     }
 
     FastPathMetadata {
@@ -501,6 +505,16 @@ fn derived_dependencies(
         }
         DerivedSemanticsSpec::Judgment { expr } => {
             collect_judgment_dependencies(expr, &mut dependencies, relation_dependencies);
+        }
+    }
+    for version in &derived.versions {
+        match &version.semantics {
+            DerivedSemanticsSpec::Scalar { expr } => {
+                collect_scalar_dependencies(expr, &mut dependencies, relation_dependencies);
+            }
+            DerivedSemanticsSpec::Judgment { expr } => {
+                collect_judgment_dependencies(expr, &mut dependencies, relation_dependencies);
+            }
         }
     }
     dependencies

--- a/src/dense.rs
+++ b/src/dense.rs
@@ -1,15 +1,14 @@
 use std::collections::{HashMap, HashSet};
 
-use rust_decimal::Decimal;
 use rust_decimal::prelude::{FromPrimitive, ToPrimitive};
+use rust_decimal::Decimal;
 use thiserror::Error;
 
 use crate::compile::CompiledProgramArtifact;
 use crate::engine::EvalError;
 use crate::model::{
-    SCALAR_ENTITY,
     ComparisonOp, DType, DerivedSemantics, IndexedParameter, JudgmentExpr, JudgmentOutcome, Period,
-    Program, RelatedValueRef, ScalarExpr, ScalarValue,
+    Program, RelatedValueRef, ScalarExpr, ScalarValue, SCALAR_ENTITY,
 };
 
 #[derive(Clone, Debug)]
@@ -192,9 +191,7 @@ impl DenseNum for f64 {
 
     fn vec_from_column(column: &DenseColumn) -> Result<Vec<Self>, EvalError> {
         match column {
-            DenseColumn::Integer(values) => {
-                Ok(values.iter().map(|value| *value as f64).collect())
-            }
+            DenseColumn::Integer(values) => Ok(values.iter().map(|value| *value as f64).collect()),
             DenseColumn::Decimal(values) => Ok(values
                 .iter()
                 .map(|value| value.to_f64().unwrap_or(f64::NAN))
@@ -750,6 +747,11 @@ impl<'a> DenseCompiler<'a> {
             self.program.derived.get(name).ok_or_else(|| {
                 DenseCompileError::Unsupported(format!("unknown derived `{name}`"))
             })?;
+        if !derived.versions.is_empty() {
+            return Err(DenseCompileError::Unsupported(format!(
+                "versioned derived formulas in `{name}`; use generic API execution"
+            )));
+        }
         if derived.entity != self.root_entity && derived.entity != SCALAR_ENTITY {
             return Err(DenseCompileError::CrossEntityDependency {
                 derived: name.to_string(),
@@ -886,8 +888,10 @@ impl<'a> DenseCompiler<'a> {
                         let input_index = self.related_input(relation_index, name, false);
                         CompiledRelatedScalarExpr::Input(input_index)
                     }
-                    RelatedValueRef::Derived(name) => self
-                        .compile_related_scalar(relation_index, &ScalarExpr::Derived(name.clone()))?,
+                    RelatedValueRef::Derived(name) => self.compile_related_scalar(
+                        relation_index,
+                        &ScalarExpr::Derived(name.clone()),
+                    )?,
                 };
                 let predicate = where_clause
                     .as_deref()
@@ -937,11 +941,9 @@ impl<'a> DenseCompiler<'a> {
                 }
                 Ok(CompiledJudgmentExpr::Derived(self.compile_derived(name)?))
             }
-            JudgmentExpr::RelationMember { relation, .. } => {
-                Err(DenseCompileError::Unsupported(format!(
-                    "relation predicate `{relation}`"
-                )))
-            }
+            JudgmentExpr::RelationMember { relation, .. } => Err(DenseCompileError::Unsupported(
+                format!("relation predicate `{relation}`"),
+            )),
             JudgmentExpr::And(items) => Ok(CompiledJudgmentExpr::And(
                 items
                     .iter()
@@ -1198,12 +1200,16 @@ impl<'a> DenseCompiler<'a> {
                     ))),
                 }
             }
-            ScalarExpr::ParameterLookup { parameter, index } => Ok(
-                CompiledScalarExpr::ParameterLookup {
+            ScalarExpr::ParameterLookup { parameter, index } => {
+                Ok(CompiledScalarExpr::ParameterLookup {
                     parameter: self.parameter(parameter)?,
-                    index: Box::new(self.compile_current_scalar_expr(derived_name, entity, index)?),
-                },
-            ),
+                    index: Box::new(self.compile_current_scalar_expr(
+                        derived_name,
+                        entity,
+                        index,
+                    )?),
+                })
+            }
             ScalarExpr::Add(items) => Ok(CompiledScalarExpr::Add(
                 items
                     .iter()
@@ -1271,12 +1277,12 @@ impl<'a> DenseCompiler<'a> {
                     else_expr,
                 )?),
             }),
-            ScalarExpr::CountRelated { .. } | ScalarExpr::SumRelated { .. } => Err(
-                DenseCompileError::Unsupported(
+            ScalarExpr::CountRelated { .. } | ScalarExpr::SumRelated { .. } => {
+                Err(DenseCompileError::Unsupported(
                     "current-entity derived relation predicates cannot aggregate another relation"
                         .to_string(),
-                ),
-            ),
+                ))
+            }
         }
     }
 
@@ -1833,7 +1839,8 @@ impl<'a, N: DenseNum> DenseExecutor<'a, N> {
             CompiledRelatedScalarExpr::Literal(value) => {
                 Ok(broadcast_scalar_literal::<N>(value, length))
             }
-            CompiledRelatedScalarExpr::Input(index) => self.batch.relations[relation].inputs[*index]
+            CompiledRelatedScalarExpr::Input(index) => self.batch.relations[relation].inputs
+                [*index]
                 .clone()
                 .ok_or_else(|| EvalError::MissingInput {
                     name: format!("related_input[{index}]"),
@@ -1954,7 +1961,9 @@ impl<'a, N: DenseNum> DenseExecutor<'a, N> {
             }
             CompiledRelatedScalarExpr::DateAddDays { date, days } => {
                 let base = self.resolve_related_scalar(relation, date)?.as_date_vec()?;
-                let offset = self.resolve_related_scalar(relation, days)?.as_index_vec()?;
+                let offset = self
+                    .resolve_related_scalar(relation, days)?
+                    .as_index_vec()?;
                 Ok(DenseColumn::Date(
                     base.into_iter()
                         .zip(offset)

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -33,6 +33,11 @@ pub enum EvalError {
         key: i64,
         at: chrono::NaiveDate,
     },
+    #[error("derived `{derived}` has no formula version at {at}")]
+    MissingDerivedFormulaVersion {
+        derived: String,
+        at: chrono::NaiveDate,
+    },
     #[error("derived `{0}` is scalar, but a judgment was requested")]
     ExpectedJudgment(String),
     #[error("derived `{0}` is judgment, but a scalar was requested")]
@@ -129,7 +134,13 @@ impl<'a> Engine<'a> {
 
         let derived = self.get_derived(derived_name)?.clone();
         self.validate_unit(&derived)?;
-        let value = match &derived.semantics {
+        let semantics = derived.semantics_at(period).ok_or_else(|| {
+            EvalError::MissingDerivedFormulaVersion {
+                derived: derived_name.to_string(),
+                at: period.start,
+            }
+        })?;
+        let value = match semantics {
             DerivedSemantics::Scalar(expr) => self.eval_scalar_expr(expr, entity_id, period)?,
             DerivedSemantics::Judgment(_) => {
                 return Err(EvalError::ExpectedScalar(derived_name.to_string()));
@@ -156,7 +167,13 @@ impl<'a> Engine<'a> {
 
         let derived = self.get_derived(derived_name)?.clone();
         self.validate_unit(&derived)?;
-        let value = match &derived.semantics {
+        let semantics = derived.semantics_at(period).ok_or_else(|| {
+            EvalError::MissingDerivedFormulaVersion {
+                derived: derived_name.to_string(),
+                at: period.start,
+            }
+        })?;
+        let value = match semantics {
             DerivedSemantics::Judgment(expr) => self.eval_judgment_expr(expr, entity_id, period)?,
             DerivedSemantics::Scalar(_) => {
                 return Err(EvalError::ExpectedJudgment(derived_name.to_string()));
@@ -474,7 +491,12 @@ impl<'a> Engine<'a> {
             JudgmentExpr::And(items) => {
                 let mut saw_undetermined = false;
                 for item in items {
-                    match self.eval_judgment_expr_inner(item, entity_id, period, relation_context)? {
+                    match self.eval_judgment_expr_inner(
+                        item,
+                        entity_id,
+                        period,
+                        relation_context,
+                    )? {
                         JudgmentOutcome::Holds => {}
                         JudgmentOutcome::NotHolds => return Ok(JudgmentOutcome::NotHolds),
                         JudgmentOutcome::Undetermined => saw_undetermined = true,
@@ -489,7 +511,12 @@ impl<'a> Engine<'a> {
             JudgmentExpr::Or(items) => {
                 let mut saw_undetermined = false;
                 for item in items {
-                    match self.eval_judgment_expr_inner(item, entity_id, period, relation_context)? {
+                    match self.eval_judgment_expr_inner(
+                        item,
+                        entity_id,
+                        period,
+                        relation_context,
+                    )? {
                         JudgmentOutcome::Holds => return Ok(JudgmentOutcome::Holds),
                         JudgmentOutcome::NotHolds => {}
                         JudgmentOutcome::Undetermined => saw_undetermined = true,
@@ -501,13 +528,13 @@ impl<'a> Engine<'a> {
                     JudgmentOutcome::NotHolds
                 })
             }
-            JudgmentExpr::Not(item) => {
-                Ok(match self.eval_judgment_expr_inner(item, entity_id, period, relation_context)? {
+            JudgmentExpr::Not(item) => Ok(
+                match self.eval_judgment_expr_inner(item, entity_id, period, relation_context)? {
                     JudgmentOutcome::Holds => JudgmentOutcome::NotHolds,
                     JudgmentOutcome::NotHolds => JudgmentOutcome::Holds,
                     JudgmentOutcome::Undetermined => JudgmentOutcome::Undetermined,
-                })
-            }
+                },
+            ),
         }
     }
 
@@ -630,8 +657,14 @@ impl<'a> Engine<'a> {
                 let context = RelationEvalContext {
                     current_id: entity_id,
                     related_id: &related_id,
-                    current_entity: derivation.slot_entities.get(derivation.current_slot).map(String::as_str),
-                    related_entity: derivation.slot_entities.get(derivation.related_slot).map(String::as_str),
+                    current_entity: derivation
+                        .slot_entities
+                        .get(derivation.current_slot)
+                        .map(String::as_str),
+                    related_entity: derivation
+                        .slot_entities
+                        .get(derivation.related_slot)
+                        .map(String::as_str),
                 };
                 if self
                     .eval_judgment_expr_inner(

--- a/src/formula.rs
+++ b/src/formula.rs
@@ -22,9 +22,9 @@ use std::str::FromStr;
 use thiserror::Error;
 
 use crate::spec::{
-    ComparisonOpSpec, DTypeSpec, DerivedSemanticsSpec, DerivedSpec, IndexedParameterSpec,
-    JudgmentExprSpec, ParameterVersionSpec, ProgramSpec, RelatedValueRefSpec, RelationSpec,
-    ScalarExprSpec, ScalarValueSpec, UnitKindSpec, UnitSpec,
+    ComparisonOpSpec, DTypeSpec, DerivedSemanticsSpec, DerivedSpec, DerivedVersionSpec,
+    IndexedParameterSpec, JudgmentExprSpec, ParameterVersionSpec, ProgramSpec, RelatedValueRefSpec,
+    RelationSpec, ScalarExprSpec, ScalarValueSpec, UnitKindSpec, UnitSpec,
 };
 
 #[derive(Debug, Error)]
@@ -1084,9 +1084,8 @@ pub fn parse_source(src: &str) -> Result<Module, FormulaError> {
 ///   literal lowers to a scalar `Parameter` keyed at index 0 (or at integer
 ///   keys if the literal is an integer-keyed table once indexed_by support
 ///   lands).
-/// - A `VariableDecl` with an `entity` lowers to a `Derived` output. Derived
-///   formulas must currently have a single temporal value; versioned derived
-///   lowering is not supported until execution can select formulas by period.
+/// - A `VariableDecl` with an `entity` lowers to a `Derived` output. Versioned
+///   derived formulas lower to dated derived versions selected by query period.
 /// - Non-literal scalar variables (with no entity but a computed expression)
 ///   lower to derived outputs attached to a synthetic `Scalar` entity so
 ///   they can be referenced from entity-scoped derived values.
@@ -1159,7 +1158,9 @@ pub fn lower_module(module: &Module) -> Result<ProgramSpec, FormulaError> {
         });
     }
 
-    // Second pass: derived outputs. Pick the latest temporal value's expr.
+    // Second pass: derived outputs. Single-version derived outputs use the
+    // historical semantics field; multi-version outputs also carry dated
+    // semantics for runtime period selection.
     let ctx = LowerCtx {
         scalars: scalar_names,
         derived: derived_names,
@@ -1170,12 +1171,6 @@ pub fn lower_module(module: &Module) -> Result<ProgramSpec, FormulaError> {
         if v.entity.is_none() && v.values.iter().all(|t| is_literal_expr(&t.expr)) {
             continue;
         }
-        if v.values.len() > 1 {
-            return Err(FormulaError::lower(format!(
-                "derived variable `{}` has multiple formula versions; versioned derived formulas are not supported yet",
-                v.path
-            )));
-        }
         let dtype = parse_dtype(v.dtype.as_deref());
         let entity = v
             .entity
@@ -1184,18 +1179,35 @@ pub fn lower_module(module: &Module) -> Result<ProgramSpec, FormulaError> {
         let last = v.values.last().ok_or_else(|| {
             FormulaError::lower(format!("variable `{}` has no temporal values", v.path))
         })?;
-        let semantics = match dtype {
-            DTypeSpec::Judgment => DerivedSemanticsSpec::Judgment {
-                expr: lower_to_judgment(&last.expr, &ctx)?,
-            },
-            DTypeSpec::Decimal => {
-                let mut expr = lower_to_scalar(&last.expr, &ctx)?;
-                promote_ints_to_decimal(&mut expr);
-                DerivedSemanticsSpec::Scalar { expr }
-            }
-            _ => DerivedSemanticsSpec::Scalar {
-                expr: lower_to_scalar(&last.expr, &ctx)?,
-            },
+        let lower_semantics =
+            |expr: &Expr, dtype: &DTypeSpec| -> Result<DerivedSemanticsSpec, FormulaError> {
+                match dtype {
+                    DTypeSpec::Judgment => Ok(DerivedSemanticsSpec::Judgment {
+                        expr: lower_to_judgment(expr, &ctx)?,
+                    }),
+                    DTypeSpec::Decimal => {
+                        let mut expr = lower_to_scalar(expr, &ctx)?;
+                        promote_ints_to_decimal(&mut expr);
+                        Ok(DerivedSemanticsSpec::Scalar { expr })
+                    }
+                    _ => Ok(DerivedSemanticsSpec::Scalar {
+                        expr: lower_to_scalar(expr, &ctx)?,
+                    }),
+                }
+            };
+        let semantics = lower_semantics(&last.expr, &dtype)?;
+        let versions = if v.values.len() > 1 {
+            v.values
+                .iter()
+                .map(|value| {
+                    Ok(DerivedVersionSpec {
+                        effective_from: value.start,
+                        semantics: lower_semantics(&value.expr, &dtype)?,
+                    })
+                })
+                .collect::<Result<Vec<DerivedVersionSpec>, FormulaError>>()?
+        } else {
+            Vec::new()
         };
         program.derived.push(DerivedSpec {
             id: None,
@@ -1207,6 +1219,7 @@ pub fn lower_module(module: &Module) -> Result<ProgramSpec, FormulaError> {
             source: v.source.clone(),
             source_url: v.source_url.clone(),
             semantics,
+            versions,
         });
     }
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -268,6 +268,12 @@ pub enum DerivedSemantics {
 }
 
 #[derive(Clone, Debug)]
+pub struct DerivedVersion {
+    pub effective_from: NaiveDate,
+    pub semantics: DerivedSemantics,
+}
+
+#[derive(Clone, Debug)]
 pub struct Derived {
     pub id: Option<String>,
     pub name: String,
@@ -277,6 +283,20 @@ pub struct Derived {
     pub source: Option<String>,
     pub source_url: Option<String>,
     pub semantics: DerivedSemantics,
+    pub versions: Vec<DerivedVersion>,
+}
+
+impl Derived {
+    pub fn semantics_at(&self, period: &Period) -> Option<&DerivedSemantics> {
+        if self.versions.is_empty() {
+            return Some(&self.semantics);
+        }
+        self.versions
+            .iter()
+            .filter(|version| version.effective_from <= period.start)
+            .max_by_key(|version| version.effective_from)
+            .map(|version| &version.semantics)
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -444,6 +464,9 @@ impl Program {
         let mut slots = HashSet::new();
         for derived in self.derived.values() {
             collect_input_slots_from_semantics(&derived.semantics, &mut slots);
+            for version in &derived.versions {
+                collect_input_slots_from_semantics(&version.semantics, &mut slots);
+            }
         }
         for parameter in self.parameters.values() {
             if let Some(indexed_by) = parameter.indexed_by.as_deref() {

--- a/src/rulespec.rs
+++ b/src/rulespec.rs
@@ -165,7 +165,9 @@ pub enum RuleSpecError {
         target: String,
         value: String,
     },
-    #[error("RuleSpec relation `{name}` is declared with conflicting arities {existing} and {new}")]
+    #[error(
+        "RuleSpec relation `{name}` is declared with conflicting arities {existing} and {new}"
+    )]
     RelationArityConflict {
         name: String,
         existing: usize,
@@ -1786,6 +1788,7 @@ fn apply_source_relation_sets(
                 }
 
                 target_derived.semantics = value_derived.semantics;
+                target_derived.versions = value_derived.versions;
             }
         }
     }
@@ -1862,6 +1865,16 @@ fn rewrite_filtered_entity_member_aliases(program: &mut ProgramSpec) {
                 }
                 DerivedSemanticsSpec::Judgment { expr } => {
                     rewrite_relation_alias_in_judgment(expr, alias, relation_name);
+                }
+            }
+            for version in &mut derived.versions {
+                match &mut version.semantics {
+                    DerivedSemanticsSpec::Scalar { expr } => {
+                        rewrite_relation_alias_in_scalar(expr, alias, relation_name);
+                    }
+                    DerivedSemanticsSpec::Judgment { expr } => {
+                        rewrite_relation_alias_in_judgment(expr, alias, relation_name);
+                    }
                 }
             }
         }
@@ -2040,6 +2053,28 @@ fn rewrite_relation_references(
                 );
             }
         }
+        for version in &mut derived.versions {
+            match &mut version.semantics {
+                DerivedSemanticsSpec::Scalar { expr } => {
+                    rewrite_scalar_relation_references(
+                        expr,
+                        origin_target,
+                        rewrites,
+                        &unambiguous_short_rewrites,
+                        &derived_origin_targets,
+                    );
+                }
+                DerivedSemanticsSpec::Judgment { expr } => {
+                    rewrite_judgment_relation_references(
+                        expr,
+                        origin_target,
+                        rewrites,
+                        &unambiguous_short_rewrites,
+                        &derived_origin_targets,
+                    );
+                }
+            }
+        }
     }
     for relation in &mut program.relations {
         let Some(origin_target) = relation
@@ -2125,6 +2160,16 @@ fn used_relation_names(program: &ProgramSpec) -> HashSet<String> {
             }
             DerivedSemanticsSpec::Judgment { expr } => {
                 collect_judgment_relation_names(expr, &mut names);
+            }
+        }
+        for version in &derived.versions {
+            match &version.semantics {
+                DerivedSemanticsSpec::Scalar { expr } => {
+                    collect_scalar_relation_names(expr, &mut names);
+                }
+                DerivedSemanticsSpec::Judgment { expr } => {
+                    collect_judgment_relation_names(expr, &mut names);
+                }
             }
         }
     }

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -7,10 +7,10 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use crate::model::{
-    ComparisonOp, DType, DataSet, Derived, DerivedSemantics, IndexedParameter, InputRecord,
-    Interval, JudgmentExpr, JudgmentOutcome, ParameterVersion, Period, PeriodKind, Program,
-    RelatedValueRef, RelationDerivation, RelationRecord, RelationSchema, ScalarExpr, ScalarValue,
-    UnitDef, UnitKind,
+    ComparisonOp, DType, DataSet, Derived, DerivedSemantics, DerivedVersion, IndexedParameter,
+    InputRecord, Interval, JudgmentExpr, JudgmentOutcome, ParameterVersion, Period, PeriodKind,
+    Program, RelatedValueRef, RelationDerivation, RelationRecord, RelationSchema, ScalarExpr,
+    ScalarValue, UnitDef, UnitKind,
 };
 
 #[derive(Debug, Error)]
@@ -299,6 +299,8 @@ pub struct DerivedSpec {
     pub source_url: Option<String>,
     #[serde(flatten)]
     pub semantics: DerivedSemanticsSpec,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub versions: Vec<DerivedVersionSpec>,
 }
 
 impl DerivedSpec {
@@ -311,6 +313,27 @@ impl DerivedSpec {
             unit: self.unit.clone(),
             source: self.source.clone(),
             source_url: self.source_url.clone(),
+            semantics: self.semantics.to_model()?,
+            versions: self
+                .versions
+                .iter()
+                .map(DerivedVersionSpec::to_model)
+                .collect::<Result<Vec<DerivedVersion>, SpecError>>()?,
+        })
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct DerivedVersionSpec {
+    pub effective_from: NaiveDate,
+    #[serde(flatten)]
+    pub semantics: DerivedSemanticsSpec,
+}
+
+impl DerivedVersionSpec {
+    fn to_model(&self) -> Result<DerivedVersion, SpecError> {
+        Ok(DerivedVersion {
+            effective_from: self.effective_from,
             semantics: self.semantics.to_model()?,
         })
     }

--- a/tests/dense.rs
+++ b/tests/dense.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::str::FromStr;
 
 use axiom_rules_engine::api::{
-    ExecutionMode, ExecutionQuery, ExecutionRequest, OutputValue, execute_request,
+    execute_request, ExecutionMode, ExecutionQuery, ExecutionRequest, OutputValue,
 };
 use axiom_rules_engine::compile::CompiledProgramArtifact;
 use axiom_rules_engine::dense::{
@@ -556,7 +556,9 @@ fn dense_sum_related_over_derived_matches_explain_mode() {
                 entity: "Person".to_string(),
                 entity_id: (*child_id).to_string(),
                 interval: interval.clone(),
-                value: ScalarValueSpec::Bool { value: *is_eligible },
+                value: ScalarValueSpec::Bool {
+                    value: *is_eligible,
+                },
             });
             dataset.relations.push(RelationRecordSpec {
                 name: "member_of_family".to_string(),
@@ -643,8 +645,10 @@ fn dense_sum_related_over_derived_matches_explain_mode() {
 
     // The award values are deterministic, so also pin them down exactly
     // rather than relying solely on explain-mode agreement.
-    let DenseOutputValue::Scalar(DenseColumn::Decimal(awards)) =
-        dense_result.outputs.get("family_weekly_award").expect("dense award")
+    let DenseOutputValue::Scalar(DenseColumn::Decimal(awards)) = dense_result
+        .outputs
+        .get("family_weekly_award")
+        .expect("dense award")
     else {
         panic!("expected decimal award column");
     };
@@ -728,10 +732,7 @@ fn dense_filtered_entity_scope_matches_explain_mode() {
                 assessment_date: None,
                 entity_id: entity_id.to_string(),
                 period: period.clone(),
-                outputs: vec![
-                    "snap_unit_size".to_string(),
-                    "snap_unit_income".to_string(),
-                ],
+                outputs: vec!["snap_unit_size".to_string(), "snap_unit_income".to_string()],
             })
             .collect(),
     })
@@ -1016,10 +1017,7 @@ fn dense_filtered_entities_can_compose_source_relations() {
                                 "has_ssn".to_string(),
                                 DenseColumn::Bool(vec![true, true, false]),
                             ),
-                            (
-                                "age".to_string(),
-                                DenseColumn::Integer(vec![30, 12, 40]),
-                            ),
+                            ("age".to_string(), DenseColumn::Integer(vec![30, 12, 40])),
                         ]),
                     },
                 )]),
@@ -2718,6 +2716,7 @@ fn dense_date_add_days_matches_explain_mode() {
                 }),
             },
         },
+        versions: vec![],
     });
     program.derived.push(DerivedSpec {
         id: None,
@@ -2739,6 +2738,7 @@ fn dense_date_add_days_matches_explain_mode() {
                 }),
             },
         },
+        versions: vec![],
     });
 
     let artifact = CompiledProgramArtifact::compile(program).expect("RuleSpec module compiles");
@@ -3356,8 +3356,10 @@ fn dense_broadcasts_scalar_entity_formula_parameters() {
         )
         .expect("dense execution succeeds");
 
-    let DenseOutputValue::Scalar(DenseColumn::Decimal(values)) =
-        result.outputs.get("tapered_amount").expect("output present")
+    let DenseOutputValue::Scalar(DenseColumn::Decimal(values)) = result
+        .outputs
+        .get("tapered_amount")
+        .expect("output present")
     else {
         panic!("expected decimal output");
     };
@@ -3398,8 +3400,10 @@ rules:
         )
         .expect("dense execution succeeds");
 
-    let DenseOutputValue::Scalar(DenseColumn::Decimal(values)) =
-        result.outputs.get("taper_fraction").expect("output present")
+    let DenseOutputValue::Scalar(DenseColumn::Decimal(values)) = result
+        .outputs
+        .get("taper_fraction")
+        .expect("output present")
     else {
         panic!("expected decimal output");
     };

--- a/tests/execution.rs
+++ b/tests/execution.rs
@@ -3,14 +3,15 @@ use std::process::{Command, Stdio};
 use std::str::FromStr;
 
 use axiom_rules_engine::api::{
-    CompiledExecutionRequest, ExecutionMode, ExecutionQuery, ExecutionRequest, ExecutionResponse,
-    OutputValue, execute_compiled_request, execute_request,
+    execute_compiled_request, execute_request, CompiledExecutionRequest, ExecutionMode,
+    ExecutionQuery, ExecutionRequest, ExecutionResponse, OutputValue,
 };
 use axiom_rules_engine::compile::CompiledProgramArtifact;
 use axiom_rules_engine::spec::{
-    ComparisonOpSpec, DTypeSpec, DatasetSpec, DerivedSemanticsSpec, DerivedSpec, InputRecordSpec,
-    IntervalSpec, JudgmentOutcomeSpec, PeriodKindSpec, PeriodSpec, ProgramSpec,
-    RelatedValueRefSpec, RelationRecordSpec, ScalarExprSpec, ScalarValueSpec,
+    ComparisonOpSpec, DTypeSpec, DatasetSpec, DerivedSemanticsSpec, DerivedSpec,
+    DerivedVersionSpec, InputRecordSpec, IntervalSpec, JudgmentOutcomeSpec, PeriodKindSpec,
+    PeriodSpec, ProgramSpec, RelatedValueRefSpec, RelationRecordSpec, ScalarExprSpec,
+    ScalarValueSpec,
 };
 use rust_decimal::Decimal;
 
@@ -182,6 +183,7 @@ fn fast_mode_coerces_integer_and_decimal_if_branches() {
                     }),
                 },
             },
+            versions: vec![],
         }],
         ..ProgramSpec::default()
     };
@@ -244,6 +246,114 @@ fn fast_mode_coerces_integer_and_decimal_if_branches() {
 }
 
 #[test]
+fn derived_formula_versions_select_by_query_period() {
+    let false_semantics = DerivedSemanticsSpec::Judgment {
+        expr: axiom_rules_engine::spec::JudgmentExprSpec::Comparison {
+            left: Box::new(ScalarExprSpec::Literal {
+                value: ScalarValueSpec::Integer { value: 0 },
+            }),
+            op: ComparisonOpSpec::Eq,
+            right: Box::new(ScalarExprSpec::Literal {
+                value: ScalarValueSpec::Integer { value: 1 },
+            }),
+        },
+    };
+    let true_semantics = DerivedSemanticsSpec::Judgment {
+        expr: axiom_rules_engine::spec::JudgmentExprSpec::Comparison {
+            left: Box::new(ScalarExprSpec::Literal {
+                value: ScalarValueSpec::Integer { value: 1 },
+            }),
+            op: ComparisonOpSpec::Eq,
+            right: Box::new(ScalarExprSpec::Literal {
+                value: ScalarValueSpec::Integer { value: 1 },
+            }),
+        },
+    };
+    let program = ProgramSpec {
+        derived: vec![DerivedSpec {
+            id: None,
+            name: "eligible".to_string(),
+            entity: "Person".to_string(),
+            dtype: DTypeSpec::Judgment,
+            unit: None,
+            source: None,
+            period: None,
+            source_url: None,
+            semantics: true_semantics.clone(),
+            versions: vec![
+                DerivedVersionSpec {
+                    effective_from: chrono::NaiveDate::from_ymd_opt(2024, 1, 1)
+                        .expect("valid date"),
+                    semantics: false_semantics,
+                },
+                DerivedVersionSpec {
+                    effective_from: chrono::NaiveDate::from_ymd_opt(2026, 1, 1)
+                        .expect("valid date"),
+                    semantics: true_semantics,
+                },
+            ],
+        }],
+        ..ProgramSpec::default()
+    };
+    let period_2024 = PeriodSpec {
+        kind: PeriodKindSpec::Month,
+        start: chrono::NaiveDate::from_ymd_opt(2024, 1, 1).expect("valid date"),
+        end: chrono::NaiveDate::from_ymd_opt(2024, 1, 31).expect("valid date"),
+    };
+    let period_2026 = PeriodSpec {
+        kind: PeriodKindSpec::Month,
+        start: chrono::NaiveDate::from_ymd_opt(2026, 1, 1).expect("valid date"),
+        end: chrono::NaiveDate::from_ymd_opt(2026, 1, 31).expect("valid date"),
+    };
+
+    let response_2024 = execute_request(ExecutionRequest {
+        mode: ExecutionMode::Fast,
+        program: program.clone(),
+        dataset: DatasetSpec::default(),
+        queries: vec![ExecutionQuery {
+            assessment_date: None,
+            entity_id: "person-1".to_string(),
+            period: period_2024,
+            outputs: vec!["eligible".to_string()],
+        }],
+    })
+    .expect("2024 versioned derived formula request succeeds");
+    let response_2026 = execute_request(ExecutionRequest {
+        mode: ExecutionMode::Fast,
+        program,
+        dataset: DatasetSpec::default(),
+        queries: vec![ExecutionQuery {
+            assessment_date: None,
+            entity_id: "person-1".to_string(),
+            period: period_2026,
+            outputs: vec!["eligible".to_string()],
+        }],
+    })
+    .expect("2026 versioned derived formula request succeeds");
+
+    assert_eq!(response_2024.metadata.actual_mode, ExecutionMode::Fast);
+    assert_eq!(response_2026.metadata.actual_mode, ExecutionMode::Fast);
+    assert_eq!(
+        judgment_output(
+            response_2024.results[0]
+                .outputs
+                .get("eligible")
+                .expect("2024 output")
+        ),
+        JudgmentOutcomeSpec::NotHolds
+    );
+    assert_eq!(
+        judgment_output(
+            response_2026.results[0]
+                .outputs
+                .get("eligible")
+                .expect("2026 output")
+        ),
+        JudgmentOutcomeSpec::Holds
+    );
+}
+
+#[test]
 fn fast_mode_falls_back_to_explain_when_bulk_support_is_missing() {
     let period = PeriodSpec {
         kind: PeriodKindSpec::Month,
@@ -275,6 +385,7 @@ fn fast_mode_falls_back_to_explain_when_bulk_support_is_missing() {
                         name: "income".to_string(),
                     },
                 },
+                versions: vec![],
             },
             DerivedSpec {
                 id: None,
@@ -296,6 +407,7 @@ fn fast_mode_falls_back_to_explain_when_bulk_support_is_missing() {
                         where_clause: None,
                     },
                 },
+                versions: vec![],
             },
         ],
         ..ProgramSpec::default()
@@ -419,6 +531,7 @@ fn fast_mode_falls_back_for_filtered_relation_counts() {
                     }),
                 },
             },
+            versions: vec![],
         }],
         ..ProgramSpec::default()
     };
@@ -577,10 +690,7 @@ rules:
             assessment_date: None,
             entity_id: "household-1".to_string(),
             period,
-            outputs: vec![
-                "snap_unit_size".to_string(),
-                "snap_unit_income".to_string(),
-            ],
+            outputs: vec!["snap_unit_size".to_string(), "snap_unit_income".to_string()],
         }],
     })
     .expect("request succeeds");
@@ -724,10 +834,7 @@ rules:
             assessment_date: None,
             entity_id: "household-1".to_string(),
             period,
-            outputs: vec![
-                "snap_unit_size".to_string(),
-                "snap_unit_income".to_string(),
-            ],
+            outputs: vec!["snap_unit_size".to_string(), "snap_unit_income".to_string()],
         }],
     })
     .expect("filtered entity request succeeds");

--- a/tests/rulespec.rs
+++ b/tests/rulespec.rs
@@ -1,10 +1,10 @@
 use axiom_rules_engine::api::{
-    ExecutionMode, ExecutionQuery, ExecutionRequest, OutputValue, execute_request,
+    execute_request, ExecutionMode, ExecutionQuery, ExecutionRequest, OutputValue,
 };
 use axiom_rules_engine::compile::{
-    CompileError, CompiledProgramArtifact, compile_program_file_to_json,
+    compile_program_file_to_json, CompileError, CompiledProgramArtifact,
 };
-use axiom_rules_engine::rulespec::{RuleSpecError, ValidationStatus, lower_rulespec_str};
+use axiom_rules_engine::rulespec::{lower_rulespec_str, RuleSpecError, ValidationStatus};
 use axiom_rules_engine::spec::{
     DatasetSpec, DerivedSemanticsSpec, InputRecordSpec, IntervalSpec, PeriodKindSpec, PeriodSpec,
     ScalarExprSpec, ScalarValueSpec,
@@ -121,19 +121,14 @@ rules:
     let program = &artifact.program;
     assert_eq!(program.parameters.len(), 2);
     assert_eq!(program.derived.len(), 7);
-    assert!(
-        program
-            .relations
-            .iter()
-            .any(|r| r.name
-                == "us-tx:policies/hhsc/snap/overlay-subset#relation.member_of_household")
-    );
-    assert!(
-        artifact
-            .metadata
-            .evaluation_order
-            .contains(&"snap_allotment".to_string())
-    );
+    assert!(program
+        .relations
+        .iter()
+        .any(|r| r.name == "us-tx:policies/hhsc/snap/overlay-subset#relation.member_of_household"));
+    assert!(artifact
+        .metadata
+        .evaluation_order
+        .contains(&"snap_allotment".to_string()));
 }
 
 #[test]
@@ -1301,20 +1296,16 @@ rules:
 
     let artifact =
         CompiledProgramArtifact::from_rulespec_file(&program_file).expect("RuleSpec compiles");
-    assert!(
-        artifact
-            .program
-            .relations
-            .iter()
-            .any(|relation| relation.name == "us:statutes/26/63/c#relation.member_of_tax_unit")
-    );
-    assert!(
-        artifact
-            .program
-            .relations
-            .iter()
-            .any(|relation| relation.name == "member_of_tax_unit")
-    );
+    assert!(artifact
+        .program
+        .relations
+        .iter()
+        .any(|relation| relation.name == "us:statutes/26/63/c#relation.member_of_tax_unit"));
+    assert!(artifact
+        .program
+        .relations
+        .iter()
+        .any(|relation| relation.name == "member_of_tax_unit"));
 
     let _ = fs::remove_dir_all(root);
 }
@@ -1873,13 +1864,11 @@ rules:
     assert_eq!(derivation.entity.as_deref(), Some("SnapUnit"));
     assert_eq!(derivation.member_relation.as_deref(), Some("members"));
     assert_eq!(derivation.slot_entities, vec!["Person", "Household"]);
-    assert!(
-        artifact
-            .program
-            .relations
-            .iter()
-            .all(|relation| relation.name != "members")
-    );
+    assert!(artifact
+        .program
+        .relations
+        .iter()
+        .all(|relation| relation.name != "members"));
 
     let snap_unit_size = artifact
         .program
@@ -1980,7 +1969,7 @@ rules:
 }
 
 #[test]
-fn rulespec_rejects_multi_version_derived_formula() {
+fn rulespec_lowers_multi_version_derived_formula() {
     let rulespec = r#"
 format: rulespec/v1
 rules:
@@ -1997,13 +1986,25 @@ rules:
         formula: able_account_contributions
 "#;
 
-    let err = lower_rulespec_str(rulespec)
-        .expect_err("multi-version derived formulas should fail before compilation");
-    assert!(
-        err.to_string()
-            .contains("versioned derived formulas are not supported yet"),
-        "unexpected error: {err}"
-    );
+    let program = lower_rulespec_str(rulespec).expect("multi-version derived formulas lower");
+    let derived = program
+        .derived
+        .iter()
+        .find(|derived| derived.name == "savers_credit_gross_contributions")
+        .expect("derived output present");
+    assert_eq!(derived.versions.len(), 2);
+    assert!(matches!(
+        &derived.versions[0].semantics,
+        DerivedSemanticsSpec::Scalar {
+            expr: ScalarExprSpec::Input { name },
+        } if name == "qualified_retirement_contributions"
+    ));
+    assert!(matches!(
+        &derived.versions[1].semantics,
+        DerivedSemanticsSpec::Scalar {
+            expr: ScalarExprSpec::Input { name },
+        } if name == "able_account_contributions"
+    ));
 }
 
 #[test]
@@ -2113,13 +2114,11 @@ rules:
 
     let artifact = compile_program_file_to_json(&co_path, &artifact_path)
         .expect("RuleSpec file with canonical import compiles");
-    assert!(
-        artifact
-            .program
-            .parameters
-            .iter()
-            .any(|parameter| parameter.name == "snap_maximum_allotment_table")
-    );
+    assert!(artifact
+        .program
+        .parameters
+        .iter()
+        .any(|parameter| parameter.name == "snap_maximum_allotment_table"));
     assert!(
         artifact
             .program
@@ -2130,22 +2129,18 @@ rules:
                     "us:policies/usda/snap/fy-2026-cola/maximum-allotments#snap_maximum_allotment_table"
                 ))
     );
-    assert!(
-        artifact
-            .program
-            .derived
-            .iter()
-            .any(|derived| derived.name == "snap_regular_month_allotment")
-    );
+    assert!(artifact
+        .program
+        .derived
+        .iter()
+        .any(|derived| derived.name == "snap_regular_month_allotment"));
     let output_id =
         "us-co:policies/cdhs/snap/fy-2026-benefit#snap_regular_month_allotment".to_string();
-    assert!(
-        artifact
-            .program
-            .derived
-            .iter()
-            .any(|derived| derived.id.as_deref() == Some(output_id.as_str()))
-    );
+    assert!(artifact
+        .program
+        .derived
+        .iter()
+        .any(|derived| derived.id.as_deref() == Some(output_id.as_str())));
 
     let period = PeriodSpec {
         kind: PeriodKindSpec::Month,


### PR DESCRIPTION
## Summary
- preserve dated derived formula versions during RuleSpec/formula lowering
- select the active derived formula by query period in explain and bulk execution
- reject versioned derived formulas in dense compilation rather than using the latest formula silently
- update tests for versioned derived formulas

## Tests
- rustfmt --check src/model.rs src/spec.rs src/formula.rs src/engine.rs src/bulk.rs src/api.rs src/rulespec.rs src/compile.rs src/dense.rs tests/execution.rs tests/dense.rs
- cargo test