### PR TITLE
Dense Python surface for the populace RulesEngine adapter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,12 @@ jobs:
       - name: cargo build --release
         run: cargo build --release --verbose
 
+      # The PyO3 extension is a separate crate that CI otherwise never
+      # compiles — a core enum change once broke it silently (the
+      # DenseColumn::Float arm). Type-check it on every run.
+      - name: cargo check (python-ext)
+        run: cargo check --manifest-path python-ext/Cargo.toml --verbose
+
   wasm:
     name: wasm32 core check
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ wasm/pkg-node/
 viz/
 
 paper/_build/
+
+# setuptools build output from pip installs of python/
+python/build/

--- a/python-ext/src/lib.rs
+++ b/python-ext/src/lib.rs
@@ -6,6 +6,7 @@ use axiom_rules_engine::dense::{
     DenseRelationSchema,
 };
 use axiom_rules_engine::model::{JudgmentOutcome, Period, PeriodKind};
+use axiom_rules_engine::spec::DTypeSpec;
 use chrono::NaiveDate;
 use numpy::{PyArray1, PyReadonlyArray1};
 use pyo3::exceptions::{PyRuntimeError, PyValueError};
@@ -41,9 +42,44 @@ impl From<&DenseRelationSchema> for RelationSchemaHandle {
     }
 }
 
+/// Authoring-level metadata for one derived rule: what the RuleSpec module
+/// declared, before lowering to the runtime model (which drops `period`).
+/// Adapters (e.g. populace's RulesEngine adapter) resolve variables through
+/// this instead of re-parsing YAML.
+#[pyclass(module = "axiom_rules_engine_dense")]
+#[derive(Clone)]
+struct DerivedMetadataHandle {
+    #[pyo3(get)]
+    name: String,
+    #[pyo3(get)]
+    id: Option<String>,
+    #[pyo3(get)]
+    entity: String,
+    #[pyo3(get)]
+    dtype: String,
+    #[pyo3(get)]
+    unit: Option<String>,
+    #[pyo3(get)]
+    period: Option<String>,
+    #[pyo3(get)]
+    source: Option<String>,
+}
+
+fn dtype_name(dtype: &DTypeSpec) -> &'static str {
+    match dtype {
+        DTypeSpec::Judgment => "judgment",
+        DTypeSpec::Bool => "bool",
+        DTypeSpec::Integer => "integer",
+        DTypeSpec::Decimal => "decimal",
+        DTypeSpec::Text => "text",
+        DTypeSpec::Date => "date",
+    }
+}
+
 #[pyclass(module = "axiom_rules_engine_dense", name = "CompiledDenseProgram")]
 struct CompiledDenseProgramHandle {
     compiled: DenseCompiledProgram,
+    derived_metadata: Vec<DerivedMetadataHandle>,
 }
 
 #[pymethods]
@@ -53,9 +89,35 @@ impl CompiledDenseProgramHandle {
     fn from_file(path: &str, entity: Option<&str>) -> PyResult<Self> {
         let artifact = CompiledProgramArtifact::from_rulespec_file(path)
             .map_err(|error| PyValueError::new_err(error.to_string()))?;
+        // Capture authoring metadata (including `period`, which the runtime
+        // model drops) for every derived rule across all entities — the
+        // dense program itself compiles only the root entity's rules.
+        let derived_metadata = artifact
+            .program
+            .derived
+            .iter()
+            .map(|spec| DerivedMetadataHandle {
+                name: spec.name.clone(),
+                id: spec.id.clone(),
+                entity: spec.entity.clone(),
+                dtype: dtype_name(&spec.dtype).to_string(),
+                unit: spec.unit.clone(),
+                period: spec.period.clone(),
+                source: spec.source.clone(),
+            })
+            .collect();
         let compiled = DenseCompiledProgram::from_artifact(&artifact, entity)
             .map_err(|error| PyValueError::new_err(error.to_string()))?;
-        Ok(Self { compiled })
+        Ok(Self {
+            compiled,
+            derived_metadata,
+        })
+    }
+
+    /// Metadata for every derived rule in the compiled module, across all
+    /// entities (not just the dense root). Order follows the module.
+    fn derived_metadata(&self) -> Vec<DerivedMetadataHandle> {
+        self.derived_metadata.clone()
     }
 
     #[getter]
@@ -90,6 +152,40 @@ impl CompiledDenseProgramHandle {
         relations: Option<Bound<'py, PyDict>>,
         outputs: Option<Vec<String>>,
     ) -> PyResult<Bound<'py, PyDict>> {
+        self.run(py, period_kind, start, end, inputs, relations, outputs, false)
+    }
+
+    /// Execute in `f64` arithmetic: numeric outputs skip the Decimal
+    /// round-trip entirely. Intended for microsimulation-style batch
+    /// workloads; exact legal determinations should use `execute`.
+    #[pyo3(signature = (period_kind, start, end, inputs, relations=None, outputs=None))]
+    fn execute_f64<'py>(
+        &self,
+        py: Python<'py>,
+        period_kind: &str,
+        start: &str,
+        end: &str,
+        inputs: Bound<'py, PyDict>,
+        relations: Option<Bound<'py, PyDict>>,
+        outputs: Option<Vec<String>>,
+    ) -> PyResult<Bound<'py, PyDict>> {
+        self.run(py, period_kind, start, end, inputs, relations, outputs, true)
+    }
+}
+
+impl CompiledDenseProgramHandle {
+    #[allow(clippy::too_many_arguments)]
+    fn run<'py>(
+        &self,
+        py: Python<'py>,
+        period_kind: &str,
+        start: &str,
+        end: &str,
+        inputs: Bound<'py, PyDict>,
+        relations: Option<Bound<'py, PyDict>>,
+        outputs: Option<Vec<String>>,
+        use_f64: bool,
+    ) -> PyResult<Bound<'py, PyDict>> {
         let period = Period {
             kind: parse_period_kind(period_kind),
             start: parse_date(start)?,
@@ -97,10 +193,12 @@ impl CompiledDenseProgramHandle {
         };
         let batch = build_batch(&self.compiled, inputs, relations)?;
         let output_names = outputs.unwrap_or_else(|| self.compiled.output_names());
-        let execution = self
-            .compiled
-            .execute(&period, batch, &output_names)
-            .map_err(|error| PyRuntimeError::new_err(error.to_string()))?;
+        let execution = if use_f64 {
+            self.compiled.execute_f64(&period, batch, &output_names)
+        } else {
+            self.compiled.execute(&period, batch, &output_names)
+        }
+        .map_err(|error| PyRuntimeError::new_err(error.to_string()))?;
 
         let output_dict = PyDict::new(py);
         for (name, value) in execution.outputs {
@@ -124,6 +222,9 @@ impl CompiledDenseProgramHandle {
                             })
                             .collect::<PyResult<Vec<f64>>>()?;
                         output_dict.set_item(name, PyArray1::from_vec(py, materialised))?;
+                    }
+                    DenseColumn::Float(values) => {
+                        output_dict.set_item(name, PyArray1::from_vec(py, values))?;
                     }
                     DenseColumn::Text(values) => {
                         output_dict.set_item(name, PyList::new(py, values)?)?;
@@ -157,6 +258,7 @@ impl CompiledDenseProgramHandle {
 fn axiom_rules_engine_dense(_py: Python<'_>, module: &Bound<'_, PyModule>) -> PyResult<()> {
     module.add_class::<CompiledDenseProgramHandle>()?;
     module.add_class::<RelationSchemaHandle>()?;
+    module.add_class::<DerivedMetadataHandle>()?;
     Ok(())
 }
 

--- a/python/axiom_rules_engine/__init__.py
+++ b/python/axiom_rules_engine/__init__.py
@@ -1,5 +1,10 @@
 from .client import AxiomRulesEngine
-from .dense import CompiledDenseProgram, DenseRelationBatch, DenseRelationSchema
+from .dense import (
+    CompiledDenseProgram,
+    DenseRelationBatch,
+    DenseRelationSchema,
+    DerivedMetadata,
+)
 from .loader import load_program
 from .models import (
     CompiledExecutionRequest,
@@ -41,6 +46,7 @@ __all__ = [
     "Dataset",
     "DenseRelationBatch",
     "DenseRelationSchema",
+    "DerivedMetadata",
     "ExecutionMetadata",
     "ExecutionMode",
     "ExecutionQuery",

--- a/python/axiom_rules_engine/dense.py
+++ b/python/axiom_rules_engine/dense.py
@@ -22,6 +22,25 @@ class DenseRelationSchema:
 
 
 @dataclass(frozen=True)
+class DerivedMetadata:
+    """Authoring-level metadata for one derived rule.
+
+    Captured from the RuleSpec module before lowering (the runtime model
+    drops ``period``). ``dtype`` is the engine vocabulary: ``judgment`` /
+    ``bool`` / ``integer`` / ``decimal`` / ``text`` / ``date``; ``period``
+    is the authored granularity (``Year`` / ``Month`` / ...) when declared.
+    """
+
+    name: str
+    id: str | None
+    entity: str
+    dtype: str
+    unit: str | None
+    period: str | None
+    source: str | None
+
+
+@dataclass(frozen=True)
 class DenseRelationBatch:
     offsets: np.ndarray
     inputs: dict[str, np.ndarray]
@@ -67,6 +86,22 @@ class CompiledDenseProgram:
             for item in self._native.relations()
         ]
 
+    @property
+    def derived_metadata(self) -> list[DerivedMetadata]:
+        """Metadata for every derived rule in the module, all entities."""
+        return [
+            DerivedMetadata(
+                name=item.name,
+                id=item.id,
+                entity=item.entity,
+                dtype=item.dtype,
+                unit=item.unit,
+                period=item.period,
+                source=item.source,
+            )
+            for item in self._native.derived_metadata()
+        ]
+
     def execute(
         self,
         *,
@@ -76,6 +111,45 @@ class CompiledDenseProgram:
         inputs: dict[str, np.ndarray],
         relations: dict[str, DenseRelationBatch] | None = None,
         outputs: list[str] | None = None,
+    ) -> dict[str, Any]:
+        return self._run(
+            self._native.execute, period_kind, start, end, inputs, relations, outputs
+        )
+
+    def execute_f64(
+        self,
+        *,
+        period_kind: str,
+        start: str,
+        end: str,
+        inputs: dict[str, np.ndarray],
+        relations: dict[str, DenseRelationBatch] | None = None,
+        outputs: list[str] | None = None,
+    ) -> dict[str, Any]:
+        """Execute in f64 arithmetic (faster; floating-point rounding).
+
+        Intended for microsimulation-style batch workloads; exact legal
+        determinations should use :meth:`execute`.
+        """
+        return self._run(
+            self._native.execute_f64,
+            period_kind,
+            start,
+            end,
+            inputs,
+            relations,
+            outputs,
+        )
+
+    def _run(
+        self,
+        native_execute: Any,
+        period_kind: str,
+        start: str,
+        end: str,
+        inputs: dict[str, np.ndarray],
+        relations: dict[str, DenseRelationBatch] | None,
+        outputs: list[str] | None,
     ) -> dict[str, Any]:
         prepared_inputs = {name: np.asarray(values) for name, values in inputs.items()}
         prepared_relations = None
@@ -90,7 +164,7 @@ class CompiledDenseProgram:
                 }
                 for key, batch in relations.items()
             }
-        return self._native.execute(
+        return native_execute(
             period_kind,
             start,
             end,

--- a/python/tests/test_dense_surface.py
+++ b/python/tests/test_dense_surface.py
@@ -1,0 +1,142 @@
+"""Dense vectorized surface: metadata, Decimal + f64 execution.
+
+These tests exercise the native ``axiom_rules_engine_dense`` extension and
+skip when it is not built (CI type-checks the extension crate but does not
+build the wheel). Build locally with::
+
+    maturin develop --release --manifest-path python-ext/Cargo.toml
+"""
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from axiom_rules_engine import CompiledDenseProgram
+from axiom_rules_engine.dense import NativeCompiledDenseProgram
+
+pytestmark = pytest.mark.skipif(
+    NativeCompiledDenseProgram is None,
+    reason="axiom_rules_engine_dense extension is not built",
+)
+
+MODULE = Path(__file__).parent / "fixtures" / "dense_flat_tax.yaml"
+
+MODULE_SOURCE = """\
+format: rulespec/v1
+module:
+  summary: |-
+    Dense-surface test fixture: a two-bracket flat tax with a boolean
+    exemption predicate, exercising metadata, Decimal and f64 execution.
+units:
+  - name: EUR
+    kind: currency
+    minor_units: 2
+rules:
+  - name: dense_test_bracket_threshold
+    kind: parameter
+    dtype: Money
+    unit: EUR
+    versions:
+      - effective_from: '2025-01-01'
+        formula: |-
+          10000
+  - name: dense_test_low_rate
+    kind: parameter
+    dtype: Rate
+    versions:
+      - effective_from: '2025-01-01'
+        formula: |-
+          0.10
+  - name: dense_test_high_rate
+    kind: parameter
+    dtype: Rate
+    versions:
+      - effective_from: '2025-01-01'
+        formula: |-
+          0.25
+  - name: dense_test_tax
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Year
+    unit: EUR
+    source: dense-surface test fixture
+    versions:
+      - effective_from: '2025-01-01'
+        formula: |-
+          if dense_test_is_exempt:
+              0
+          else:
+              if dense_test_income <= dense_test_bracket_threshold:
+                  dense_test_income * dense_test_low_rate
+              else:
+                  dense_test_bracket_threshold * dense_test_low_rate + (dense_test_income - dense_test_bracket_threshold) * dense_test_high_rate
+"""
+
+
+@pytest.fixture(scope="module")
+def program(tmp_path_factory) -> CompiledDenseProgram:
+    path = tmp_path_factory.mktemp("dense") / "dense_flat_tax.yaml"
+    path.write_text(MODULE_SOURCE, encoding="utf-8")
+    return CompiledDenseProgram.from_file(path, entity="Person")
+
+
+class TestDerivedMetadata:
+    def test_reports_entity_dtype_period_unit_source(self, program) -> None:
+        by_name = {item.name: item for item in program.derived_metadata}
+        tax = by_name["dense_test_tax"]
+        assert tax.entity == "Person"
+        assert tax.dtype == "decimal"
+        assert tax.period == "Year"
+        assert tax.unit == "EUR"
+        assert tax.source == "dense-surface test fixture"
+        # Durable ids derive from the country-repo logical path (e.g.
+        # `be:statutes/...#rule`); a bare fixture outside that layout has none.
+        assert tax.id is None
+
+
+class TestExecutionModes:
+    def _inputs(self, n: int = 3) -> dict:
+        return {
+            "dense_test_income": np.array([5_000.0, 10_000.0, 20_000.0][:n]),
+            "dense_test_is_exempt": np.array([False, False, False][:n]),
+        }
+
+    EXPECTED = [500.0, 1_000.0, 3_500.0]
+
+    def test_decimal_execution(self, program) -> None:
+        result = program.execute(
+            period_kind="calendar_year",
+            start="2025-01-01",
+            end="2025-12-31",
+            inputs=self._inputs(),
+        )
+        assert result["row_count"] == 3
+        np.testing.assert_allclose(
+            result["outputs"]["dense_test_tax"], self.EXPECTED
+        )
+
+    def test_f64_execution_matches_decimal(self, program) -> None:
+        result = program.execute_f64(
+            period_kind="calendar_year",
+            start="2025-01-01",
+            end="2025-12-31",
+            inputs=self._inputs(),
+        )
+        np.testing.assert_allclose(
+            result["outputs"]["dense_test_tax"], self.EXPECTED
+        )
+
+    def test_exemption_predicate_takes_bool_columns(self, program) -> None:
+        inputs = self._inputs()
+        inputs["dense_test_is_exempt"] = np.array([True, False, True])
+        result = program.execute(
+            period_kind="calendar_year",
+            start="2025-01-01",
+            end="2025-12-31",
+            inputs=inputs,
+        )
+        np.testing.assert_allclose(
+            result["outputs"]["dense_test_tax"], [0.0, 1_000.0, 0.0]
+        )

--- a/python/tests/test_dense_surface.py
+++ b/python/tests/test_dense_surface.py
@@ -7,8 +7,6 @@ build the wheel). Build locally with::
     maturin develop --release --manifest-path python-ext/Cargo.toml
 """
 
-from pathlib import Path
-
 import numpy as np
 import pytest
 
@@ -19,8 +17,6 @@ pytestmark = pytest.mark.skipif(
     NativeCompiledDenseProgram is None,
     reason="axiom_rules_engine_dense extension is not built",
 )
-
-MODULE = Path(__file__).parent / "fixtures" / "dense_flat_tax.yaml"
 
 MODULE_SOURCE = """\
 format: rulespec/v1


### PR DESCRIPTION
Part of #62 (vectorized engine surface for the populace `RulesEngine` adapter; epic PolicyEngine/populace#259).

Wiring the populace adapter (PolicyEngine/populace#260) against `rulespec-be` surfaced three gaps in the dense Python surface. This PR closes them.

## What

1. **Fix: the PyO3 extension did not compile against `main`.** `DenseColumn::Float` (added with `execute_f64`) was missing from the output-marshalling match in `python-ext/src/lib.rs` (E0004). CI never compiles the extension crate, so this shipped silently — the Rust job now runs `cargo check --manifest-path python-ext/Cargo.toml` to keep type drift from breaking the binding again.
2. **Expose `execute_f64`.** The f64 execution mode existed in Rust (`src/dense.rs`) but was unreachable from Python. `CompiledDenseProgram` (native handle + `axiom_rules_engine.dense` wrapper) now exposes it alongside `execute`, sharing the batch/marshalling path. Its docstring points microsimulation-style batch workloads at it, per the Rust-side note.
3. **Expose variable metadata: `derived_metadata`.** An adapter needs owning entity / dtype kind / period semantics per variable without re-parsing YAML (issue #62, requirement 1). `from_file` now captures the authoring-level `DerivedSpec` metadata — including `period`, which the runtime model drops — for every derived rule across all entities (not just the dense root), exposed as `derived_metadata` returning `DerivedMetadata(name, id, entity, dtype, unit, period, source)`.

## Verified against rulespec-be

- `be/statutes/income_tax/individual/rate_scale.yaml` reproduces hand-computed 2025 liabilities over a dense batch: taxable income 10,000 / 30,000 / 60,000 → **2,500 / 9,612 / 23,620** (Decimal and f64 agree).
- Full federal PIT pipeline (`tax_liability_pipeline.yaml`, 49 outputs): **200,000 persons in ~1.04s Decimal / ~0.87s f64** on an M-series laptop — the issue's "~100k rows in seconds" acceptance clears with room.
- Metadata example: `belgium_pit_article_130_base_tax` → entity `Person`, dtype `decimal`, unit `EUR`, period `Year`, id `be:statutes/income_tax/individual/rate_scale#belgium_pit_article_130_base_tax`.

## Tests

- `python/tests/test_dense_surface.py`: metadata fields, Decimal execution, f64-matches-Decimal, and bool-column predicates, over a self-contained fixture module; skips when the extension isn't built (CI type-checks the crate; the wheel is built locally via maturin).
- Full suite: 32 passed locally (3.14, extension built).

## Notes for follow-up (kept out of this PR)

- **Input metadata is still name-only.** Truthiness-context inputs (e.g. `belgium_pit_article_49_actual_professional_expenses_are_justified`) strictly require Bool columns — Integer and Decimal are rejected at evaluation — but nothing on the surface distinguishes them from numeric inputs; callers discover by probing. A `root_input_specs()` exposing per-input usage kind + optionality would let adapters build batches without dtype knowledge on their side. (The populace adapter sidesteps this by typing batches from its Frame's column dtypes.)
- `DTypeSpec` has no `Count` alias; rulespec-be family-benefit modules author `dtype: Count`. Worth either an alias (→ Integer) or a corpus-side rename before the benefits slice lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
