### PR TITLE
Cross-period reductions: lifetime execution surface (#67)

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -4,6 +4,93 @@ Short decision log for architecture choices. Publicly and internally, this is
 the Axiom Rules Engine; the Rust crate and executable are `axiom-rules-engine`. One
 entry per decision, most recent first.
 
+## 2026-07-05 — Lifetime execution surface: over-periods reductions and their semantics
+
+**Decision.** A `derived` formula may reduce a value across an entity's own
+period axis with one of four builtins — `sum_over_periods(x)`,
+`max_over_periods(x)`, `count_over_periods(x)`, and
+`sum_top_n_over_periods(x, n)` — which lower to a single additive expression
+node (`ScalarExpr::OverPeriods { kind, value, n }`, serde-tagged, no artifact
+format-version bump). They evaluate only under a new lifetime execution surface
+(`DenseCompiledProgram::execute_lifetime` / `execute_lifetime_f64`), which takes
+one input batch per supplied period, all describing the same entity rows in the
+same positional order. The per-period execution paths reject every reduction
+node (`EvalError::OverPeriodsOutsideLifetime`). The following semantics are
+settled:
+
+- **Reference period = the chronologically-last supplied period.** The entry
+  points require the supplied periods to be **strictly ascending by start
+  date** and error otherwise (`EvalError::LifetimePeriodsNotAscending`, naming
+  the offending adjacent pair) rather than silently sorting — so the caller's
+  period/batch pairing stays authoritative and a bend point / COLA parameter
+  cannot resolve at the wrong year. Every period-specific scalar combined with a
+  reduction (a `ParameterLookup`, and the `n` of `sum_top_n_over_periods`)
+  resolves at that reference period.
+
+- **Referential transparency (period-invariant input binding + inlined-body
+  derived).** Inside any reduction, the inner expression is evaluated once per
+  period with the ordinary per-period executor. Outside every reduction: a
+  `ParameterLookup` resolves at the reference period; a bare **input** is bound
+  only when it is provably identical across all supplied periods for each row
+  (`eval_period_invariant_input`), else `EvalError::LifetimePeriodVaryingInput`
+  names the input and the first divergence — this legalizes exactly the
+  per-person-constant inputs (year attained 21 / 62) that a real
+  computation-year count bottoms out in, and nothing else; and a **derived**
+  reference means its body inlined and evaluated in this same lifetime context,
+  so a derived denotes exactly its definition whether referenced inside or
+  outside a reduction. A parameter-bearing derived reused in both contexts with
+  a period-varying input inside it therefore errors loudly instead of silently
+  computing two different values.
+
+- **`count_over_periods` counts nonzero.** It evaluates its argument per period
+  (the same leaf rules as the other reductions) and counts, per row, the
+  periods whose value is nonzero (a `Bool` inner value counts `true`). It is not
+  a bare supplied-period count; a text/date inner value has no zero and is
+  rejected.
+
+- **Strict `n` contract for `sum_top_n_over_periods`.** After truncation toward
+  zero to an exact `i64`, `n` must satisfy `1 <= n <= the supplied period
+  count`. A non-finite or out-of-range `n` (`try_to_i64_trunc` -> `None`), an
+  over-length `n`, and an `n` that is not period-invariant all raise typed
+  errors (`OverPeriodsTopNOutOfRange`, `OverPeriodsTopNPeriodVarying`) — no
+  clamp to `i64::MAX`, no silent pin to the reference period, no zero-padding
+  past the period count. Parameter-sourced and input-sourced `n` are held to the
+  identical contract (both evaluated under every period's executor and required
+  invariant). Summing more slots than periods only pads with zeros — an
+  arithmetic no-op — so an over-length count is treated as a data error, not
+  absorbed.
+
+**Why.**
+
+- 42 USC 415(b)'s AIME is the motivating shape: sum the top `n` of a worker's
+  indexed annual earnings, where `n` (the benefit-computation-year count) is
+  itself derived from per-person-constant inputs. That needs a period axis the
+  per-period executor does not have, an `n` reached through a derived chain
+  outside every reduction, and a floor-divided quotient — all of which the
+  surface above supports end to end.
+- The reductions must be *referentially consistent*: a named derived reused
+  inside and outside a reduction, or a `count`/`n` whose value silently depends
+  on evaluation position, would compute wrong money without any signal. Each
+  ambiguous case is resolved by a single documented rule and a loud typed error
+  when the inputs violate it, rather than a clamp or a positional default.
+
+**Consequences.**
+
+- **Additive; no artifact format-version bump.** The `over_periods` variant is
+  additive on `ScalarExprSpec`; existing compiled artifacts and per-period
+  execution are unchanged. Reductions are rejected in every non-lifetime path
+  (per-period dense, sparse, bulk) with a clear error.
+- **Lifetime outputs must reduce.** `execute_lifetime[_f64]` only supports
+  outputs whose formula contains at least one over-periods reduction
+  (`LifetimeOutputWithoutReduction`); period-specific outputs still use the
+  per-period entry points.
+- **Directly-nested reductions are a compile error**
+  (`DenseCompileError::NestedOverPeriods`); a reduction reached only through a
+  derived reference still fails safely at runtime.
+- **PyO3 exposure is f64-only for now** (`execute_lifetime_f64`), matching the
+  existing `execute_f64` parity; the exact Decimal `execute_lifetime` is staged
+  for a follow-up before a consumer migrates an exact per-period workflow.
+
 ## 2026-07-03 — Currency rules opt into output rounding; `minor_units` becomes live
 
 **Decision.** A `derived` rule may declare `rounding: <mode>` (one of

--- a/FEATURE_BRIEF.md
+++ b/FEATURE_BRIEF.md
@@ -1,0 +1,72 @@
+# Feature brief: cross-period reduction (issue #67)
+
+Implement the capability tracked in
+https://github.com/TheAxiomFoundation/axiom-rules-engine/issues/67 :
+reductions over a person's own period axis, so 42 USC 415(b) AIME
+(highest-35-years selection) computes end-to-end from a RuleSpec
+encoding.
+
+## Design (decided — do not relitigate, flag concerns in PROGRESS.md)
+
+1. **Lifetime execution surface, per-period evaluation reused.**
+   Add to `CompiledDenseProgram`:
+   `execute_lifetime` / `execute_lifetime_f64(periods, batches,
+   outputs)` where `periods: &[Period]` and `batches` is one
+   `DenseBatchSpec` per period with IDENTICAL entity row order and
+   count (v1 constraint — validate and error clearly if row counts
+   differ; alignment by position). Internally: for each output whose
+   formula contains an over-periods reduction, evaluate the
+   reduction's inner expression per period with the existing
+   `DenseExecutor`, stack the per-period vectors, apply the
+   reduction row-wise, then evaluate the remainder of the formula in
+   a context where the reduction call yields that per-entity vector.
+   Non-reduction outputs error under lifetime execution only if they
+   are requested and reference no reduction (direct users should use
+   the existing per-period entry points) — keep it simple: lifetime
+   execution only supports outputs whose formulas contain at least
+   one over-periods reduction; error otherwise.
+2. **Builtins** (formula.rs), valid only in lifetime context —
+   error with a clear message if compiled for per-period execution:
+   - `sum_over_periods(x)`
+   - `max_over_periods(x)`
+   - `count_over_periods(x)` (count of periods supplied)
+   - `sum_top_n_over_periods(x, n)` — sum of the n largest
+     per-period values of `x` for the entity; if fewer than n
+     periods are supplied, missing periods contribute zero (this
+     mirrors 415(b): computation years count whether or not the
+     worker had earnings). `n` may be any scalar expression
+     (typically a parameter); truncate to integer, error if < 1.
+3. **PyO3 surface**: expose `execute_lifetime_f64` on the Python
+   binding exactly parallel to the existing `execute_f64` (see the
+   python/ package for how execute_f64 is exported and tested).
+4. **No RuleSpec schema changes.** The declarative
+   `over: periods` schema form is a separate future conversation;
+   this feature is expression-level only.
+
+## Tests
+
+- Rust: unit tests for each builtin (top-n correctness incl. ties,
+  n greater than period count, n as expression, negative values;
+  alignment validation errors; per-period-context rejection of the
+  builtins).
+- Python: an integration test that compiles a MINIMAL inline
+  rulespec module with rules
+  `aime = floor(sum_top_n_over_periods(indexed_earnings, 35) / 420)`
+  (shape it to whatever the module/loader needs), feeds a synthetic
+  worker with a 40-year history through `execute_lifetime_f64`, and
+  asserts the AIME equals the hand-derived value written out in a
+  comment. This is the acceptance test from issue #67.
+
+## Working rules
+
+- Worktree: this directory, branch `cross-period-reduction`.
+- Read the repo's CLAUDE.md/AGENTS.md and CI workflow first; match
+  existing code style; run `cargo fmt`, `cargo clippy`, `cargo test`
+  and the python-ext test path CI runs, before every commit.
+- Maintain PROGRESS.md (state / done / next / concerns) from the
+  start; commit and push after every coherent step
+  (`git push -u origin cross-period-reduction` on first push).
+- Finish with a DRAFT pull request titled
+  "Cross-period reductions: lifetime execution surface (#67)"
+  referencing issue #67, summarizing semantics and limitations
+  (positional alignment, lifetime-only builtins). Do not merge.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -67,16 +67,26 @@ CI workflow, and tests/dense.rs. Starting implementation.
 
 ## Done
 - Full exploration; PROGRESS.md seeded.
+- model.rs: OverPeriodsKind (+ as_call_name) + ScalarExpr::OverPeriods + input-slot collector arm.
+- spec.rs: ScalarExprSpec::OverPeriods + OverPeriodsKindSpec + to_model.
+- formula.rs: parse sum/max/count/sum_top_n_over_periods in lower_to_scalar; promote_ints descends into value.
+- engine.rs: EvalError variants (OverPeriodsOutsideLifetime, Lifetime*, OverPeriodsTopNInvalid) + sparse reject arm.
+- bulk.rs (both paths) + api.rs collector: new arms.
+- compile.rs: fast-blocker (adds blocker), dependency collector, relation-member collector arms.
+- rulespec.rs: 4 traversal arms (alias rewrite, relation-name collect, relation-ref rewrite, imported-derived check).
+- dense.rs: CompiledScalarExpr::OverPeriods + compile arm + per-period reject + related/current reject +
+  DenseNum::to_i64_trunc + LifetimeExecutor + execute_lifetime[_f64] + derived_reduces_over_periods gate.
+- schemas/compiled-artifact.v1.schema.json regenerated (additive over_periods variant; no format-version bump).
+- GREEN: cargo build, fmt, cargo test (default + schema feature), cargo check python-ext.
+- clippy: baseline origin/main already emits 36 lib warnings; my additions introduce ZERO new warnings
+  (every warning location is in pre-existing code). Not touching the 36 pre-existing ones (scope).
 
 ## Next
-1. model.rs: OverPeriodsKind + ScalarExpr::OverPeriods + collector arm.
-2. spec.rs: ScalarExprSpec::OverPeriods + to_model.
-3. formula.rs: parse four builtins in lower_to_scalar.
-4. engine.rs / bulk.rs / api.rs: new arms (reject in sparse+bulk, recurse in collectors).
-5. dense.rs: CompiledScalarExpr arm + compile arms + per-period reject + LifetimeExecutor + execute_lifetime[_f64] + EvalError variants.
-6. python-ext + dense.py: execute_lifetime_f64.
-7. Rust unit tests (new tests file) + Python acceptance test (AIME 40-yr worker).
-8. fmt / clippy / test / schema feature / python-ext check; draft PR.
+1. python-ext/src/lib.rs + python/dense.py: execute_lifetime_f64 (parallel to execute_f64).
+2. Rust unit tests (tests/lifetime.rs): each builtin (top-n ties, n>period_count, n as expr, negatives),
+   alignment/validation errors, per-period-context rejection, count, max, sum, f64==decimal.
+3. Python acceptance test (test_dense_lifetime.py): AIME 40-yr worker, hand-derived expected in comment.
+4. Build wheel locally (maturin) to run Python tests; final fmt/clippy/test/schema/python-ext; draft PR.
 
 ## Concerns
 - Reference-period choice for non-reduction scalars (parameters/derived) inside the outer formula:

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -114,8 +114,10 @@ Added 2 Rust tests for the nested-reduction rejection (24 lifetime tests total).
   in tests/lifetime.rs or python-ext.
 - 24 Rust lifetime tests + 36 Python tests pass against the maturin-built extension.
 
-## Next
-- Open DRAFT PR; record URL here and in final message.
+## DRAFT PR
+https://github.com/TheAxiomFoundation/axiom-rules-engine/pull/68
+(draft, base main, head cross-period-reduction, title "Cross-period reductions: lifetime execution surface (#67)").
+Do NOT merge.
 
 ## Concerns
 - Reference-period choice for non-reduction scalars (parameters/derived) inside the outer formula:

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -180,3 +180,80 @@ proven by `earnings_total = [3_456_000, 1_922_000]`, which matches exactly.
   lines; 35 lib + 35 lib-test as before) — ZERO new warnings; none reference the new code.
 - 28 Rust lifetime tests + 38 Python tests pass against the maturin-rebuilt extension; the corrected
   scratchpad acceptance script passes (earnings_total [3456000, 1922000], aime [8000, 5166]).
+
+## Review response — six fixes (this session, PR #68 review)
+
+Six confirmed review findings addressed; semantics decided by the feature-brief
+author. Referential transparency, ordering validation, and count-nonzero were
+already implemented from the prior session; this session completed the strict n
+contract, the exhaustive reduction parse, and the DECISIONS.md entry, corrected
+the stale comments, and pinned every case as a test.
+
+1. **Referential transparency (dense.rs).** A derived referenced OUTSIDE a
+   reduction is evaluated by inlining its body in the lifetime context (the
+   `Derived` arm recurses through the lifetime executor): parameters resolve at
+   the reference period, and a bare input inside that body goes through the
+   per-row period-invariance guard. A parameter-bearing derived reused both
+   inside a reduction and bare outside it therefore denotes exactly its
+   definition in both positions. The review's 600-case
+   (`sum_over_periods(credit) + credit`, `credit = rate + earnings`, `earnings`
+   period-varying) now errors loudly via `LifetimePeriodVaryingInput` naming
+   `earnings`, instead of silently returning 600. Test:
+   `derived_reused_inside_and_outside_reduction_errors_on_period_varying_input`.
+
+2. **Strictly-ascending periods (dense.rs + engine.rs).** `execute_lifetime[_f64]`
+   validate that supplied periods strictly ascend by start date and error with
+   `LifetimePeriodsNotAscending` (naming the offending adjacent pair) rather than
+   silently resolving parameters / n at a positionally-last-but-chronologically-
+   earlier year. Reference period = the (now guaranteed chronologically-last)
+   final period. Tests: `errors_when_periods_are_not_strictly_ascending`
+   (Rust), `test_descending_periods_raise` (Python).
+
+3. **count_over_periods counts nonzero (dense.rs + model.rs).** `count_over_periods`
+   now evaluates its argument per period and counts, per row, the periods whose
+   value is nonzero (`Bool` counts `true`; text/date rejected). It is no longer a
+   bare supplied-period count. The stale "evaluated but ignored" doc on
+   `OverPeriodsKind::Count` (model.rs) was corrected. Tests:
+   `count_over_periods_counts_nonzero_periods_per_row`,
+   `count_over_periods_all_zero_is_zero` (Rust), and a Python analogue.
+
+4. **Strict n contract for sum_top_n (dense.rs + engine.rs + model.rs).**
+   `DenseNum::try_to_i64_trunc(self) -> Option<i64>` replaces the saturating
+   `to_i64_trunc` in both dtype impls. `eval_top_n_counts` now: evaluates n under
+   EVERY period's executor and rejects a period-VARYING n (parameter- and
+   input-sourced held to the identical contract) with
+   `OverPeriodsTopNPeriodVarying`; truncates the reference column toward zero to
+   an exact i64 (a non-finite / out-of-range value -> `None` -> hard error); and
+   enforces `1 <= n <= period_count`, erroring `OverPeriodsTopNOutOfRange` on
+   under- and over-length n. No clamp to i64::MAX, no silent reference-period
+   pin, no zero-pad past the period count. Tests:
+   `sum_top_n_n_exceeds_period_count_errors_in_decimal_path`,
+   `...in_f64_path`, `sum_top_n_period_varying_parameter_n_errors`, updated
+   `errors_when_sum_top_n_n_is_less_than_one` and the former zero-pad test
+   (now `sum_top_n_errors_when_n_exceeds_the_period_count`); Python analogues.
+
+5. **Exhaustive reduction parse (formula.rs).** The one-argument over-periods
+   arm chooses its kind by an exhaustive match with an explicit error arm (no
+   wildcard falling through to `Count`), and any other `*_over_periods` name is
+   rejected with a reduction-specific parse error rather than the generic
+   "unknown function". Tests: `unknown_over_periods_reduction_fails_to_parse`
+   (Rust + Python).
+
+6. **DECISIONS.md.** One new most-recent-first entry (2026-07-05) covering the
+   lifetime execution surface: the `OverPeriods` node + four builtins, reference
+   period = chronologically-last supplied period, strictly-ascending validation,
+   period-invariant input binding + inlined-body derived semantics,
+   count-nonzero, and the strict n contract.
+
+### Final gate (all GREEN, this session)
+- `cargo fmt` applied; `cargo fmt --check` clean; `cargo build`; `cargo test`
+  (default) 0 failed; `cargo test --features schema` 0 failed;
+  `cargo check --manifest-path python-ext/Cargo.toml`;
+  `cargo check --target wasm32-unknown-unknown --no-default-features`.
+- clippy: `--lib` and `--all-targets` finding multisets BYTE-IDENTICAL to branch
+  tip 984a4e0 (per-file counts diff empty) — ZERO new warnings; python-ext clippy
+  identical to baseline (2 pre-existing).
+- 35 Rust lifetime tests + 42 Python tests pass against the maturin-rebuilt
+  (`--release`) extension; the acceptance script
+  `scratchpad/check_derived_n_lifetime.py` prints
+  `earnings_total [3456000. 1922000.]`, `aime [8000. 5166.]` and all assertions pass.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,0 +1,86 @@
+# PROGRESS — cross-period reduction (issue #67)
+
+Branch: `cross-period-reduction` (worktree axiom-engine-67, from origin/main).
+
+## State
+Design finalized after full read of dense.rs, formula.rs, spec.rs, model.rs,
+engine.rs, bulk.rs, api.rs, rulespec.rs, python-ext/src/lib.rs, python/dense.py,
+CI workflow, and tests/dense.rs. Starting implementation.
+
+## Design (from brief, settled) + resolved mechanics
+
+### New expression node (threaded end-to-end)
+- model `ScalarExpr::OverPeriods { kind: OverPeriodsKind, value: Box<ScalarExpr>, n: Option<Box<ScalarExpr>> }`
+  where `OverPeriodsKind ∈ { Sum, Max, Count, SumTopN }`.
+- spec `ScalarExprSpec::OverPeriods { kind, value, n }` (serde-tagged, round-trips; additive → no artifact version bump).
+- dense `CompiledScalarExpr::OverPeriods { kind, value: Box<..>, n: Option<Box<..>> }`.
+- formula.rs `lower_to_scalar` parses the four builtin `Call`s:
+  - `sum_over_periods(x)` → OverPeriods{Sum, x, None}
+  - `max_over_periods(x)` → OverPeriods{Max, x, None}
+  - `count_over_periods(x)` → OverPeriods{Count, x, None}  (x still lowered so alignment/period count is well-defined; count ignores values)
+  - `sum_top_n_over_periods(x, n)` → OverPeriods{SumTopN, x, Some(n)}
+  arg-count errors mirror existing builtins.
+
+### Per-period-context rejection (lifetime-only)
+- Per-period dense executor `eval_scalar_expr`: OverPeriods → EvalError::OverPeriodsOutsideLifetime.
+- dense `compile_related_scalar` / `compile_current_scalar_expr`: reject (can't nest a cross-period
+  reduction inside a related/where expr) via DenseCompileError::Unsupported.
+- Sparse `engine.rs` eval_scalar_expr + bulk.rs (both columnar and related scalar paths) + api.rs
+  dep-collector + model.rs input-slot collector: handle new variant (sparse/bulk error clearly;
+  collectors recurse into value/n so inputs referenced inside a reduction are still discovered).
+
+### Lifetime execution surface (dense.rs)
+- `execute_lifetime(periods: &[Period], batches: Vec<DenseBatchSpec>, outputs) -> DenseExecutionResult` (Decimal)
+- `execute_lifetime_f64(...)` (f64), parallel to execute/execute_f64.
+- Validation:
+  - periods.len() == batches.len(), non-empty.
+  - every batch binds identically (bind_batch each) and all have the SAME row_count (v1 positional
+    alignment; error clearly on mismatch — new EvalError::LifetimeRowCountMismatch).
+  - each requested output's compiled formula must contain ≥1 OverPeriods node; else
+    EvalError::LifetimeOutputWithoutReduction (brief: lifetime exec only supports reduction outputs).
+- Evaluation model (LifetimeExecutor):
+  - Build one per-period bound batch + a way to make a per-period DenseExecutor<N>.
+  - Outer formula evaluated ONCE (row-wise), recursively:
+    * OverPeriods{kind,value,n}: evaluate `value` per period with that period's DenseExecutor
+      → P columns of length R; transpose to per-row Vec<N> of length P; reduce row-wise:
+        Sum = Σ; Max = max (error if P==0 — guaranteed ≥1 by non-empty periods); Count = P (ignores value);
+        SumTopN = sort desc, take top n, zero-pad when P<n (missing periods contribute 0 — mirrors 415(b)).
+        n: evaluate `n` at reference period (last), per-row; truncate toward zero to i64; error if < 1
+        (EvalError::TypeMismatch with a clear message). n is per-row but typically constant.
+    * Literal / Add / Sub / Mul / Div / Max / Min / Ceil / Floor / If(condition over reductions): recurse row-wise.
+    * ParameterLookup / Derived(scalar): evaluate at reference period (last period) — parameters like a
+      bend point are indexed to the eligibility/last year; Derived recurses through lifetime evaluator so a
+      derived that itself reduces works.
+    * Period-ambiguous leaves OUTSIDE any reduction (bare Input, InputOrElse, PeriodStart/End, CountRelated,
+      SumRelated): error EvalError::LifetimeAmbiguousLeaf — tell the caller these must appear inside an
+      over-periods reduction. (Faithful to "reused per-period evaluation"; keeps semantics unambiguous.)
+  - Reference period = last period supplied (documented). Rationale: over-periods reductions are the
+    lifetime axis; scalars combined with the reduction (bend points, divisor) are resolved at the
+    determination period, which is the most recent supplied period.
+
+### PyO3
+- `execute_lifetime_f64(periods, batches, outputs=None)` on CompiledDenseProgramHandle, parallel to
+  execute_f64. `periods`: list of (period_kind, start, end); `batches`: list of the same input/relation
+  dict shape build_batch already accepts. Python wrapper method `execute_lifetime_f64` in dense.py.
+
+### No RuleSpec schema changes (expression-level only). Additive serde on ScalarExprSpec.
+
+## Done
+- Full exploration; PROGRESS.md seeded.
+
+## Next
+1. model.rs: OverPeriodsKind + ScalarExpr::OverPeriods + collector arm.
+2. spec.rs: ScalarExprSpec::OverPeriods + to_model.
+3. formula.rs: parse four builtins in lower_to_scalar.
+4. engine.rs / bulk.rs / api.rs: new arms (reject in sparse+bulk, recurse in collectors).
+5. dense.rs: CompiledScalarExpr arm + compile arms + per-period reject + LifetimeExecutor + execute_lifetime[_f64] + EvalError variants.
+6. python-ext + dense.py: execute_lifetime_f64.
+7. Rust unit tests (new tests file) + Python acceptance test (AIME 40-yr worker).
+8. fmt / clippy / test / schema feature / python-ext check; draft PR.
+
+## Concerns
+- Reference-period choice for non-reduction scalars (parameters/derived) inside the outer formula:
+  chose LAST supplied period. Documented; flag for review. For the AIME acceptance formula the outer
+  formula only combines the reduction with a literal (420), so this choice is not exercised there.
+- Lifetime execution intentionally rejects period-ambiguous bare leaves outside reductions rather than
+  silently picking a period — the safe faithful reading of the brief.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -81,12 +81,41 @@ CI workflow, and tests/dense.rs. Starting implementation.
 - clippy: baseline origin/main already emits 36 lib warnings; my additions introduce ZERO new warnings
   (every warning location is in pre-existing code). Not touching the 36 pre-existing ones (scope).
 
+- python-ext/src/lib.rs: execute_lifetime_f64 PyO3 method + shared execution_to_pydict +
+  split_lifetime_batch; python/dense.py: execute_lifetime_f64 wrapper.
+- tests/lifetime.rs: 22 Rust tests — AIME acceptance (Decimal + f64, =2833), each builtin, top-n
+  (ties, n>period_count zero-pad, n as param expr, non-integer n truncation, negatives), multi-row
+  alignment, outer-formula-with-parameter, all validation/error paths, per-period rejection, Decimal exactness.
+- python/tests/test_dense_lifetime.py: 4 tests — AIME acceptance (=2833), two-worker row alignment,
+  period/batch-count and row-count mismatch errors. Built wheel via maturin (py3.14 venv), 36/36 python tests pass.
+
+## Acceptance test AIME value
+AIME = 2833. Synthetic 40-year worker, indexed earnings year k = 12_000 + 1_000*(k-1) (12_000..51_000).
+Top 35 of 40 drops the lowest 5; sum(top 35) = 35*(17_000+51_000)/2 = 1_190_000;
+floor(1_190_000 / 420) = floor(2833.33..) = 2833.
+
+## Independent review + fixes (applied)
+An independent read-only review found NO correctness bugs (verified AIME math, Max empty-slice safety,
+SumTopN zero-pad/ties/negatives, rejection completeness, transitive gate + cycle protection, serde
+round-trip, PyO3 layer). Three polish items applied:
+- LifetimeAmbiguousLeaf now carries a String (removed the Box::leak &'static str helper).
+- count_over_periods short-circuits before building the per-period matrix (a period count must not fail
+  because the inner body is unevaluable).
+- Directly-nested reductions (e.g. sum_over_periods(max_over_periods(x)), or a reduction in the `n` arg)
+  are now rejected at DENSE COMPILE TIME (DenseCompileError::NestedOverPeriods) with a precise message,
+  instead of surfacing an opaque per-period runtime error. Reduction-via-Derived still errors safely at
+  runtime (documented; transitive check needs the whole program, not one expr).
+Added 2 Rust tests for the nested-reduction rejection (24 lifetime tests total).
+
+## Final gate (all GREEN)
+- cargo fmt --check clean; cargo build; cargo test (default) all pass; cargo test --features schema all pass;
+  cargo check python-ext; cargo check wasm32-unknown-unknown --no-default-features.
+- clippy: 36 lib warnings, identical to origin/main baseline — ZERO introduced by this change; no warnings
+  in tests/lifetime.rs or python-ext.
+- 24 Rust lifetime tests + 36 Python tests pass against the maturin-built extension.
+
 ## Next
-1. python-ext/src/lib.rs + python/dense.py: execute_lifetime_f64 (parallel to execute_f64).
-2. Rust unit tests (tests/lifetime.rs): each builtin (top-n ties, n>period_count, n as expr, negatives),
-   alignment/validation errors, per-period-context rejection, count, max, sum, f64==decimal.
-3. Python acceptance test (test_dense_lifetime.py): AIME 40-yr worker, hand-derived expected in comment.
-4. Build wheel locally (maturin) to run Python tests; final fmt/clippy/test/schema/python-ext; draft PR.
+- Open DRAFT PR; record URL here and in final message.
 
 ## Concerns
 - Reference-period choice for non-reduction scalars (parameters/derived) inside the outer formula:

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -123,5 +123,60 @@ Do NOT merge.
 - Reference-period choice for non-reduction scalars (parameters/derived) inside the outer formula:
   chose LAST supplied period. Documented; flag for review. For the AIME acceptance formula the outer
   formula only combines the reduction with a literal (420), so this choice is not exercised there.
-- Lifetime execution intentionally rejects period-ambiguous bare leaves outside reductions rather than
-  silently picking a period — the safe faithful reading of the brief.
+- (Superseded for INPUTS by the amendment below.) Lifetime execution previously rejected ALL
+  period-ambiguous bare leaves outside reductions. Bare inputs are now bound when provably invariant;
+  the reference-period-for-parameters convention above is unchanged.
+
+## Amendment — runtime-verified period-invariant binding for inputs (this session)
+
+### Why
+42 USC 415(b)'s benefit-computation-year count is a derived scalar built from per-person-constant
+inputs (year the worker attains 21 / 62) and must feed `sum_top_n_over_periods` as its `n`. Under the
+original design that `n` — a bare input reached through a derived chain, sitting OUTSIDE every reduction
+— hit the blanket `LifetimeAmbiguousLeaf` rejection, so real 415(b) logic could not run end to end.
+Empirically confirmed failing (scratchpad/check_derived_n_lifetime.py errored on `year_attained_62`).
+
+### What changed (dense.rs lifetime paths only; no schema change; per-period execute/execute_f64 unchanged)
+- `LifetimeExecutor::eval_scalar` `Input` / `InputOrElse` arms no longer error. They call the new
+  `eval_period_invariant_input(expr, name)`, which evaluates the SAME bare-input node under every
+  period's `DenseExecutor` (one column per period, positionally aligned) and checks PER ROW that the
+  value is identical across ALL supplied periods.
+  - All rows invariant → bind period 0's column (dtype preserved); the caller consumes it exactly like
+    any other column, so a value in scalar OR in the `n` position, reached directly OR through a derived
+    chain (Sub/Max/… compose row-wise), all work.
+  - Any row varies → new `EvalError::LifetimePeriodVaryingInput`, naming the input and the first two
+    differing period labels (`start..end`) and values. Truly period-varying inputs still fail loudly.
+- New free helpers in dense.rs: `first_differing_row` (exact per-row equality; numeric variants compared
+  by Decimal-promoted value so `1985` == `1985.0`; non-numeric mismatch or non-finite → treated as
+  differing = safe error), `period_label`, `dense_value_label`.
+- New `EvalError::LifetimePeriodVaryingInput` variant in engine.rs. `LifetimeAmbiguousLeaf` still used
+  for the genuinely period-specific leaves (PeriodStart/End, Date*, Count/SumRelated).
+- Parameters keep their existing last-supplied-period behavior; the amendment touches inputs only.
+
+### Tests
+- tests/lifetime.rs (+4, 28 total): (a) per-person-constant input binds outside a reduction;
+  (b) per-row-varying but per-period-constant input binds per row (rows 100 vs 500);
+  (c) period-VARYING input errors, message names the input; (d) the derived-n-from-constant-inputs
+  chain end to end (two workers, n = 36 and 31; earnings_total [3_456_000, 1_922_000]; aime [8000, 5166]).
+- python/tests/test_dense_lifetime.py (+2): two-worker derived-n case (mirrors the scratchpad script) and
+  a period-varying-input error case naming the input.
+
+### Acceptance-script arithmetic note (IMPORTANT — flagged for review)
+scratchpad/check_derived_n_lifetime.py as delivered expected `aime[1] = 5167` for worker B, with a
+comment `floor(5167.20)`. That is wrong: worker B has total 1_922_000, n = 31, so
+`aime = floor(1_922_000 / (12*31 = 372)) = floor(5166.666…) = 5166`. 5167 is the round-HALF-UP value,
+not the `floor` the module (and 42 USC 415(b)(2)(A) / 20 CFR 404.211(d), which round DOWN) use — and no
+integer months divisor can even produce 5167 for this total (floor jumps 5180 at d=371 to 5166 at d=372,
+skipping 5167). Independently re-derived. The engine is statutorily correct at 5166; the fixture's one
+expected constant was corrected 5167 → 5166 (worker A's 8000 is unaffected: floor and round agree there).
+The binding mechanism the script exercises — two workers with DIFFERENT derived n binding correctly — is
+proven by `earnings_total = [3_456_000, 1_922_000]`, which matches exactly.
+
+### Final gate (all GREEN, this amendment)
+- cargo fmt --check clean; cargo build; cargo test (default) 0 failed; cargo test --features schema
+  0 failed (schema golden-file guard passes — no artifact-schema change); cargo check python-ext;
+  cargo check wasm32-unknown-unknown --no-default-features.
+- clippy --all-targets: actual lint findings BYTE-IDENTICAL to the pre-amendment branch tip (37 finding
+  lines; 35 lib + 35 lib-test as before) — ZERO new warnings; none reference the new code.
+- 28 Rust lifetime tests + 38 Python tests pass against the maturin-rebuilt extension; the corrected
+  scratchpad acceptance script passes (earnings_total [3456000, 1922000], aime [8000, 5166]).

--- a/python-ext/src/lib.rs
+++ b/python-ext/src/lib.rs
@@ -171,6 +171,60 @@ impl CompiledDenseProgramHandle {
     ) -> PyResult<Bound<'py, PyDict>> {
         self.run(py, period_kind, start, end, inputs, relations, outputs, true)
     }
+
+    /// Execute over an entity's lifetime in `f64` arithmetic: one positionally
+    /// aligned input batch per period, so formulas can reduce over the period
+    /// axis with `sum_over_periods` / `max_over_periods` / `count_over_periods`
+    /// / `sum_top_n_over_periods`.
+    ///
+    /// `periods` is a list of `(period_kind, start, end)` triples and `batches`
+    /// a same-length list of `(inputs[, relations])` — each `inputs` a dict of
+    /// column arrays and each optional `relations` the dict shape `execute`
+    /// accepts. Row `i` must be the same entity in every batch (identical row
+    /// order and count). Every requested output's formula must contain an
+    /// over-periods reduction; period-specific outputs should use `execute_f64`.
+    #[pyo3(signature = (periods, batches, outputs=None))]
+    fn execute_lifetime_f64<'py>(
+        &self,
+        py: Python<'py>,
+        periods: Vec<(String, String, String)>,
+        batches: Vec<Bound<'py, PyAny>>,
+        outputs: Option<Vec<String>>,
+    ) -> PyResult<Bound<'py, PyDict>> {
+        if periods.len() != batches.len() {
+            return Err(PyValueError::new_err(format!(
+                "lifetime execution needs one batch per period: got {} periods and {} batches",
+                periods.len(),
+                batches.len()
+            )));
+        }
+
+        let parsed_periods = periods
+            .iter()
+            .map(|(period_kind, start, end)| {
+                Ok(Period {
+                    kind: parse_period_kind(period_kind),
+                    start: parse_date(start)?,
+                    end: parse_date(end)?,
+                })
+            })
+            .collect::<PyResult<Vec<Period>>>()?;
+
+        let built_batches = batches
+            .into_iter()
+            .map(|batch| {
+                let (inputs, relations) = split_lifetime_batch(&batch)?;
+                build_batch(&self.compiled, inputs, relations)
+            })
+            .collect::<PyResult<Vec<DenseBatchSpec>>>()?;
+
+        let output_names = outputs.unwrap_or_else(|| self.compiled.output_names());
+        let execution = self
+            .compiled
+            .execute_lifetime_f64(&parsed_periods, built_batches, &output_names)
+            .map_err(|error| PyRuntimeError::new_err(error.to_string()))?;
+        execution_to_pydict(py, execution)
+    }
 }
 
 impl CompiledDenseProgramHandle {
@@ -200,58 +254,91 @@ impl CompiledDenseProgramHandle {
         }
         .map_err(|error| PyRuntimeError::new_err(error.to_string()))?;
 
-        let output_dict = PyDict::new(py);
-        for (name, value) in execution.outputs {
-            match value {
-                axiom_rules_engine::dense::DenseOutputValue::Scalar(column) => match column {
-                    DenseColumn::Bool(values) => {
-                        output_dict.set_item(name, PyArray1::from_vec(py, values))?;
-                    }
-                    DenseColumn::Integer(values) => {
-                        output_dict.set_item(name, PyArray1::from_vec(py, values))?;
-                    }
-                    DenseColumn::Decimal(values) => {
-                        let materialised = values
-                            .into_iter()
-                            .map(|value| {
-                                value.to_f64().ok_or_else(|| {
-                                    PyRuntimeError::new_err(
-                                        "failed to materialise decimal output as float64",
-                                    )
-                                })
-                            })
-                            .collect::<PyResult<Vec<f64>>>()?;
-                        output_dict.set_item(name, PyArray1::from_vec(py, materialised))?;
-                    }
-                    DenseColumn::Float(values) => {
-                        output_dict.set_item(name, PyArray1::from_vec(py, values))?;
-                    }
-                    DenseColumn::Text(values) => {
-                        output_dict.set_item(name, PyList::new(py, values)?)?;
-                    }
-                    DenseColumn::Date(values) => {
-                        let materialised = values
-                            .into_iter()
-                            .map(|value| value.to_string())
-                            .collect::<Vec<String>>();
-                        output_dict.set_item(name, PyList::new(py, materialised)?)?;
-                    }
-                },
-                axiom_rules_engine::dense::DenseOutputValue::Judgment(values) => {
+        execution_to_pydict(py, execution)
+    }
+}
+
+/// Materialise a dense execution result into the `{row_count, outputs}` dict the
+/// Python surface returns. Shared by the per-period and lifetime entry points.
+fn execution_to_pydict(
+    py: Python<'_>,
+    execution: axiom_rules_engine::dense::DenseExecutionResult,
+) -> PyResult<Bound<'_, PyDict>> {
+    let output_dict = PyDict::new(py);
+    for (name, value) in execution.outputs {
+        match value {
+            axiom_rules_engine::dense::DenseOutputValue::Scalar(column) => match column {
+                DenseColumn::Bool(values) => {
+                    output_dict.set_item(name, PyArray1::from_vec(py, values))?;
+                }
+                DenseColumn::Integer(values) => {
+                    output_dict.set_item(name, PyArray1::from_vec(py, values))?;
+                }
+                DenseColumn::Decimal(values) => {
                     let materialised = values
                         .into_iter()
-                        .map(|value| judgment_code(&value))
-                        .collect::<Vec<i8>>();
+                        .map(|value| {
+                            value.to_f64().ok_or_else(|| {
+                                PyRuntimeError::new_err(
+                                    "failed to materialise decimal output as float64",
+                                )
+                            })
+                        })
+                        .collect::<PyResult<Vec<f64>>>()?;
                     output_dict.set_item(name, PyArray1::from_vec(py, materialised))?;
                 }
+                DenseColumn::Float(values) => {
+                    output_dict.set_item(name, PyArray1::from_vec(py, values))?;
+                }
+                DenseColumn::Text(values) => {
+                    output_dict.set_item(name, PyList::new(py, values)?)?;
+                }
+                DenseColumn::Date(values) => {
+                    let materialised = values
+                        .into_iter()
+                        .map(|value| value.to_string())
+                        .collect::<Vec<String>>();
+                    output_dict.set_item(name, PyList::new(py, materialised)?)?;
+                }
+            },
+            axiom_rules_engine::dense::DenseOutputValue::Judgment(values) => {
+                let materialised = values
+                    .into_iter()
+                    .map(|value| judgment_code(&value))
+                    .collect::<Vec<i8>>();
+                output_dict.set_item(name, PyArray1::from_vec(py, materialised))?;
             }
         }
-
-        let result = PyDict::new(py);
-        result.set_item("row_count", execution.row_count)?;
-        result.set_item("outputs", output_dict)?;
-        Ok(result)
     }
+
+    let result = PyDict::new(py);
+    result.set_item("row_count", execution.row_count)?;
+    result.set_item("outputs", output_dict)?;
+    Ok(result)
+}
+
+/// Split one lifetime batch entry into its `(inputs, relations)` parts. A batch
+/// is either a bare inputs dict, or a `(inputs[, relations])` tuple/list — the
+/// same relation dict shape `build_batch` already consumes.
+fn split_lifetime_batch<'py>(
+    batch: &Bound<'py, PyAny>,
+) -> PyResult<(Bound<'py, PyDict>, Option<Bound<'py, PyDict>>)> {
+    if let Ok(inputs) = batch.cast::<PyDict>() {
+        return Ok((inputs.clone(), None));
+    }
+    // Otherwise expect a sequence: (inputs,) or (inputs, relations).
+    let items = batch.try_iter()?.collect::<PyResult<Vec<_>>>()?;
+    if items.is_empty() || items.len() > 2 {
+        return Err(PyValueError::new_err(
+            "each lifetime batch must be an inputs dict or an (inputs[, relations]) tuple",
+        ));
+    }
+    let inputs = items[0].cast::<PyDict>()?.clone();
+    let relations = match items.get(1) {
+        Some(value) if !value.is_none() => Some(value.cast::<PyDict>()?.clone()),
+        _ => None,
+    };
+    Ok((inputs, relations))
 }
 
 #[pymodule]

--- a/python/axiom_rules_engine/dense.py
+++ b/python/axiom_rules_engine/dense.py
@@ -141,6 +141,67 @@ class CompiledDenseProgram:
             outputs,
         )
 
+    def execute_lifetime_f64(
+        self,
+        *,
+        periods: list[tuple[str, str, str]],
+        batches: list[dict[str, np.ndarray]]
+        | list[tuple[dict[str, np.ndarray], dict[str, DenseRelationBatch] | None]],
+        outputs: list[str] | None = None,
+    ) -> dict[str, Any]:
+        """Execute over an entity's lifetime in f64 arithmetic.
+
+        One positionally aligned input batch per period, so formulas can reduce
+        over the period axis with ``sum_over_periods`` / ``max_over_periods`` /
+        ``count_over_periods`` / ``sum_top_n_over_periods``.
+
+        ``periods`` is a list of ``(period_kind, start, end)`` triples;
+        ``batches`` is a same-length list where each entry is either a bare
+        ``inputs`` dict (no relations) or an ``(inputs, relations)`` tuple, using
+        the same column and relation shapes :meth:`execute` accepts. Row ``i``
+        must be the same entity in every batch (identical row order and count).
+        Every requested output's formula must contain an over-periods reduction;
+        period-specific outputs should use :meth:`execute_f64`.
+        """
+        if len(periods) != len(batches):
+            raise ValueError(
+                "execute_lifetime_f64 needs one batch per period: "
+                f"got {len(periods)} periods and {len(batches)} batches"
+            )
+        prepared_batches = [
+            self._prepare_lifetime_batch(batch) for batch in batches
+        ]
+        prepared_periods = [
+            (str(kind), str(start), str(end)) for kind, start, end in periods
+        ]
+        return self._native.execute_lifetime_f64(
+            prepared_periods, prepared_batches, outputs
+        )
+
+    @staticmethod
+    def _prepare_lifetime_batch(
+        batch: dict[str, np.ndarray]
+        | tuple[dict[str, np.ndarray], dict[str, DenseRelationBatch] | None],
+    ) -> Any:
+        if isinstance(batch, dict):
+            inputs: dict[str, np.ndarray] = batch
+            relations: dict[str, DenseRelationBatch] | None = None
+        else:
+            inputs, relations = batch
+        prepared_inputs = {name: np.asarray(values) for name, values in inputs.items()}
+        if relations is None:
+            return (prepared_inputs, None)
+        prepared_relations = {
+            key: {
+                "offsets": np.asarray(rel.offsets),
+                "inputs": {
+                    name: np.asarray(values) for name, values in rel.inputs.items()
+                },
+            }
+            for key, rel in relations.items()
+        }
+        return (prepared_inputs, prepared_relations)
+
     def _run(
         self,
         native_execute: Any,

--- a/python/tests/test_dense_lifetime.py
+++ b/python/tests/test_dense_lifetime.py
@@ -27,9 +27,9 @@ pytestmark = pytest.mark.skipif(
 )
 
 # 42 USC 415(b): AIME is the sum of a worker's highest-35 years of indexed
-# earnings divided by 420 (35 years x 12 months), rounded down. The computation
-# years count whether or not the worker had earnings, so sum_top_n zero-pads
-# missing years — here there are 40 years, so the lowest 5 are dropped instead.
+# earnings divided by 420 (35 years x 12 months), rounded down. Under the strict
+# n contract n must be within 1..=the supplied period count; here 40 years are
+# supplied and the top 35 drop the lowest 5.
 AIME_MODULE = """\
 format: rulespec/v1
 module:
@@ -239,10 +239,15 @@ class TestDerivedPersonVaryingN:
         )
         np.testing.assert_allclose(result["outputs"]["aime"], [8_000.0, 5_166.0])
 
-    def test_period_varying_input_raises_naming_it(self, derived_n_program) -> None:
-        # If a bare input actually varies across periods it is period-ambiguous
-        # outside a reduction and must error, naming the input. Here worker 0's
-        # year_attained_62 changes between the two periods.
+    def test_period_varying_n_raises_under_strict_contract(
+        self, derived_n_program
+    ) -> None:
+        # year_attained_62 feeds computation_year_count, which is the `n` of
+        # sum_top_n_over_periods. When that input varies across periods the
+        # derived n varies too, so the strict n contract catches it first with a
+        # precise "n is not period-invariant" error (36 vs 37) rather than
+        # silently pinning n to the reference period. Parameter- and
+        # input-sourced n are held to the identical invariance requirement.
         periods = [
             ("calendar_year", "1985-01-01", "1985-12-31"),
             ("calendar_year", "1986-01-01", "1986-12-31"),
@@ -256,10 +261,10 @@ class TestDerivedPersonVaryingN:
             {
                 "indexed_earnings": np.array([50_000.0]),
                 "year_attained_21": np.array([1985.0]),
-                "year_attained_62": np.array([2027.0]),  # varies -> ambiguous
+                "year_attained_62": np.array([2027.0]),  # varies -> n varies
             },
         ]
-        with pytest.raises(RuntimeError, match="year_attained_62"):
+        with pytest.raises(RuntimeError, match="n is not period-invariant"):
             derived_n_program.execute_lifetime_f64(
                 periods=periods, batches=batches, outputs=["aime"]
             )
@@ -283,3 +288,85 @@ class TestLifetimeErrors:
         ]
         with pytest.raises(RuntimeError, match="same entity row count"):
             program.execute_lifetime_f64(periods=periods, batches=batches, outputs=["aime"])
+
+    def test_descending_periods_raise(self, program) -> None:
+        # Supplied periods must be strictly ascending by start date.
+        periods = [
+            ("calendar_year", "1991-01-01", "1991-12-31"),
+            ("calendar_year", "1990-01-01", "1990-12-31"),
+        ]
+        batches = [
+            {"indexed_earnings": np.array([10_000.0])},
+            {"indexed_earnings": np.array([20_000.0])},
+        ]
+        with pytest.raises(RuntimeError, match="strictly ascending"):
+            program.execute_lifetime_f64(periods=periods, batches=batches, outputs=["aime"])
+
+
+def _single_rule_module(name: str, dtype: str, formula: str) -> str:
+    return f"""\
+format: rulespec/v1
+rules:
+  - name: {name}
+    kind: derived
+    entity: Worker
+    dtype: {dtype}
+    period: Year
+    versions:
+      - effective_from: '1979-01-01'
+        formula: |-
+          {formula}
+"""
+
+
+class TestReductionSemantics:
+    """Post-review semantics exercised through the exposed f64 lifetime path."""
+
+    def test_count_over_periods_counts_nonzero_per_row(self, tmp_path) -> None:
+        # count_over_periods counts, per row, the periods with a nonzero value.
+        module = _single_rule_module("years", "Integer", "count_over_periods(earnings)")
+        path = tmp_path / "count.yaml"
+        path.write_text(module, encoding="utf-8")
+        program = CompiledDenseProgram.from_file(path, entity="Worker")
+        periods = [
+            ("calendar_year", f"{2001 + k}-01-01", f"{2001 + k}-12-31")
+            for k in range(4)
+        ]
+        # Row 0: [0, 20, 0, 40] -> 2 nonzero. Row 1: [9, 0, 7, 6] -> 3 nonzero.
+        batches = [
+            {"earnings": np.array([0.0, 9.0])},
+            {"earnings": np.array([20.0, 0.0])},
+            {"earnings": np.array([0.0, 7.0])},
+            {"earnings": np.array([40.0, 6.0])},
+        ]
+        result = program.execute_lifetime_f64(
+            periods=periods, batches=batches, outputs=["years"]
+        )
+        np.testing.assert_allclose(result["outputs"]["years"], [2.0, 3.0])
+
+    def test_sum_top_n_n_exceeds_period_count_raises(self, tmp_path) -> None:
+        # Strict n contract in the exposed f64 path: n=45 with 41 periods is out
+        # of range (the four extra slots would only pad zeros).
+        module = _single_rule_module(
+            "top", "Money", "sum_top_n_over_periods(earnings, 45)"
+        )
+        path = tmp_path / "topn.yaml"
+        path.write_text(module, encoding="utf-8")
+        program = CompiledDenseProgram.from_file(path, entity="Worker")
+        periods = [
+            ("calendar_year", f"{1985 + k}-01-01", f"{1985 + k}-12-31")
+            for k in range(41)
+        ]
+        batches = [{"earnings": np.array([1_000.0])} for _ in range(41)]
+        with pytest.raises(RuntimeError, match="1 <= n <="):
+            program.execute_lifetime_f64(
+                periods=periods, batches=batches, outputs=["top"]
+            )
+
+    def test_unknown_over_periods_reduction_fails_to_parse(self, tmp_path) -> None:
+        # An unknown *_over_periods name fails at parse/compile time.
+        module = _single_rule_module("bad", "Money", "avg_over_periods(earnings)")
+        path = tmp_path / "bad.yaml"
+        path.write_text(module, encoding="utf-8")
+        with pytest.raises((ValueError, RuntimeError), match="avg_over_periods"):
+            CompiledDenseProgram.from_file(path, entity="Worker")

--- a/python/tests/test_dense_lifetime.py
+++ b/python/tests/test_dense_lifetime.py
@@ -118,6 +118,153 @@ class TestAimeAcceptance:
         np.testing.assert_allclose(result["outputs"]["aime"], [2833.0, 1666.0])
 
 
+# A benefit-computation-year count derived from per-person-constant inputs (the
+# years a worker attains 21 and 62), used both as the person-varying `n` of
+# sum_top_n_over_periods and as an outer divisor — the exact shape of 42 USC
+# 415(b). The count sits outside every reduction and is reached only through a
+# derived chain; lifetime execution binds the per-person-constant inputs it
+# bottoms out in because they are supplied identically in every period.
+DERIVED_N_MODULE = """\
+format: rulespec/v1
+module:
+  summary: |-
+    Shape-mirror of 42 USC 415(b): a benefit-computation-year count derived from
+    per-person-constant inputs feeds sum_top_n_over_periods as a person-varying n
+    and divides the total to an AIME.
+rules:
+  - name: dropout_years
+    kind: parameter
+    dtype: Integer
+    versions:
+      - effective_from: '1979-01-01'
+        formula: '5'
+  - name: minimum_computation_years
+    kind: parameter
+    dtype: Integer
+    versions:
+      - effective_from: '1979-01-01'
+        formula: '2'
+  - name: months_per_year
+    kind: parameter
+    dtype: Integer
+    versions:
+      - effective_from: '1979-01-01'
+        formula: '12'
+  - name: elapsed_years
+    kind: derived
+    entity: Worker
+    dtype: Integer
+    period: Year
+    versions:
+      - effective_from: '1979-01-01'
+        formula: |-
+          year_attained_62 - max(1950, year_attained_21)
+  - name: computation_year_count
+    kind: derived
+    entity: Worker
+    dtype: Integer
+    period: Year
+    versions:
+      - effective_from: '1979-01-01'
+        formula: |-
+          max(minimum_computation_years, elapsed_years - dropout_years)
+  - name: earnings_total
+    kind: derived
+    entity: Worker
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '1979-01-01'
+        formula: |-
+          sum_top_n_over_periods(indexed_earnings, computation_year_count)
+  - name: aime
+    kind: derived
+    entity: Worker
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '1979-01-01'
+        formula: |-
+          floor(earnings_total / (months_per_year * computation_year_count))
+"""
+
+
+@pytest.fixture(scope="module")
+def derived_n_program(tmp_path_factory) -> CompiledDenseProgram:
+    path = tmp_path_factory.mktemp("derived_n") / "aime.yaml"
+    path.write_text(DERIVED_N_MODULE, encoding="utf-8")
+    return CompiledDenseProgram.from_file(path, entity="Worker")
+
+
+class TestDerivedPersonVaryingN:
+    """Two workers with DIFFERENT derived `n` (36 vs 31) in one batch, mirroring
+    the scratchpad acceptance fixture and rulespec-us #541's 415(b) shape.
+
+    Worker A: year21=1985, year62=2026 -> elapsed 41, count max(2, 41-5) = 36.
+        Earnings 96_000 x36 then 12_000, 6_000, 0, 0, 0 (41 periods).
+        top-36 sum = 36 * 96_000 = 3_456_000.
+        aime = floor(3_456_000 / (12*36 = 432)) = floor(8000.0) = 8000.
+    Worker B: year21=1990, year62=2026 -> elapsed 36, count max(2, 36-5) = 31.
+        Earnings flat 62_000 (41 periods). top-31 sum = 31 * 62_000 = 1_922_000.
+        aime = floor(1_922_000 / (12*31 = 372)) = floor(5166.666...) = 5166.
+            (Statutory floor per 42 USC 415(b)(2)(A) / 20 CFR 404.211(d); the
+             quotient rounds DOWN, so 5166 — not the round-half-up 5167, which no
+             integer months divisor can even produce for this total.)
+    """
+
+    def test_two_workers_with_different_derived_n(self, derived_n_program) -> None:
+        n_periods = 41
+        periods = [
+            ("calendar_year", f"{1985 + k}-01-01", f"{1985 + k}-12-31")
+            for k in range(n_periods)
+        ]
+        a_earn = [96_000.0] * 36 + [12_000.0, 6_000.0, 0.0, 0.0, 0.0]
+        b_earn = [62_000.0] * n_periods
+        batches = [
+            {
+                "indexed_earnings": np.array([a_earn[k], b_earn[k]]),
+                "year_attained_21": np.array([1985.0, 1990.0]),
+                "year_attained_62": np.array([2026.0, 2026.0]),
+            }
+            for k in range(n_periods)
+        ]
+        result = derived_n_program.execute_lifetime_f64(
+            periods=periods,
+            batches=batches,
+            outputs=["earnings_total", "aime"],
+        )
+        assert result["row_count"] == 2
+        np.testing.assert_allclose(
+            result["outputs"]["earnings_total"], [3_456_000.0, 1_922_000.0]
+        )
+        np.testing.assert_allclose(result["outputs"]["aime"], [8_000.0, 5_166.0])
+
+    def test_period_varying_input_raises_naming_it(self, derived_n_program) -> None:
+        # If a bare input actually varies across periods it is period-ambiguous
+        # outside a reduction and must error, naming the input. Here worker 0's
+        # year_attained_62 changes between the two periods.
+        periods = [
+            ("calendar_year", "1985-01-01", "1985-12-31"),
+            ("calendar_year", "1986-01-01", "1986-12-31"),
+        ]
+        batches = [
+            {
+                "indexed_earnings": np.array([50_000.0]),
+                "year_attained_21": np.array([1985.0]),
+                "year_attained_62": np.array([2026.0]),
+            },
+            {
+                "indexed_earnings": np.array([50_000.0]),
+                "year_attained_21": np.array([1985.0]),
+                "year_attained_62": np.array([2027.0]),  # varies -> ambiguous
+            },
+        ]
+        with pytest.raises(RuntimeError, match="year_attained_62"):
+            derived_n_program.execute_lifetime_f64(
+                periods=periods, batches=batches, outputs=["aime"]
+            )
+
+
 class TestLifetimeErrors:
     def test_period_and_batch_count_mismatch_raises(self, program) -> None:
         periods = [("calendar_year", "1990-01-01", "1990-12-31")]

--- a/python/tests/test_dense_lifetime.py
+++ b/python/tests/test_dense_lifetime.py
@@ -1,0 +1,138 @@
+"""Lifetime (cross-period reduction) surface: ``execute_lifetime_f64``.
+
+The acceptance test from issue #67: compile a minimal inline rulespec module
+whose ``aime`` rule is
+
+    aime = floor(sum_top_n_over_periods(indexed_earnings, 35) / 420)
+
+feed a synthetic worker with a 40-year history through
+``execute_lifetime_f64``, and assert the AIME equals the hand-derived value.
+
+These tests exercise the native ``axiom_rules_engine_dense`` extension and skip
+when it is not built (CI type-checks the extension crate but does not build the
+wheel). Build locally with::
+
+    maturin develop --release --manifest-path python-ext/Cargo.toml
+"""
+
+import numpy as np
+import pytest
+
+from axiom_rules_engine import CompiledDenseProgram
+from axiom_rules_engine.dense import NativeCompiledDenseProgram
+
+pytestmark = pytest.mark.skipif(
+    NativeCompiledDenseProgram is None,
+    reason="axiom_rules_engine_dense extension is not built",
+)
+
+# 42 USC 415(b): AIME is the sum of a worker's highest-35 years of indexed
+# earnings divided by 420 (35 years x 12 months), rounded down. The computation
+# years count whether or not the worker had earnings, so sum_top_n zero-pads
+# missing years — here there are 40 years, so the lowest 5 are dropped instead.
+AIME_MODULE = """\
+format: rulespec/v1
+module:
+  summary: |-
+    Synthetic 42 USC 415(b) AIME: highest-35-years selection over a worker's own
+    earnings history. Acceptance fixture for cross-period reductions (#67).
+rules:
+  - name: computation_years
+    kind: parameter
+    dtype: Integer
+    versions:
+      - effective_from: '1960-01-01'
+        formula: '35'
+  - name: aime_divisor
+    kind: parameter
+    dtype: Integer
+    versions:
+      - effective_from: '1960-01-01'
+        formula: '420'
+  - name: aime
+    kind: derived
+    entity: Worker
+    dtype: Money
+    unit: USD
+    period: Year
+    source: 42 USC 415(b)
+    versions:
+      - effective_from: '1960-01-01'
+        formula: |-
+          floor(sum_top_n_over_periods(indexed_earnings, computation_years) / aime_divisor)
+"""
+
+
+@pytest.fixture(scope="module")
+def program(tmp_path_factory) -> CompiledDenseProgram:
+    path = tmp_path_factory.mktemp("lifetime") / "aime.yaml"
+    path.write_text(AIME_MODULE, encoding="utf-8")
+    return CompiledDenseProgram.from_file(path, entity="Worker")
+
+
+def _aime_worker() -> tuple[list[tuple[str, str, str]], list[dict[str, np.ndarray]]]:
+    """A synthetic 40-year worker with a clean, hand-derivable AIME.
+
+    Year k (k = 1..40) earns 12_000 + 1_000 * (k - 1):
+        12_000, 13_000, ..., 51_000.
+    The highest 35 of 40 drop the five smallest (12_000..16_000), keeping the
+    arithmetic series 17_000, 18_000, ..., 51_000 (35 terms):
+        sum(top 35) = 35 * (17_000 + 51_000) / 2 = 35 * 34_000 = 1_190_000
+        AIME        = floor(1_190_000 / 420) = floor(2833.33...) = 2833
+    """
+    periods = [
+        ("calendar_year", f"{1980 + k}-01-01", f"{1980 + k}-12-31") for k in range(1, 41)
+    ]
+    batches = [
+        {"indexed_earnings": np.array([12_000.0 + 1_000.0 * (k - 1)])} for k in range(1, 41)
+    ]
+    return periods, batches
+
+
+class TestAimeAcceptance:
+    EXPECTED_AIME = 2833.0  # hand-derived in _aime_worker()
+
+    def test_forty_year_worker_aime(self, program) -> None:
+        periods, batches = _aime_worker()
+        result = program.execute_lifetime_f64(
+            periods=periods, batches=batches, outputs=["aime"]
+        )
+        assert result["row_count"] == 1
+        np.testing.assert_allclose(result["outputs"]["aime"], [self.EXPECTED_AIME])
+
+    def test_two_workers_align_by_row(self, program) -> None:
+        # Two workers side by side. Worker 0 is the reference 40-year worker;
+        # worker 1 earns a flat 20_000 every year, so its top 35 = 35 * 20_000 =
+        # 700_000 and AIME = floor(700_000 / 420) = floor(1666.66...) = 1666.
+        periods = [
+            ("calendar_year", f"{1980 + k}-01-01", f"{1980 + k}-12-31") for k in range(1, 41)
+        ]
+        batches = [
+            {"indexed_earnings": np.array([12_000.0 + 1_000.0 * (k - 1), 20_000.0])}
+            for k in range(1, 41)
+        ]
+        result = program.execute_lifetime_f64(
+            periods=periods, batches=batches, outputs=["aime"]
+        )
+        assert result["row_count"] == 2
+        np.testing.assert_allclose(result["outputs"]["aime"], [2833.0, 1666.0])
+
+
+class TestLifetimeErrors:
+    def test_period_and_batch_count_mismatch_raises(self, program) -> None:
+        periods = [("calendar_year", "1990-01-01", "1990-12-31")]
+        batches: list[dict[str, np.ndarray]] = []
+        with pytest.raises(ValueError, match="one batch per period"):
+            program.execute_lifetime_f64(periods=periods, batches=batches, outputs=["aime"])
+
+    def test_row_count_mismatch_raises(self, program) -> None:
+        periods = [
+            ("calendar_year", "1990-01-01", "1990-12-31"),
+            ("calendar_year", "1991-01-01", "1991-12-31"),
+        ]
+        batches = [
+            {"indexed_earnings": np.array([10_000.0, 20_000.0])},
+            {"indexed_earnings": np.array([10_000.0])},
+        ]
+        with pytest.raises(RuntimeError, match="same entity row count"):
+            program.execute_lifetime_f64(periods=periods, batches=batches, outputs=["aime"])

--- a/schemas/compiled-artifact.v1.schema.json
+++ b/schemas/compiled-artifact.v1.schema.json
@@ -474,6 +474,16 @@
       },
       "type": "object"
     },
+    "OverPeriodsKindSpec": {
+      "description": "The over-periods reduction vocabulary, mirroring\n[`crate::model::OverPeriodsKind`].",
+      "enum": [
+        "sum",
+        "max",
+        "count",
+        "sum_top_n"
+      ],
+      "type": "string"
+    },
     "ParameterVersionSpec": {
       "properties": {
         "effective_from": {
@@ -1071,6 +1081,37 @@
             "condition",
             "then_expr",
             "else_expr"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "Reduction over an entity's own period axis (lifetime execution only).\n`n` is present only for the `sum_top_n` reduction. Expression-level,\nadditive to the serialized surface — no artifact-format-version bump.",
+          "properties": {
+            "kind": {
+              "const": "over_periods",
+              "type": "string"
+            },
+            "n": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/ScalarExprSpec"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "over": {
+              "$ref": "#/$defs/OverPeriodsKindSpec"
+            },
+            "value": {
+              "$ref": "#/$defs/ScalarExprSpec"
+            }
+          },
+          "required": [
+            "kind",
+            "over",
+            "value"
           ],
           "type": "object"
         }

--- a/src/api.rs
+++ b/src/api.rs
@@ -442,6 +442,12 @@ fn collect_scalar_deps(
             collect_scalar_deps(then_expr, deps);
             collect_scalar_deps(else_expr, deps);
         }
+        ScalarExpr::OverPeriods { value, n, .. } => {
+            collect_scalar_deps(value, deps);
+            if let Some(n) = n {
+                collect_scalar_deps(n, deps);
+            }
+        }
     }
 }
 

--- a/src/bulk.rs
+++ b/src/bulk.rs
@@ -1,7 +1,7 @@
 use std::collections::{BTreeMap, HashMap, HashSet};
 
-use rust_decimal::prelude::ToPrimitive;
 use rust_decimal::Decimal;
+use rust_decimal::prelude::ToPrimitive;
 
 use crate::api::{
     ExecutionMetadata, ExecutionMode, ExecutionQuery, ExecutionResponse, OutputValue, QueryResult,
@@ -594,6 +594,9 @@ impl<'a> BulkEvaluator<'a> {
             ScalarExpr::DaysBetween { .. } => Err(EvalError::TypeMismatch(
                 "bulk fast mode does not yet support days_between".to_string(),
             )),
+            ScalarExpr::OverPeriods { kind, .. } => {
+                Err(EvalError::OverPeriodsOutsideLifetime(kind.as_call_name()))
+            }
             ScalarExpr::CountRelated {
                 relation,
                 current_slot,
@@ -1117,6 +1120,9 @@ impl<'a> BulkEvaluator<'a> {
             )),
             ScalarExpr::PeriodStart => Ok(ScalarValue::Date(self.period.start)),
             ScalarExpr::PeriodEnd => Ok(ScalarValue::Date(self.period.end)),
+            ScalarExpr::OverPeriods { kind, .. } => {
+                Err(EvalError::OverPeriodsOutsideLifetime(kind.as_call_name()))
+            }
             ScalarExpr::DateAddDays { .. }
             | ScalarExpr::DaysBetween { .. }
             | ScalarExpr::CountRelated { .. }

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -389,6 +389,15 @@ fn collect_fast_blockers_from_scalar_expr(
             collect_fast_blockers_from_scalar_expr(derived_name, then_expr, blockers);
             collect_fast_blockers_from_scalar_expr(derived_name, else_expr, blockers);
         }
+        ScalarExprSpec::OverPeriods { value, n, .. } => {
+            blockers.push(format!(
+                "{derived_name}: bulk fast mode does not support over-periods reductions; use the dense lifetime execution surface"
+            ));
+            collect_fast_blockers_from_scalar_expr(derived_name, value, blockers);
+            if let Some(n) = n {
+                collect_fast_blockers_from_scalar_expr(derived_name, n, blockers);
+            }
+        }
     }
 }
 
@@ -604,6 +613,12 @@ fn collect_scalar_dependencies(
             collect_scalar_dependencies(then_expr, dependencies, relation_dependencies);
             collect_scalar_dependencies(else_expr, dependencies, relation_dependencies);
         }
+        ScalarExprSpec::OverPeriods { value, n, .. } => {
+            collect_scalar_dependencies(value, dependencies, relation_dependencies);
+            if let Some(n) = n {
+                collect_scalar_dependencies(n, dependencies, relation_dependencies);
+            }
+        }
     }
 }
 
@@ -694,6 +709,12 @@ fn collect_relation_members_from_scalar(expr: &ScalarExprSpec, relations: &mut H
             collect_relation_members_from_judgment(condition, relations);
             collect_relation_members_from_scalar(then_expr, relations);
             collect_relation_members_from_scalar(else_expr, relations);
+        }
+        ScalarExprSpec::OverPeriods { value, n, .. } => {
+            collect_relation_members_from_scalar(value, relations);
+            if let Some(n) = n {
+                collect_relation_members_from_scalar(n, relations);
+            }
         }
     }
 }

--- a/src/dense.rs
+++ b/src/dense.rs
@@ -351,6 +351,13 @@ pub enum DenseCompileError {
     #[error("dense compilation does not yet support {0}")]
     Unsupported(String),
     #[error(
+        "over-periods reductions cannot be nested: `{outer}` contains `{inner}` in its argument — reduce over the period axis once"
+    )]
+    NestedOverPeriods {
+        outer: &'static str,
+        inner: &'static str,
+    },
+    #[error(
         "dense compilation only supports dependencies within the same root entity; `{dependency}` from `{derived}` crosses into `{entity}`"
     )]
     CrossEntityDependency {
@@ -1204,13 +1211,30 @@ impl<'a> DenseCompiler<'a> {
                 then_expr: Box::new(self.compile_scalar_expr(derived_name, then_expr)?),
                 else_expr: Box::new(self.compile_scalar_expr(derived_name, else_expr)?),
             }),
-            ScalarExpr::OverPeriods { kind, value, n } => Ok(CompiledScalarExpr::OverPeriods {
-                kind: *kind,
-                value: Box::new(self.compile_scalar_expr(derived_name, value)?),
-                n: n.as_ref()
+            ScalarExpr::OverPeriods { kind, value, n } => {
+                let value = self.compile_scalar_expr(derived_name, value)?;
+                let n = n
+                    .as_ref()
                     .map(|inner| self.compile_scalar_expr(derived_name, inner).map(Box::new))
-                    .transpose()?,
-            }),
+                    .transpose()?;
+                // A reduction reduces the period axis away, so nesting another
+                // reduction directly in its argument is meaningless. Reject it at
+                // compile time with a precise message rather than letting the
+                // inner reduction surface an opaque per-period error at run time.
+                if let Some(inner) = nested_over_periods_kind(&value)
+                    .or_else(|| n.as_deref().and_then(nested_over_periods_kind))
+                {
+                    return Err(DenseCompileError::NestedOverPeriods {
+                        outer: kind.as_call_name(),
+                        inner: inner.as_call_name(),
+                    });
+                }
+                Ok(CompiledScalarExpr::OverPeriods {
+                    kind: *kind,
+                    value: Box::new(value),
+                    n,
+                })
+            }
         }
     }
 
@@ -2563,27 +2587,29 @@ impl<'a, N: DenseNum> LifetimeExecutor<'a, N> {
             }
             // Period-specific leaves have no defined period outside a reduction.
             CompiledScalarExpr::Input(index) => Err(EvalError::LifetimeAmbiguousLeaf(
-                leaked_input_name(&self.program.root_inputs[*index]),
+                self.program.root_inputs[*index].clone(),
             )),
             CompiledScalarExpr::InputOrElse { input, .. } => Err(EvalError::LifetimeAmbiguousLeaf(
-                leaked_input_name(&self.program.root_inputs[*input]),
+                self.program.root_inputs[*input].clone(),
             )),
             CompiledScalarExpr::PeriodStart => {
-                Err(EvalError::LifetimeAmbiguousLeaf("period_start"))
+                Err(EvalError::LifetimeAmbiguousLeaf("period_start".to_string()))
             }
-            CompiledScalarExpr::PeriodEnd => Err(EvalError::LifetimeAmbiguousLeaf("period_end")),
-            CompiledScalarExpr::DateAddDays { .. } => {
-                Err(EvalError::LifetimeAmbiguousLeaf("date_add_days"))
+            CompiledScalarExpr::PeriodEnd => {
+                Err(EvalError::LifetimeAmbiguousLeaf("period_end".to_string()))
             }
+            CompiledScalarExpr::DateAddDays { .. } => Err(EvalError::LifetimeAmbiguousLeaf(
+                "date_add_days".to_string(),
+            )),
             CompiledScalarExpr::DaysBetween { .. } => {
-                Err(EvalError::LifetimeAmbiguousLeaf("days_between"))
+                Err(EvalError::LifetimeAmbiguousLeaf("days_between".to_string()))
             }
             CompiledScalarExpr::CountRelated { .. } => Err(EvalError::LifetimeAmbiguousLeaf(
-                "count/len over a relation",
+                "count/len over a relation".to_string(),
             )),
-            CompiledScalarExpr::SumRelated { .. } => {
-                Err(EvalError::LifetimeAmbiguousLeaf("sum over a relation"))
-            }
+            CompiledScalarExpr::SumRelated { .. } => Err(EvalError::LifetimeAmbiguousLeaf(
+                "sum over a relation".to_string(),
+            )),
         }
     }
 
@@ -2597,6 +2623,17 @@ impl<'a, N: DenseNum> LifetimeExecutor<'a, N> {
         n: Option<&CompiledScalarExpr>,
     ) -> Result<DenseColumn, EvalError> {
         let period_count = self.period_executors.len();
+
+        // Count is the number of supplied periods, identical for every row, and
+        // does not depend on the inner value — so short-circuit before touching
+        // it (a period count must not fail because the body is unevaluable).
+        if kind == OverPeriodsKind::Count {
+            return Ok(DenseColumn::Integer(vec![
+                period_count as i64;
+                self.row_count
+            ]));
+        }
+
         // period-major: per_period[p][r] is entity r's inner value in period p.
         let mut per_period: Vec<Vec<N>> = Vec::with_capacity(period_count);
         for executor in &mut self.period_executors {
@@ -2605,14 +2642,8 @@ impl<'a, N: DenseNum> LifetimeExecutor<'a, N> {
         }
 
         let result = match kind {
-            OverPeriodsKind::Count => {
-                // Count of supplied periods, identical for every row. Integer
-                // column regardless of numeric mode.
-                return Ok(DenseColumn::Integer(vec![
-                    period_count as i64;
-                    self.row_count
-                ]));
-            }
+            // Handled above, before the per-period matrix is built.
+            OverPeriodsKind::Count => unreachable!("count short-circuits above"),
             OverPeriodsKind::Sum => (0..self.row_count)
                 .map(|row| {
                     let mut total = N::ZERO;
@@ -2742,12 +2773,48 @@ impl<'a, N: DenseNum> LifetimeExecutor<'a, N> {
     }
 }
 
-/// Leak a root-input name to a `&'static str` for the lifetime-ambiguous-leaf
-/// diagnostic. Called only on the error path (a caller mistake), so the tiny,
-/// bounded leak — one per distinct offending input name across a process — is
-/// an acceptable trade for a specific message that names the input.
-fn leaked_input_name(name: &str) -> &'static str {
-    Box::leak(name.to_string().into_boxed_str())
+/// Find a directly-nested over-periods reduction inside a compiled scalar
+/// expression, returning its kind. Used at compile time to reject
+/// `sum_over_periods(max_over_periods(x))` and similar: a reduction consumes the
+/// period axis, so nesting another in its argument is meaningless. This walks
+/// the compiled tree structurally; a reduction reached only through a `Derived`
+/// reference is not flagged here (it still errors safely at run time), because
+/// that transitive check needs the whole compiled program, not one expression.
+fn nested_over_periods_kind(expr: &CompiledScalarExpr) -> Option<OverPeriodsKind> {
+    match expr {
+        CompiledScalarExpr::OverPeriods { kind, .. } => Some(*kind),
+        CompiledScalarExpr::Literal(_)
+        | CompiledScalarExpr::Input(_)
+        | CompiledScalarExpr::InputOrElse { .. }
+        | CompiledScalarExpr::Derived(_)
+        | CompiledScalarExpr::PeriodStart
+        | CompiledScalarExpr::PeriodEnd
+        | CompiledScalarExpr::CountRelated { .. }
+        | CompiledScalarExpr::SumRelated { .. } => None,
+        CompiledScalarExpr::ParameterLookup { index, .. } => nested_over_periods_kind(index),
+        CompiledScalarExpr::Add(items)
+        | CompiledScalarExpr::Max(items)
+        | CompiledScalarExpr::Min(items) => items.iter().find_map(nested_over_periods_kind),
+        CompiledScalarExpr::Sub(left, right)
+        | CompiledScalarExpr::Mul(left, right)
+        | CompiledScalarExpr::Div(left, right) => {
+            nested_over_periods_kind(left).or_else(|| nested_over_periods_kind(right))
+        }
+        CompiledScalarExpr::Ceil(value) | CompiledScalarExpr::Floor(value) => {
+            nested_over_periods_kind(value)
+        }
+        CompiledScalarExpr::DateAddDays { date, days } => {
+            nested_over_periods_kind(date).or_else(|| nested_over_periods_kind(days))
+        }
+        CompiledScalarExpr::DaysBetween { from, to } => {
+            nested_over_periods_kind(from).or_else(|| nested_over_periods_kind(to))
+        }
+        CompiledScalarExpr::If {
+            then_expr,
+            else_expr,
+            ..
+        } => nested_over_periods_kind(then_expr).or_else(|| nested_over_periods_kind(else_expr)),
+    }
 }
 
 fn project_root_judgment_to_related(

--- a/src/dense.rs
+++ b/src/dense.rs
@@ -1,14 +1,15 @@
 use std::collections::{HashMap, HashSet};
 
-use rust_decimal::prelude::{FromPrimitive, ToPrimitive};
 use rust_decimal::Decimal;
+use rust_decimal::prelude::{FromPrimitive, ToPrimitive};
 use thiserror::Error;
 
 use crate::compile::CompiledProgramArtifact;
 use crate::engine::EvalError;
 use crate::model::{
-    ComparisonOp, DType, DerivedSemantics, IndexedParameter, JudgmentExpr, JudgmentOutcome, Period,
-    Program, RelatedValueRef, Rounding, RoundingMode, ScalarExpr, ScalarValue, SCALAR_ENTITY,
+    ComparisonOp, DType, DerivedSemantics, IndexedParameter, JudgmentExpr, JudgmentOutcome,
+    OverPeriodsKind, Period, Program, RelatedValueRef, Rounding, RoundingMode, SCALAR_ENTITY,
+    ScalarExpr, ScalarValue,
 };
 
 #[derive(Clone, Debug)]
@@ -115,6 +116,10 @@ trait DenseNum:
     /// determinations.
     fn round_to(self, rounding: Rounding) -> Self;
     fn is_zero(self) -> bool;
+    /// Truncate an already-floored value to `i64`, saturating past the `i64`
+    /// range. Used to read the `n` of `sum_top_n_over_periods` (a small count)
+    /// from a numeric column.
+    fn to_i64_trunc(self) -> i64;
     /// Wrap evaluated values in the column variant for this mode.
     fn into_column(values: Vec<Self>) -> DenseColumn;
     /// Read any numeric column as this mode's working vector.
@@ -144,6 +149,19 @@ impl DenseNum for Decimal {
 
     fn is_zero(self) -> bool {
         self == Decimal::ZERO
+    }
+
+    fn to_i64_trunc(self) -> i64 {
+        // `self` is already floored by the caller; clamp to the i64 range so an
+        // absurd `n` cannot panic (it will simply exceed the period count and
+        // be clamped there).
+        self.trunc().to_i64().unwrap_or_else(|| {
+            if self > Decimal::ZERO {
+                i64::MAX
+            } else {
+                i64::MIN
+            }
+        })
     }
 
     fn into_column(values: Vec<Self>) -> DenseColumn {
@@ -210,6 +228,12 @@ impl DenseNum for f64 {
 
     fn is_zero(self) -> bool {
         self == 0.0
+    }
+
+    fn to_i64_trunc(self) -> i64 {
+        // Saturating cast: NaN -> 0, out-of-range -> i64::MIN/MAX (Rust's
+        // `as` on floats already saturates and maps NaN to 0).
+        self.trunc() as i64
     }
 
     fn into_column(values: Vec<Self>) -> DenseColumn {
@@ -380,6 +404,15 @@ enum CompiledScalarExpr {
         condition: Box<CompiledJudgmentExpr>,
         then_expr: Box<CompiledScalarExpr>,
         else_expr: Box<CompiledScalarExpr>,
+    },
+    /// Cross-period reduction, evaluated only by the lifetime executor. `value`
+    /// is compiled as an ordinary per-period scalar (evaluated once per supplied
+    /// period); `n` (SumTopN only) is compiled likewise and read at the
+    /// reference period. The per-period executor rejects this node.
+    OverPeriods {
+        kind: OverPeriodsKind,
+        value: Box<CompiledScalarExpr>,
+        n: Option<Box<CompiledScalarExpr>>,
     },
 }
 
@@ -616,6 +649,210 @@ impl DenseCompiledProgram {
             row_count: executor.batch.row_count,
             outputs: result,
         })
+    }
+
+    /// Execute over an entity's lifetime — one positionally aligned input batch
+    /// per period — in canonical `Decimal` arithmetic. See
+    /// [`Self::execute_lifetime_f64`] for the full contract.
+    pub fn execute_lifetime(
+        &self,
+        periods: &[Period],
+        batches: Vec<DenseBatchSpec>,
+        outputs: &[String],
+    ) -> Result<DenseExecutionResult, EvalError> {
+        self.execute_lifetime_with::<Decimal>(periods, batches, outputs)
+    }
+
+    /// Execute over an entity's lifetime in `f64` arithmetic (throughput mode).
+    ///
+    /// `periods` and `batches` must have equal length (one batch per period),
+    /// and every batch must describe the SAME entity rows in the SAME order and
+    /// count (v1 positional alignment — row `i` is the same entity in every
+    /// period). Each requested output's formula must contain at least one
+    /// over-periods reduction (`sum_over_periods`, `max_over_periods`,
+    /// `count_over_periods`, `sum_top_n_over_periods`); outputs with no
+    /// reduction are period-specific and should use the per-period
+    /// [`Self::execute_f64`] entry point instead.
+    ///
+    /// Each reduction's inner expression is evaluated once per period with the
+    /// ordinary per-period executor; the per-period vectors are stacked and
+    /// reduced row-wise. Non-reduction scalars combined with a reduction
+    /// (parameters, derived values) resolve at the last supplied period.
+    pub fn execute_lifetime_f64(
+        &self,
+        periods: &[Period],
+        batches: Vec<DenseBatchSpec>,
+        outputs: &[String],
+    ) -> Result<DenseExecutionResult, EvalError> {
+        self.execute_lifetime_with::<f64>(periods, batches, outputs)
+    }
+
+    fn execute_lifetime_with<N: DenseNum>(
+        &self,
+        periods: &[Period],
+        batches: Vec<DenseBatchSpec>,
+        outputs: &[String],
+    ) -> Result<DenseExecutionResult, EvalError> {
+        if periods.is_empty() {
+            return Err(EvalError::LifetimeNoPeriods);
+        }
+        if periods.len() != batches.len() {
+            return Err(EvalError::LifetimePeriodBatchMismatch {
+                periods: periods.len(),
+                batches: batches.len(),
+            });
+        }
+
+        // Bind every period's batch and require identical row counts (positional
+        // alignment). Row `i` is the same entity across every period.
+        let mut bound = Vec::with_capacity(batches.len());
+        let mut expected_row_count = None;
+        for (index, batch) in batches.into_iter().enumerate() {
+            let bound_batch = self.bind_batch(batch)?;
+            match expected_row_count {
+                None => expected_row_count = Some(bound_batch.row_count),
+                Some(expected) if bound_batch.row_count != expected => {
+                    return Err(EvalError::LifetimeRowCountMismatch {
+                        period: index,
+                        row_count: bound_batch.row_count,
+                        expected,
+                    });
+                }
+                Some(_) => {}
+            }
+            bound.push(bound_batch);
+        }
+        let row_count = expected_row_count.unwrap_or(0);
+
+        // Every requested output must reduce over the period axis; a purely
+        // per-period output has no single-column lifetime meaning.
+        for output in outputs {
+            let Some(&derived_index) = self.derived_index.get(output) else {
+                return Err(EvalError::UnknownDerived(output.clone()));
+            };
+            if !self.derived_reduces_over_periods(derived_index) {
+                return Err(EvalError::LifetimeOutputWithoutReduction(output.clone()));
+            }
+        }
+
+        let mut executor: LifetimeExecutor<'_, N> =
+            LifetimeExecutor::new(self, periods, bound, row_count);
+        let mut result = HashMap::new();
+        for output in outputs {
+            let derived_index = self.derived_index[output];
+            let value = match &self.derived[derived_index].semantics {
+                CompiledSemantics::Scalar(_) => {
+                    DenseOutputValue::Scalar(executor.evaluate_scalar(derived_index)?.clone())
+                }
+                CompiledSemantics::Judgment(_) => {
+                    DenseOutputValue::Judgment(executor.evaluate_judgment(derived_index)?.clone())
+                }
+            };
+            result.insert(output.clone(), value);
+        }
+        Ok(DenseExecutionResult {
+            row_count,
+            outputs: result,
+        })
+    }
+
+    /// Does this derived's compiled formula contain an over-periods reduction,
+    /// directly or through the derived values it depends on? Used to gate
+    /// lifetime execution to reduction outputs only.
+    fn derived_reduces_over_periods(&self, derived_index: usize) -> bool {
+        let mut visiting = HashSet::new();
+        self.derived_reduces_over_periods_inner(derived_index, &mut visiting)
+    }
+
+    fn derived_reduces_over_periods_inner(
+        &self,
+        derived_index: usize,
+        visiting: &mut HashSet<usize>,
+    ) -> bool {
+        if !visiting.insert(derived_index) {
+            return false;
+        }
+        let result = match &self.derived[derived_index].semantics {
+            CompiledSemantics::Scalar(expr) => self.scalar_reduces_over_periods(expr, visiting),
+            CompiledSemantics::Judgment(expr) => self.judgment_reduces_over_periods(expr, visiting),
+        };
+        visiting.remove(&derived_index);
+        result
+    }
+
+    fn scalar_reduces_over_periods(
+        &self,
+        expr: &CompiledScalarExpr,
+        visiting: &mut HashSet<usize>,
+    ) -> bool {
+        match expr {
+            CompiledScalarExpr::OverPeriods { .. } => true,
+            CompiledScalarExpr::Literal(_)
+            | CompiledScalarExpr::Input(_)
+            | CompiledScalarExpr::InputOrElse { .. }
+            | CompiledScalarExpr::PeriodStart
+            | CompiledScalarExpr::PeriodEnd => false,
+            CompiledScalarExpr::Derived(index) => {
+                self.derived_reduces_over_periods_inner(*index, visiting)
+            }
+            CompiledScalarExpr::ParameterLookup { index, .. } => {
+                self.scalar_reduces_over_periods(index, visiting)
+            }
+            CompiledScalarExpr::Add(items)
+            | CompiledScalarExpr::Max(items)
+            | CompiledScalarExpr::Min(items) => items
+                .iter()
+                .any(|item| self.scalar_reduces_over_periods(item, visiting)),
+            CompiledScalarExpr::Sub(left, right)
+            | CompiledScalarExpr::Mul(left, right)
+            | CompiledScalarExpr::Div(left, right) => {
+                self.scalar_reduces_over_periods(left, visiting)
+                    || self.scalar_reduces_over_periods(right, visiting)
+            }
+            CompiledScalarExpr::Ceil(value) | CompiledScalarExpr::Floor(value) => {
+                self.scalar_reduces_over_periods(value, visiting)
+            }
+            CompiledScalarExpr::DateAddDays { date, days } => {
+                self.scalar_reduces_over_periods(date, visiting)
+                    || self.scalar_reduces_over_periods(days, visiting)
+            }
+            CompiledScalarExpr::DaysBetween { from, to } => {
+                self.scalar_reduces_over_periods(from, visiting)
+                    || self.scalar_reduces_over_periods(to, visiting)
+            }
+            CompiledScalarExpr::CountRelated { .. } | CompiledScalarExpr::SumRelated { .. } => {
+                false
+            }
+            CompiledScalarExpr::If {
+                condition,
+                then_expr,
+                else_expr,
+            } => {
+                self.judgment_reduces_over_periods(condition, visiting)
+                    || self.scalar_reduces_over_periods(then_expr, visiting)
+                    || self.scalar_reduces_over_periods(else_expr, visiting)
+            }
+        }
+    }
+
+    fn judgment_reduces_over_periods(
+        &self,
+        expr: &CompiledJudgmentExpr,
+        visiting: &mut HashSet<usize>,
+    ) -> bool {
+        match expr {
+            CompiledJudgmentExpr::Comparison { left, right, .. } => {
+                self.scalar_reduces_over_periods(left, visiting)
+                    || self.scalar_reduces_over_periods(right, visiting)
+            }
+            CompiledJudgmentExpr::Derived(index) => {
+                self.derived_reduces_over_periods_inner(*index, visiting)
+            }
+            CompiledJudgmentExpr::And(items) | CompiledJudgmentExpr::Or(items) => items
+                .iter()
+                .any(|item| self.judgment_reduces_over_periods(item, visiting)),
+            CompiledJudgmentExpr::Not(item) => self.judgment_reduces_over_periods(item, visiting),
+        }
     }
 
     fn bind_batch(&self, batch: DenseBatchSpec) -> Result<DenseBoundBatch, EvalError> {
@@ -967,6 +1204,13 @@ impl<'a> DenseCompiler<'a> {
                 then_expr: Box::new(self.compile_scalar_expr(derived_name, then_expr)?),
                 else_expr: Box::new(self.compile_scalar_expr(derived_name, else_expr)?),
             }),
+            ScalarExpr::OverPeriods { kind, value, n } => Ok(CompiledScalarExpr::OverPeriods {
+                kind: *kind,
+                value: Box::new(self.compile_scalar_expr(derived_name, value)?),
+                n: n.as_ref()
+                    .map(|inner| self.compile_scalar_expr(derived_name, inner).map(Box::new))
+                    .transpose()?,
+            }),
         }
     }
 
@@ -1041,16 +1285,16 @@ impl<'a> DenseCompiler<'a> {
                     || derived.entity == self.root_entity
                 {
                     return match &derived.semantics {
-                        DerivedSemantics::Judgment(expr) => Ok(
-                            CompiledRelatedJudgmentExpr::RootJudgment(Box::new(
+                        DerivedSemantics::Judgment(expr) => {
+                            Ok(CompiledRelatedJudgmentExpr::RootJudgment(Box::new(
                                 self.compile_current_judgment_expr(name, &derived.entity, expr)?,
-                            )),
-                        ),
-                        DerivedSemantics::Scalar(_) => Err(DenseCompileError::Unsupported(
-                            format!(
+                            )))
+                        }
+                        DerivedSemantics::Scalar(_) => {
+                            Err(DenseCompileError::Unsupported(format!(
                                 "where-clause predicates cannot reference scalar derived values (`{name}`)"
-                            ),
-                        )),
+                            )))
+                        }
                     };
                 }
                 if relation.related_entity.is_some()
@@ -1119,18 +1363,16 @@ impl<'a> DenseCompiler<'a> {
                     || derived.entity == SCALAR_ENTITY
                 {
                     return match &derived.semantics {
-                        DerivedSemantics::Scalar(expr) => Ok(CompiledRelatedScalarExpr::RootScalar(
-                            Box::new(self.compile_current_scalar_expr(
-                                name,
-                                &derived.entity,
-                                expr,
-                            )?),
-                        )),
-                        DerivedSemantics::Judgment(_) => Err(DenseCompileError::Unsupported(
-                            format!(
+                        DerivedSemantics::Scalar(expr) => {
+                            Ok(CompiledRelatedScalarExpr::RootScalar(Box::new(
+                                self.compile_current_scalar_expr(name, &derived.entity, expr)?,
+                            )))
+                        }
+                        DerivedSemantics::Judgment(_) => {
+                            Err(DenseCompileError::Unsupported(format!(
                                 "related scalar expressions cannot reference judgment derived values (`{name}`)"
-                            ),
-                        )),
+                            )))
+                        }
                     };
                 }
                 if relation.related_entity.is_some()
@@ -1142,7 +1384,9 @@ impl<'a> DenseCompiler<'a> {
                     )));
                 }
                 match &derived.semantics {
-                    DerivedSemantics::Scalar(expr) => self.compile_related_scalar(relation_index, expr),
+                    DerivedSemantics::Scalar(expr) => {
+                        self.compile_related_scalar(relation_index, expr)
+                    }
                     DerivedSemantics::Judgment(_) => Err(DenseCompileError::Unsupported(format!(
                         "related scalar expressions cannot reference judgment derived values (`{name}`)"
                     ))),
@@ -1214,6 +1458,10 @@ impl<'a> DenseCompiler<'a> {
                     "aggregation over relation `{relation}` nested inside a related expression"
                 )))
             }
+            ScalarExpr::OverPeriods { kind, .. } => Err(DenseCompileError::Unsupported(format!(
+                "over-periods reduction `{}` nested inside a related expression",
+                kind.as_call_name()
+            ))),
         }
     }
 
@@ -1338,6 +1586,10 @@ impl<'a> DenseCompiler<'a> {
                         .to_string(),
                 ))
             }
+            ScalarExpr::OverPeriods { kind, .. } => Err(DenseCompileError::Unsupported(format!(
+                "over-periods reduction `{}` nested inside a current-entity related expression",
+                kind.as_call_name()
+            ))),
         }
     }
 
@@ -1798,6 +2050,11 @@ impl<'a, N: DenseNum> DenseExecutor<'a, N> {
                 let else_values = self.eval_scalar_expr(else_expr)?;
                 select_dense_scalar_column::<N>(condition, then_values, else_values)
             }
+            // Cross-period reductions require a batch per period; they are
+            // evaluated by the lifetime executor, never here.
+            CompiledScalarExpr::OverPeriods { kind, .. } => {
+                Err(EvalError::OverPeriodsOutsideLifetime(kind.as_call_name()))
+            }
         }
     }
 
@@ -2113,6 +2370,385 @@ impl<'a, N: DenseNum> DenseExecutor<'a, N> {
                 .collect()),
         }
     }
+}
+
+/// Executor for the lifetime surface: it owns one bound batch (and one
+/// [`DenseExecutor`]) per period, all describing the same entity rows in the
+/// same order. It evaluates a formula once, row-wise, collapsing each
+/// over-periods reduction to a per-entity column by evaluating the reduction's
+/// inner expression across every period's executor and reducing down the period
+/// axis. Scalars outside any reduction that need a period (parameters, derived
+/// values) resolve at the reference period (the last one supplied).
+struct LifetimeExecutor<'a, N: DenseNum> {
+    program: &'a DenseCompiledProgram,
+    /// One per-period executor, index-aligned with `periods`. Each carries its
+    /// own per-period scalar/judgment memoization.
+    period_executors: Vec<DenseExecutor<'a, N>>,
+    /// Index of the reference period (last supplied) for period-specific
+    /// scalars combined with a reduction.
+    reference_period: usize,
+    row_count: usize,
+    /// Lifetime-level memoization of derived values (keyed by derived index),
+    /// so a derived referenced from several places reduces once. Rounding is
+    /// applied before caching, mirroring the per-period path.
+    scalar_cache: Vec<Option<DenseColumn>>,
+    judgment_cache: Vec<Option<Vec<JudgmentOutcome>>>,
+}
+
+impl<'a, N: DenseNum> LifetimeExecutor<'a, N> {
+    fn new(
+        program: &'a DenseCompiledProgram,
+        periods: &'a [Period],
+        bound: Vec<DenseBoundBatch>,
+        row_count: usize,
+    ) -> Self {
+        let period_executors = periods
+            .iter()
+            .zip(bound)
+            .map(|(period, batch)| DenseExecutor::new(program, period, batch))
+            .collect();
+        Self {
+            program,
+            period_executors,
+            reference_period: periods.len() - 1,
+            row_count,
+            scalar_cache: vec![None; program.derived.len()],
+            judgment_cache: vec![None; program.derived.len()],
+        }
+    }
+
+    fn evaluate_scalar(&mut self, derived_index: usize) -> Result<&DenseColumn, EvalError> {
+        if self.scalar_cache[derived_index].is_none() {
+            let program = self.program;
+            let mut column = match &program.derived[derived_index].semantics {
+                CompiledSemantics::Scalar(expr) => self.eval_scalar(expr)?,
+                CompiledSemantics::Judgment(_) => {
+                    return Err(EvalError::ExpectedScalar(
+                        program.derived[derived_index].name.clone(),
+                    ));
+                }
+            };
+            if let Some(rounding) = program.derived[derived_index].rounding {
+                column = round_dense_column::<N>(column, rounding)?;
+            }
+            self.scalar_cache[derived_index] = Some(column);
+        }
+        Ok(self.scalar_cache[derived_index].as_ref().expect("cached"))
+    }
+
+    fn evaluate_judgment(
+        &mut self,
+        derived_index: usize,
+    ) -> Result<&Vec<JudgmentOutcome>, EvalError> {
+        if self.judgment_cache[derived_index].is_none() {
+            let program = self.program;
+            let values = match &program.derived[derived_index].semantics {
+                CompiledSemantics::Judgment(expr) => self.eval_judgment(expr)?,
+                CompiledSemantics::Scalar(_) => {
+                    return Err(EvalError::ExpectedJudgment(
+                        program.derived[derived_index].name.clone(),
+                    ));
+                }
+            };
+            self.judgment_cache[derived_index] = Some(values);
+        }
+        Ok(self.judgment_cache[derived_index].as_ref().expect("cached"))
+    }
+
+    fn eval_scalar(&mut self, expr: &CompiledScalarExpr) -> Result<DenseColumn, EvalError> {
+        match expr {
+            CompiledScalarExpr::OverPeriods { kind, value, n } => {
+                self.eval_over_periods(*kind, value, n.as_deref())
+            }
+            CompiledScalarExpr::Literal(value) => {
+                Ok(broadcast_scalar_literal::<N>(value, self.row_count))
+            }
+            CompiledScalarExpr::Derived(index) => Ok(self.evaluate_scalar(*index)?.clone()),
+            CompiledScalarExpr::ParameterLookup { parameter, index } => {
+                // Period-specific: resolve at the reference period. The index
+                // expression is itself lifetime-evaluated (typically a literal
+                // or derived), then used as integer keys.
+                let keys = self.eval_scalar(index)?.as_index_vec()?;
+                lookup_parameter_dense::<N>(
+                    &self.program.parameters[*parameter].parameter,
+                    &keys,
+                    self.period_executors[self.reference_period].period,
+                )
+            }
+            CompiledScalarExpr::Add(items) => {
+                let mut total = vec![N::ZERO; self.row_count];
+                for item in items {
+                    let values = N::vec_from_column(&self.eval_scalar(item)?)?;
+                    for (index, value) in values.into_iter().enumerate() {
+                        total[index] += value;
+                    }
+                }
+                Ok(N::into_column(total))
+            }
+            CompiledScalarExpr::Sub(left, right) => {
+                let left = N::vec_from_column(&self.eval_scalar(left)?)?;
+                let right = N::vec_from_column(&self.eval_scalar(right)?)?;
+                Ok(N::into_column(
+                    left.into_iter().zip(right).map(|(l, r)| l - r).collect(),
+                ))
+            }
+            CompiledScalarExpr::Mul(left, right) => {
+                let left = N::vec_from_column(&self.eval_scalar(left)?)?;
+                let right = N::vec_from_column(&self.eval_scalar(right)?)?;
+                Ok(N::into_column(
+                    left.into_iter().zip(right).map(|(l, r)| l * r).collect(),
+                ))
+            }
+            CompiledScalarExpr::Div(left, right) => {
+                let left = N::vec_from_column(&self.eval_scalar(left)?)?;
+                let right = N::vec_from_column(&self.eval_scalar(right)?)?;
+                Ok(N::into_column(
+                    left.into_iter()
+                        .zip(right)
+                        .map(|(l, r)| {
+                            if r.is_zero() {
+                                Err(EvalError::DivisionByZero)
+                            } else {
+                                Ok(l / r)
+                            }
+                        })
+                        .collect::<Result<Vec<N>, EvalError>>()?,
+                ))
+            }
+            CompiledScalarExpr::Max(items) => {
+                let mut values = vec![N::MIN; self.row_count];
+                for item in items {
+                    let candidate = N::vec_from_column(&self.eval_scalar(item)?)?;
+                    for (index, value) in candidate.into_iter().enumerate() {
+                        if value > values[index] {
+                            values[index] = value;
+                        }
+                    }
+                }
+                Ok(N::into_column(values))
+            }
+            CompiledScalarExpr::Min(items) => {
+                let mut values = vec![N::MAX; self.row_count];
+                for item in items {
+                    let candidate = N::vec_from_column(&self.eval_scalar(item)?)?;
+                    for (index, value) in candidate.into_iter().enumerate() {
+                        if value < values[index] {
+                            values[index] = value;
+                        }
+                    }
+                }
+                Ok(N::into_column(values))
+            }
+            CompiledScalarExpr::Ceil(value) => Ok(N::into_column(
+                N::vec_from_column(&self.eval_scalar(value)?)?
+                    .into_iter()
+                    .map(|value| value.ceil())
+                    .collect(),
+            )),
+            CompiledScalarExpr::Floor(value) => Ok(N::into_column(
+                N::vec_from_column(&self.eval_scalar(value)?)?
+                    .into_iter()
+                    .map(|value| value.floor())
+                    .collect(),
+            )),
+            CompiledScalarExpr::If {
+                condition,
+                then_expr,
+                else_expr,
+            } => {
+                let condition = self.eval_judgment(condition)?;
+                let then_values = self.eval_scalar(then_expr)?;
+                let else_values = self.eval_scalar(else_expr)?;
+                select_dense_scalar_column::<N>(condition, then_values, else_values)
+            }
+            // Period-specific leaves have no defined period outside a reduction.
+            CompiledScalarExpr::Input(index) => Err(EvalError::LifetimeAmbiguousLeaf(
+                leaked_input_name(&self.program.root_inputs[*index]),
+            )),
+            CompiledScalarExpr::InputOrElse { input, .. } => Err(EvalError::LifetimeAmbiguousLeaf(
+                leaked_input_name(&self.program.root_inputs[*input]),
+            )),
+            CompiledScalarExpr::PeriodStart => {
+                Err(EvalError::LifetimeAmbiguousLeaf("period_start"))
+            }
+            CompiledScalarExpr::PeriodEnd => Err(EvalError::LifetimeAmbiguousLeaf("period_end")),
+            CompiledScalarExpr::DateAddDays { .. } => {
+                Err(EvalError::LifetimeAmbiguousLeaf("date_add_days"))
+            }
+            CompiledScalarExpr::DaysBetween { .. } => {
+                Err(EvalError::LifetimeAmbiguousLeaf("days_between"))
+            }
+            CompiledScalarExpr::CountRelated { .. } => Err(EvalError::LifetimeAmbiguousLeaf(
+                "count/len over a relation",
+            )),
+            CompiledScalarExpr::SumRelated { .. } => {
+                Err(EvalError::LifetimeAmbiguousLeaf("sum over a relation"))
+            }
+        }
+    }
+
+    /// Collapse an over-periods reduction to a per-entity column: evaluate the
+    /// inner `value` under every period's executor, then reduce down the period
+    /// axis for each row.
+    fn eval_over_periods(
+        &mut self,
+        kind: OverPeriodsKind,
+        value: &CompiledScalarExpr,
+        n: Option<&CompiledScalarExpr>,
+    ) -> Result<DenseColumn, EvalError> {
+        let period_count = self.period_executors.len();
+        // period-major: per_period[p][r] is entity r's inner value in period p.
+        let mut per_period: Vec<Vec<N>> = Vec::with_capacity(period_count);
+        for executor in &mut self.period_executors {
+            let column = executor.eval_scalar_expr(value)?;
+            per_period.push(N::vec_from_column(&column)?);
+        }
+
+        let result = match kind {
+            OverPeriodsKind::Count => {
+                // Count of supplied periods, identical for every row. Integer
+                // column regardless of numeric mode.
+                return Ok(DenseColumn::Integer(vec![
+                    period_count as i64;
+                    self.row_count
+                ]));
+            }
+            OverPeriodsKind::Sum => (0..self.row_count)
+                .map(|row| {
+                    let mut total = N::ZERO;
+                    for period in &per_period {
+                        total += period[row];
+                    }
+                    total
+                })
+                .collect::<Vec<N>>(),
+            OverPeriodsKind::Max => (0..self.row_count)
+                .map(|row| {
+                    // period_count >= 1 is guaranteed by the caller.
+                    let mut best = per_period[0][row];
+                    for period in &per_period[1..] {
+                        if period[row] > best {
+                            best = period[row];
+                        }
+                    }
+                    best
+                })
+                .collect::<Vec<N>>(),
+            OverPeriodsKind::SumTopN => {
+                let counts = self.eval_top_n_counts(n)?;
+                (0..self.row_count)
+                    .map(|row| {
+                        let mut values: Vec<N> =
+                            per_period.iter().map(|period| period[row]).collect();
+                        // Descending sort. N is Decimal or f64; per-period inner
+                        // values are finite in practice, so a total order via
+                        // partial_cmp is safe here.
+                        values
+                            .sort_by(|a, b| b.partial_cmp(a).unwrap_or(std::cmp::Ordering::Equal));
+                        // Take the top `n`; when fewer than `n` periods exist the
+                        // shortfall contributes zero (missing computation years),
+                        // which is exactly summing the available values.
+                        let take = counts[row].min(values.len());
+                        let mut total = N::ZERO;
+                        for value in &values[..take] {
+                            total += *value;
+                        }
+                        total
+                    })
+                    .collect::<Vec<N>>()
+            }
+        };
+        Ok(N::into_column(result))
+    }
+
+    /// Evaluate the `n` of `sum_top_n_over_periods` at the reference period into
+    /// a per-row count, truncating toward zero and rejecting `n < 1`.
+    fn eval_top_n_counts(
+        &mut self,
+        n: Option<&CompiledScalarExpr>,
+    ) -> Result<Vec<usize>, EvalError> {
+        let n = n.ok_or_else(|| {
+            EvalError::TypeMismatch("sum_top_n_over_periods requires an n argument".to_string())
+        })?;
+        let raw = N::vec_from_column(&self.eval_scalar(n)?)?;
+        raw.into_iter()
+            .map(|value| {
+                // Truncate toward zero, then require >= 1.
+                let truncated = value.floor();
+                let as_i64 = N::to_i64_trunc(truncated);
+                if as_i64 < 1 {
+                    Err(EvalError::OverPeriodsTopNInvalid(as_i64))
+                } else {
+                    Ok(as_i64 as usize)
+                }
+            })
+            .collect()
+    }
+
+    fn eval_judgment(
+        &mut self,
+        expr: &CompiledJudgmentExpr,
+    ) -> Result<Vec<JudgmentOutcome>, EvalError> {
+        match expr {
+            CompiledJudgmentExpr::Comparison { left, op, right } => {
+                let left = self.eval_scalar(left)?;
+                let right = self.eval_scalar(right)?;
+                compare_dense_columns::<N>(left, *op, right)
+            }
+            CompiledJudgmentExpr::Derived(index) => Ok(self.evaluate_judgment(*index)?.clone()),
+            CompiledJudgmentExpr::And(items) => {
+                let mut results = vec![JudgmentOutcome::Holds; self.row_count];
+                for item in items {
+                    let values = self.eval_judgment(item)?;
+                    for (index, value) in values.into_iter().enumerate() {
+                        results[index] = match (results[index], value) {
+                            (JudgmentOutcome::NotHolds, _) | (_, JudgmentOutcome::NotHolds) => {
+                                JudgmentOutcome::NotHolds
+                            }
+                            (JudgmentOutcome::Undetermined, _)
+                            | (_, JudgmentOutcome::Undetermined) => JudgmentOutcome::Undetermined,
+                            _ => JudgmentOutcome::Holds,
+                        };
+                    }
+                }
+                Ok(results)
+            }
+            CompiledJudgmentExpr::Or(items) => {
+                let mut results = vec![JudgmentOutcome::NotHolds; self.row_count];
+                for item in items {
+                    let values = self.eval_judgment(item)?;
+                    for (index, value) in values.into_iter().enumerate() {
+                        results[index] = match (results[index], value) {
+                            (JudgmentOutcome::Holds, _) | (_, JudgmentOutcome::Holds) => {
+                                JudgmentOutcome::Holds
+                            }
+                            (JudgmentOutcome::Undetermined, _)
+                            | (_, JudgmentOutcome::Undetermined) => JudgmentOutcome::Undetermined,
+                            _ => JudgmentOutcome::NotHolds,
+                        };
+                    }
+                }
+                Ok(results)
+            }
+            CompiledJudgmentExpr::Not(item) => Ok(self
+                .eval_judgment(item)?
+                .into_iter()
+                .map(|value| match value {
+                    JudgmentOutcome::Holds => JudgmentOutcome::NotHolds,
+                    JudgmentOutcome::NotHolds => JudgmentOutcome::Holds,
+                    JudgmentOutcome::Undetermined => JudgmentOutcome::Undetermined,
+                })
+                .collect()),
+        }
+    }
+}
+
+/// Leak a root-input name to a `&'static str` for the lifetime-ambiguous-leaf
+/// diagnostic. Called only on the error path (a caller mistake), so the tiny,
+/// bounded leak — one per distinct offending input name across a process — is
+/// an acceptable trade for a specific message that names the input.
+fn leaked_input_name(name: &str) -> &'static str {
+    Box::leak(name.to_string().into_boxed_str())
 }
 
 fn project_root_judgment_to_related(

--- a/src/dense.rs
+++ b/src/dense.rs
@@ -2673,9 +2673,8 @@ impl<'a, N: DenseNum> LifetimeExecutor<'a, N> {
         let raw = N::vec_from_column(&self.eval_scalar(n)?)?;
         raw.into_iter()
             .map(|value| {
-                // Truncate toward zero, then require >= 1.
-                let truncated = value.floor();
-                let as_i64 = N::to_i64_trunc(truncated);
+                // Truncate toward zero to an integer count, then require >= 1.
+                let as_i64 = N::to_i64_trunc(value);
                 if as_i64 < 1 {
                     Err(EvalError::OverPeriodsTopNInvalid(as_i64))
                 } else {

--- a/src/dense.rs
+++ b/src/dense.rs
@@ -116,10 +116,11 @@ trait DenseNum:
     /// determinations.
     fn round_to(self, rounding: Rounding) -> Self;
     fn is_zero(self) -> bool;
-    /// Truncate an already-floored value to `i64`, saturating past the `i64`
-    /// range. Used to read the `n` of `sum_top_n_over_periods` (a small count)
-    /// from a numeric column.
-    fn to_i64_trunc(self) -> i64;
+    /// Truncate toward zero to an exact `i64`, or `None` when the value is
+    /// non-finite or lies beyond the `i64` range. Used to read the `n` of
+    /// `sum_top_n_over_periods`: `None` (and any out-of-range integer) is a hard
+    /// error under the strict n contract, never a silent saturation.
+    fn try_to_i64_trunc(self) -> Option<i64>;
     /// Wrap evaluated values in the column variant for this mode.
     fn into_column(values: Vec<Self>) -> DenseColumn;
     /// Read any numeric column as this mode's working vector.
@@ -151,17 +152,11 @@ impl DenseNum for Decimal {
         self == Decimal::ZERO
     }
 
-    fn to_i64_trunc(self) -> i64 {
-        // `self` is already floored by the caller; clamp to the i64 range so an
-        // absurd `n` cannot panic (it will simply exceed the period count and
-        // be clamped there).
-        self.trunc().to_i64().unwrap_or_else(|| {
-            if self > Decimal::ZERO {
-                i64::MAX
-            } else {
-                i64::MIN
-            }
-        })
+    fn try_to_i64_trunc(self) -> Option<i64> {
+        // Truncate toward zero; `to_i64` returns None when the truncated value
+        // is beyond the i64 range, which the strict n contract treats as a hard
+        // error (never a saturation to i64::MAX).
+        self.trunc().to_i64()
     }
 
     fn into_column(values: Vec<Self>) -> DenseColumn {
@@ -230,10 +225,15 @@ impl DenseNum for f64 {
         self == 0.0
     }
 
-    fn to_i64_trunc(self) -> i64 {
-        // Saturating cast: NaN -> 0, out-of-range -> i64::MIN/MAX (Rust's
-        // `as` on floats already saturates and maps NaN to 0).
-        self.trunc() as i64
+    fn try_to_i64_trunc(self) -> Option<i64> {
+        // Reject non-finite and out-of-range values instead of saturating: the
+        // strict n contract errors on a garbage n rather than silently reading
+        // it as 0 (NaN) or a clamped extreme.
+        let truncated = self.trunc();
+        if !truncated.is_finite() || truncated < i64::MIN as f64 || truncated > i64::MAX as f64 {
+            return None;
+        }
+        Some(truncated as i64)
     }
 
     fn into_column(values: Vec<Self>) -> DenseColumn {
@@ -673,18 +673,22 @@ impl DenseCompiledProgram {
     /// Execute over an entity's lifetime in `f64` arithmetic (throughput mode).
     ///
     /// `periods` and `batches` must have equal length (one batch per period),
-    /// and every batch must describe the SAME entity rows in the SAME order and
-    /// count (v1 positional alignment — row `i` is the same entity in every
-    /// period). Each requested output's formula must contain at least one
-    /// over-periods reduction (`sum_over_periods`, `max_over_periods`,
-    /// `count_over_periods`, `sum_top_n_over_periods`); outputs with no
-    /// reduction are period-specific and should use the per-period
-    /// [`Self::execute_f64`] entry point instead.
+    /// the periods must be strictly ascending by start date, and every batch
+    /// must describe the SAME entity rows in the SAME order and count (v1
+    /// positional alignment — row `i` is the same entity in every period). Each
+    /// requested output's formula must contain at least one over-periods
+    /// reduction (`sum_over_periods`, `max_over_periods`, `count_over_periods`,
+    /// `sum_top_n_over_periods`); outputs with no reduction are period-specific
+    /// and should use the per-period [`Self::execute_f64`] entry point instead.
     ///
     /// Each reduction's inner expression is evaluated once per period with the
     /// ordinary per-period executor; the per-period vectors are stacked and
     /// reduced row-wise. Non-reduction scalars combined with a reduction
-    /// (parameters, derived values) resolve at the last supplied period.
+    /// resolve at the reference period — the chronologically-last supplied
+    /// period (parameters like a bend point index to the determination year);
+    /// a derived referenced outside a reduction means its body inlined in this
+    /// same lifetime context, and a bare period-invariant input binds its
+    /// common value.
     pub fn execute_lifetime_f64(
         &self,
         periods: &[Period],
@@ -708,6 +712,24 @@ impl DenseCompiledProgram {
                 periods: periods.len(),
                 batches: batches.len(),
             });
+        }
+
+        // Periods must be strictly ascending by start date. The reference period
+        // for period-specific scalars (parameters, and the `n` of
+        // `sum_top_n_over_periods`) is the chronologically-last supplied period;
+        // an unsorted or descending list would otherwise resolve a bend point or
+        // COLA at the wrong year with no signal. Reject rather than silently sort
+        // so the caller's period/batch pairing stays authoritative.
+        for (earlier_index, window) in periods.windows(2).enumerate() {
+            let (earlier, later) = (&window[0], &window[1]);
+            if earlier.start >= later.start {
+                return Err(EvalError::LifetimePeriodsNotAscending {
+                    earlier_index,
+                    earlier: format!("{}..{}", earlier.start, earlier.end),
+                    later_index: earlier_index + 1,
+                    later: format!("{}..{}", later.start, later.end),
+                });
+            }
         }
 
         // Bind every period's batch and require identical row counts (positional
@@ -2401,15 +2423,20 @@ impl<'a, N: DenseNum> DenseExecutor<'a, N> {
 /// same order. It evaluates a formula once, row-wise, collapsing each
 /// over-periods reduction to a per-entity column by evaluating the reduction's
 /// inner expression across every period's executor and reducing down the period
-/// axis. Scalars outside any reduction that need a period (parameters, derived
-/// values) resolve at the reference period (the last one supplied).
+/// axis. Scalars outside any reduction that need a period (parameters) resolve
+/// at the reference period — the chronologically-last supplied period, which
+/// the `execute_lifetime` entry points validate the period list to end with. A
+/// derived referenced outside a reduction is evaluated by inlining its body in
+/// this same lifetime context (so it means exactly its definition), and a bare
+/// period-invariant input binds its common value.
 struct LifetimeExecutor<'a, N: DenseNum> {
     program: &'a DenseCompiledProgram,
     /// One per-period executor, index-aligned with `periods`. Each carries its
     /// own per-period scalar/judgment memoization.
     period_executors: Vec<DenseExecutor<'a, N>>,
-    /// Index of the reference period (last supplied) for period-specific
-    /// scalars combined with a reduction.
+    /// Index of the reference period — the chronologically-last supplied period
+    /// (the entry points validate the list is strictly ascending, so this is the
+    /// final index) — for period-specific scalars combined with a reduction.
     reference_period: usize,
     row_count: usize,
     /// Lifetime-level memoization of derived values (keyed by derived index),
@@ -2634,14 +2661,20 @@ impl<'a, N: DenseNum> LifetimeExecutor<'a, N> {
     ) -> Result<DenseColumn, EvalError> {
         let period_count = self.period_executors.len();
 
-        // Count is the number of supplied periods, identical for every row, and
-        // does not depend on the inner value — so short-circuit before touching
-        // it (a period count must not fail because the body is unevaluable).
+        // Count evaluates its argument per period (same leaf rules as the other
+        // reductions — period-specific leaves are legal inside a reduction) and
+        // counts, per row, the periods whose value is nonzero. This is
+        // referentially consistent with the sibling reductions rather than a
+        // special-cased period count: `count_over_periods(x)` means "how many
+        // periods had a nonzero `x`". A Bool/judgment-shaped inner value counts
+        // `true`; every numeric variant counts `!= 0`.
         if kind == OverPeriodsKind::Count {
-            return Ok(DenseColumn::Integer(vec![
-                period_count as i64;
-                self.row_count
-            ]));
+            let mut counts = vec![0_i64; self.row_count];
+            for executor in &mut self.period_executors {
+                let column = executor.eval_scalar_expr(value)?;
+                accumulate_nonzero_counts(&column, &mut counts)?;
+            }
+            return Ok(DenseColumn::Integer(counts));
         }
 
         // period-major: per_period[p][r] is entity r's inner value in period p.
@@ -2652,8 +2685,8 @@ impl<'a, N: DenseNum> LifetimeExecutor<'a, N> {
         }
 
         let result = match kind {
-            // Handled above, before the per-period matrix is built.
-            OverPeriodsKind::Count => unreachable!("count short-circuits above"),
+            // Handled above: count does not build the numeric period matrix.
+            OverPeriodsKind::Count => unreachable!("count is handled above"),
             OverPeriodsKind::Sum => (0..self.row_count)
                 .map(|row| {
                     let mut total = N::ZERO;
@@ -2676,7 +2709,12 @@ impl<'a, N: DenseNum> LifetimeExecutor<'a, N> {
                 })
                 .collect::<Vec<N>>(),
             OverPeriodsKind::SumTopN => {
-                let counts = self.eval_top_n_counts(n)?;
+                // `eval_top_n_counts` enforces 1 <= n <= period_count for every
+                // row, so `take` below never exceeds the number of periods: a
+                // top-N sum is a mathematical no-op past the period count (extra
+                // slots would only add zeros), so over-length n is rejected as a
+                // likely data error rather than silently padded.
+                let counts = self.eval_top_n_counts(n, period_count)?;
                 (0..self.row_count)
                     .map(|row| {
                         let mut values: Vec<N> =
@@ -2686,10 +2724,9 @@ impl<'a, N: DenseNum> LifetimeExecutor<'a, N> {
                         // partial_cmp is safe here.
                         values
                             .sort_by(|a, b| b.partial_cmp(a).unwrap_or(std::cmp::Ordering::Equal));
-                        // Take the top `n`; when fewer than `n` periods exist the
-                        // shortfall contributes zero (missing computation years),
-                        // which is exactly summing the available values.
-                        let take = counts[row].min(values.len());
+                        // n is bounded by the period count, so this takes a
+                        // genuine prefix of the sorted values (no zero padding).
+                        let take = counts[row];
                         let mut total = N::ZERO;
                         for value in &values[..take] {
                             total += *value;
@@ -2702,22 +2739,76 @@ impl<'a, N: DenseNum> LifetimeExecutor<'a, N> {
         Ok(N::into_column(result))
     }
 
-    /// Evaluate the `n` of `sum_top_n_over_periods` at the reference period into
-    /// a per-row count, truncating toward zero and rejecting `n < 1`.
+    /// Resolve the `n` of `sum_top_n_over_periods` into a per-row count under the
+    /// strict n contract. `n` is evaluated under EVERY period's executor and must
+    /// resolve to the same value in every period (parameter- and input-sourced n
+    /// are held to the identical contract — a period-varying parameter n is a
+    /// data error, not a silent pin to the reference period). The reference
+    /// period's column is then truncated toward zero to an exact `i64`; a
+    /// non-finite or out-of-range value (`try_to_i64_trunc` -> `None`) and any
+    /// `n` outside `1 <= n <= period_count` both raise typed errors — never a
+    /// clamp to `i64::MAX`, never a silent pin, never a pad past the period count
+    /// (which would be an arithmetic no-op masking the bad count).
     fn eval_top_n_counts(
         &mut self,
         n: Option<&CompiledScalarExpr>,
+        period_count: usize,
     ) -> Result<Vec<usize>, EvalError> {
         let n = n.ok_or_else(|| {
             EvalError::TypeMismatch("sum_top_n_over_periods requires an n argument".to_string())
         })?;
-        let raw = N::vec_from_column(&self.eval_scalar(n)?)?;
+        let reduction = OverPeriodsKind::SumTopN.as_call_name();
+
+        // Evaluate `n` under each period's executor: one column per period,
+        // positionally aligned by row. A parameter-sourced n indexes each
+        // period's date, so a year-varying parameter yields different columns and
+        // is caught below; an n derived from period-invariant inputs (the
+        // 42 USC 415(b) computation-year count) is identical in every period and
+        // passes.
+        let mut per_period: Vec<DenseColumn> = Vec::with_capacity(self.period_executors.len());
+        for executor in &mut self.period_executors {
+            per_period.push(executor.eval_scalar_expr(n)?);
+        }
+        let (reference, others) = per_period
+            .split_last()
+            .expect("lifetime execution guarantees at least one period");
+        // Reject a period-varying n: compare every earlier period against the
+        // reference (chronologically-last) period, in each column's own dtype.
+        for (index, column) in others.iter().enumerate() {
+            if let Some(row) = first_differing_row(reference, column) {
+                return Err(EvalError::OverPeriodsTopNPeriodVarying {
+                    reduction,
+                    first_period: period_label(self.period_executors[index].period),
+                    first_value: dense_value_label(column, row),
+                    second_period: period_label(
+                        self.period_executors[self.reference_period].period,
+                    ),
+                    second_value: dense_value_label(reference, row),
+                });
+            }
+        }
+
+        // n is period-invariant: truncate the reference column toward zero to an
+        // exact i64 and enforce 1 <= n <= period_count per row.
+        let raw = N::vec_from_column(reference)?;
         raw.into_iter()
-            .map(|value| {
-                // Truncate toward zero to an integer count, then require >= 1.
-                let as_i64 = N::to_i64_trunc(value);
-                if as_i64 < 1 {
-                    Err(EvalError::OverPeriodsTopNInvalid(as_i64))
+            .enumerate()
+            .map(|(row, value)| {
+                let as_i64 = value.try_to_i64_trunc().ok_or_else(|| {
+                    // Non-finite or beyond the i64 range: a garbage n, reported
+                    // as out of range rather than saturated to a clamp.
+                    EvalError::OverPeriodsTopNOutOfRange {
+                        reduction,
+                        n: dense_value_label(reference, row),
+                        period_count,
+                    }
+                })?;
+                if as_i64 < 1 || (as_i64 as u64) > period_count as u64 {
+                    Err(EvalError::OverPeriodsTopNOutOfRange {
+                        reduction,
+                        n: as_i64.to_string(),
+                        period_count,
+                    })
                 } else {
                     Ok(as_i64 as usize)
                 }
@@ -2855,6 +2946,57 @@ fn dense_value_label(column: &DenseColumn, row: usize) -> String {
         DenseColumn::Text(values) => format!("{:?}", values[row]),
         DenseColumn::Date(values) => values[row].to_string(),
     }
+}
+
+/// Add one to `counts[row]` for each row whose value in `column` is nonzero,
+/// used by `count_over_periods` to count the periods with a nonzero inner value.
+/// Numeric variants count `!= 0`; a `Bool` column counts `true`; `Date`/`Text`
+/// columns have no zero and cannot be produced by an arithmetic inner value, so
+/// they are rejected rather than silently counted.
+fn accumulate_nonzero_counts(column: &DenseColumn, counts: &mut [i64]) -> Result<(), EvalError> {
+    if column.len() != counts.len() {
+        return Err(EvalError::TypeMismatch(format!(
+            "count_over_periods inner value produced {} rows but the batch has {}",
+            column.len(),
+            counts.len()
+        )));
+    }
+    match column {
+        DenseColumn::Bool(values) => {
+            for (row, value) in values.iter().enumerate() {
+                if *value {
+                    counts[row] += 1;
+                }
+            }
+        }
+        DenseColumn::Integer(values) => {
+            for (row, value) in values.iter().enumerate() {
+                if *value != 0 {
+                    counts[row] += 1;
+                }
+            }
+        }
+        DenseColumn::Decimal(values) => {
+            for (row, value) in values.iter().enumerate() {
+                if !value.is_zero() {
+                    counts[row] += 1;
+                }
+            }
+        }
+        DenseColumn::Float(values) => {
+            for (row, value) in values.iter().enumerate() {
+                if *value != 0.0 {
+                    counts[row] += 1;
+                }
+            }
+        }
+        DenseColumn::Text(_) | DenseColumn::Date(_) => {
+            return Err(EvalError::TypeMismatch(
+                "count_over_periods requires a numeric or boolean inner value (text and date have no zero to count against)".to_string(),
+            ));
+        }
+    }
+    Ok(())
 }
 
 /// Return the first row index at which two positionally aligned dense columns

--- a/src/dense.rs
+++ b/src/dense.rs
@@ -2585,13 +2585,23 @@ impl<'a, N: DenseNum> LifetimeExecutor<'a, N> {
                 let else_values = self.eval_scalar(else_expr)?;
                 select_dense_scalar_column::<N>(condition, then_values, else_values)
             }
-            // Period-specific leaves have no defined period outside a reduction.
-            CompiledScalarExpr::Input(index) => Err(EvalError::LifetimeAmbiguousLeaf(
-                self.program.root_inputs[*index].clone(),
-            )),
-            CompiledScalarExpr::InputOrElse { input, .. } => Err(EvalError::LifetimeAmbiguousLeaf(
-                self.program.root_inputs[*input].clone(),
-            )),
+            // A bare input outside a reduction has no single period in general,
+            // but a per-person-constant input (a birth / age-attainment year —
+            // the shape every statutory computation-year count bottoms out in)
+            // carries the same value in every supplied period. Bind it per row
+            // when it is verified period-invariant; error naming the input and
+            // the first divergence when it is not. This is reached directly and
+            // through a derived chain (e.g. an elapsed-years count built from
+            // `year_attained_62 - year_attained_21`), and it may sit in scalar
+            // or in the `n` position of `sum_top_n_over_periods`.
+            CompiledScalarExpr::Input(index) => {
+                let name = self.program.root_inputs[*index].clone();
+                self.eval_period_invariant_input(expr, &name)
+            }
+            CompiledScalarExpr::InputOrElse { input, .. } => {
+                let name = self.program.root_inputs[*input].clone();
+                self.eval_period_invariant_input(expr, &name)
+            }
             CompiledScalarExpr::PeriodStart => {
                 Err(EvalError::LifetimeAmbiguousLeaf("period_start".to_string()))
             }
@@ -2715,6 +2725,60 @@ impl<'a, N: DenseNum> LifetimeExecutor<'a, N> {
             .collect()
     }
 
+    /// Bind a bare input evaluated OUTSIDE any reduction, when — and only when —
+    /// its supplied value is verified identical across every period for a given
+    /// row.
+    ///
+    /// A reduction defines the period axis explicitly; a bare input does not, so
+    /// it is period-ambiguous in general. But the derived counts real statutes
+    /// build (42 USC 415(b)'s benefit-computation-year count, from the year a
+    /// worker attains 21 and 62) bottom out in inputs that are constant across
+    /// the whole history by construction. Rather than reject every such input, we
+    /// evaluate `expr` under each period's ordinary executor and check PER ROW
+    /// that the value never changes. If a row is invariant across all periods,
+    /// that single value is bound for it; if any row diverges, we error, naming
+    /// the input and the first two differing period labels and values. Truly
+    /// period-varying inputs therefore still fail loudly — the check only
+    /// legalizes provably unambiguous bindings.
+    ///
+    /// Values are compared in each column's own dtype (numeric, bool, text or
+    /// date), so the invariance test is exact and never rounds. `expr` is the
+    /// original `Input` / `InputOrElse` node, replayed identically in every
+    /// period; an absent `InputOrElse` broadcasts the same default in each and so
+    /// is trivially invariant, binding that default.
+    fn eval_period_invariant_input(
+        &mut self,
+        expr: &CompiledScalarExpr,
+        input_name: &str,
+    ) -> Result<DenseColumn, EvalError> {
+        // Evaluate the leaf under every period's executor: one column per
+        // period, each of length `row_count` and positionally aligned by row.
+        let mut per_period: Vec<DenseColumn> = Vec::with_capacity(self.period_executors.len());
+        for executor in &mut self.period_executors {
+            per_period.push(executor.eval_scalar_expr(expr)?);
+        }
+        // A single period is invariant by definition; nothing to compare.
+        let (first, rest) = per_period
+            .split_first()
+            .expect("lifetime execution guarantees at least one period");
+        for (offset, column) in rest.iter().enumerate() {
+            if let Some(row) = first_differing_row(first, column) {
+                // `offset` indexes `rest`, so the diverging period is `offset + 1`.
+                let later_period = offset + 1;
+                return Err(EvalError::LifetimePeriodVaryingInput {
+                    input: input_name.to_string(),
+                    first_period: period_label(self.period_executors[0].period),
+                    first_value: dense_value_label(first, row),
+                    second_period: period_label(self.period_executors[later_period].period),
+                    second_value: dense_value_label(column, row),
+                });
+            }
+        }
+        // Every row agrees across all periods: bind the (identical) first
+        // period's column, preserving its original dtype for the caller.
+        Ok(first.clone())
+    }
+
     fn eval_judgment(
         &mut self,
         expr: &CompiledJudgmentExpr,
@@ -2770,6 +2834,69 @@ impl<'a, N: DenseNum> LifetimeExecutor<'a, N> {
                 })
                 .collect()),
         }
+    }
+}
+
+/// A human-readable label for a period, used in period-invariance error
+/// messages. The `start..end` boundaries identify the period unambiguously and
+/// match how periods are otherwise surfaced to callers.
+fn period_label(period: &Period) -> String {
+    format!("in {}..{}", period.start, period.end)
+}
+
+/// Format the value at `row` of a dense column for an error message, in the
+/// column's own dtype (so an integer year reads `1985`, not `1985.0`).
+fn dense_value_label(column: &DenseColumn, row: usize) -> String {
+    match column {
+        DenseColumn::Bool(values) => values[row].to_string(),
+        DenseColumn::Integer(values) => values[row].to_string(),
+        DenseColumn::Decimal(values) => values[row].to_string(),
+        DenseColumn::Float(values) => values[row].to_string(),
+        DenseColumn::Text(values) => format!("{:?}", values[row]),
+        DenseColumn::Date(values) => values[row].to_string(),
+    }
+}
+
+/// Return the first row index at which two positionally aligned dense columns
+/// disagree, or `None` if every row is identical. Comparison is exact and in
+/// each column's dtype; two numeric columns of different variants (e.g. an
+/// `Integer` and a `Float`) are compared by numeric value so an input supplied
+/// as `1985` in one period and `1985.0` in another is still period-invariant.
+/// Columns whose lengths differ, or whose types are non-numeric and mismatched,
+/// are treated as differing at the first row (this errors loudly, which is the
+/// safe outcome for a period that supplied a structurally different value).
+fn first_differing_row(left: &DenseColumn, right: &DenseColumn) -> Option<usize> {
+    // Length mismatch cannot arise under positional lifetime alignment (every
+    // period's batch has the same row count), but guard it: report row 0.
+    if left.len() != right.len() {
+        return Some(0);
+    }
+    match (left, right) {
+        (DenseColumn::Bool(a), DenseColumn::Bool(b)) => (0..a.len()).find(|&row| a[row] != b[row]),
+        (DenseColumn::Text(a), DenseColumn::Text(b)) => (0..a.len()).find(|&row| a[row] != b[row]),
+        (DenseColumn::Date(a), DenseColumn::Date(b)) => (0..a.len()).find(|&row| a[row] != b[row]),
+        // Any pairing of numeric variants (Integer / Decimal / Float) compares
+        // by numeric value. `vec_from_column::<Decimal>` promotes both sides to
+        // Decimal for an exact comparison when representable; a value not
+        // representable as Decimal — an f64 that is non-finite or beyond
+        // Decimal's magnitude (~7.9e28), neither of which a per-person constant
+        // year or money amount ever is — falls back to differing.
+        (
+            DenseColumn::Integer(_) | DenseColumn::Decimal(_) | DenseColumn::Float(_),
+            DenseColumn::Integer(_) | DenseColumn::Decimal(_) | DenseColumn::Float(_),
+        ) => match (
+            <Decimal as DenseNum>::vec_from_column(left),
+            <Decimal as DenseNum>::vec_from_column(right),
+        ) {
+            (Ok(a), Ok(b)) => (0..a.len()).find(|&row| a[row] != b[row]),
+            // Non-representable value on at least one side (non-finite or out of
+            // Decimal range): cannot prove invariance, so treat as differing at
+            // the first row.
+            _ => Some(0),
+        },
+        // Genuinely different, non-numeric column shapes: not provably
+        // invariant.
+        _ => Some(0),
     }
 }
 

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -69,7 +69,7 @@ pub enum EvalError {
     #[error(
         "lifetime execution cannot evaluate `{0}` outside an over-periods reduction because it is period-specific; wrap it in a reduction (e.g. sum_over_periods) so its period is defined"
     )]
-    LifetimeAmbiguousLeaf(&'static str),
+    LifetimeAmbiguousLeaf(String),
     #[error("sum_top_n_over_periods requires n >= 1, got {0}")]
     OverPeriodsTopNInvalid(i64),
 }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -44,6 +44,34 @@ pub enum EvalError {
     ExpectedScalar(String),
     #[error("division by zero")]
     DivisionByZero,
+    #[error(
+        "over-periods reduction `{0}` is valid only under lifetime execution (execute_lifetime); it has no meaning in per-period execution"
+    )]
+    OverPeriodsOutsideLifetime(&'static str),
+    #[error(
+        "lifetime execution requires one input batch per period: got {periods} periods and {batches} batches"
+    )]
+    LifetimePeriodBatchMismatch { periods: usize, batches: usize },
+    #[error("lifetime execution requires at least one period")]
+    LifetimeNoPeriods,
+    #[error(
+        "lifetime execution requires every period's batch to have the same entity row count (positional alignment): period {period} has {row_count} rows but period 0 has {expected}"
+    )]
+    LifetimeRowCountMismatch {
+        period: usize,
+        row_count: usize,
+        expected: usize,
+    },
+    #[error(
+        "lifetime execution only supports outputs whose formula contains an over-periods reduction; `{0}` does not — use the per-period execute / execute_f64 entry points instead"
+    )]
+    LifetimeOutputWithoutReduction(String),
+    #[error(
+        "lifetime execution cannot evaluate `{0}` outside an over-periods reduction because it is period-specific; wrap it in a reduction (e.g. sum_over_periods) so its period is defined"
+    )]
+    LifetimeAmbiguousLeaf(&'static str),
+    #[error("sum_top_n_over_periods requires n >= 1, got {0}")]
+    OverPeriodsTopNInvalid(i64),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
@@ -456,6 +484,12 @@ impl<'a> Engine<'a> {
                 } else {
                     self.eval_scalar_expr(else_expr, entity_id, period)
                 }
+            }
+            // Cross-period reductions are only defined when a batch is supplied
+            // per period (the dense lifetime surface). The sparse single-period
+            // interpreter has no period axis to reduce over.
+            ScalarExpr::OverPeriods { kind, .. } => {
+                Err(EvalError::OverPeriodsOutsideLifetime(kind.as_call_name()))
             }
         }
     }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -80,8 +80,33 @@ pub enum EvalError {
         second_period: String,
         second_value: String,
     },
-    #[error("sum_top_n_over_periods requires n >= 1, got {0}")]
-    OverPeriodsTopNInvalid(i64),
+    #[error(
+        "lifetime execution requires supplied periods in strictly ascending order by start date, but period {earlier_index} ({earlier}) does not start before period {later_index} ({later})"
+    )]
+    LifetimePeriodsNotAscending {
+        earlier_index: usize,
+        earlier: String,
+        later_index: usize,
+        later: String,
+    },
+    #[error(
+        "{reduction} requires an integer n with 1 <= n <= the {period_count} supplied periods, but n resolved to {n} for at least one entity; a top-N sum over more periods than exist only pads with zeros (a no-op), so this masks a data error — supply an n within range or pad the period history explicitly"
+    )]
+    OverPeriodsTopNOutOfRange {
+        reduction: &'static str,
+        n: String,
+        period_count: usize,
+    },
+    #[error(
+        "{reduction}'s n is not period-invariant for at least one entity — {first_period} it is {first_value} but {second_period} it is {second_value}; n must resolve to the same value in every supplied period (parameter- and input-sourced n are held to the same contract)"
+    )]
+    OverPeriodsTopNPeriodVarying {
+        reduction: &'static str,
+        first_period: String,
+        first_value: String,
+        second_period: String,
+        second_value: String,
+    },
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -70,6 +70,16 @@ pub enum EvalError {
         "lifetime execution cannot evaluate `{0}` outside an over-periods reduction because it is period-specific; wrap it in a reduction (e.g. sum_over_periods) so its period is defined"
     )]
     LifetimeAmbiguousLeaf(String),
+    #[error(
+        "lifetime execution cannot evaluate input `{input}` outside an over-periods reduction: its value is not period-invariant for at least one entity — {first_period} it is {first_value} but {second_period} it is {second_value}; wrap it in a reduction (e.g. sum_over_periods) so its period is defined, or supply the same value for every period"
+    )]
+    LifetimePeriodVaryingInput {
+        input: String,
+        first_period: String,
+        first_value: String,
+        second_period: String,
+        second_value: String,
+    },
     #[error("sum_top_n_over_periods requires n >= 1, got {0}")]
     OverPeriodsTopNInvalid(i64),
 }

--- a/src/formula.rs
+++ b/src/formula.rs
@@ -23,8 +23,8 @@ use thiserror::Error;
 
 use crate::spec::{
     ComparisonOpSpec, DTypeSpec, DerivedSemanticsSpec, DerivedSpec, DerivedVersionSpec,
-    IndexedParameterSpec, JudgmentExprSpec, ParameterVersionSpec, ProgramSpec, RelatedValueRefSpec,
-    RelationSpec, ScalarExprSpec, ScalarValueSpec, UnitKindSpec, UnitSpec,
+    IndexedParameterSpec, JudgmentExprSpec, OverPeriodsKindSpec, ParameterVersionSpec, ProgramSpec,
+    RelatedValueRefSpec, RelationSpec, ScalarExprSpec, ScalarValueSpec, UnitKindSpec, UnitSpec,
 };
 
 #[derive(Debug, Error)]
@@ -1444,6 +1444,36 @@ fn lower_to_scalar(e: &Expr, ctx: &LowerCtx) -> Result<ScalarExprSpec, FormulaEr
                     days: Box::new(lower_to_scalar(&args[1], ctx)?),
                 }
             }
+            // Over-periods reductions: reduce the inner expression across an
+            // entity's own period axis. Meaningful only under the lifetime
+            // execution surface; the per-period execution paths reject them.
+            "sum_over_periods" | "max_over_periods" | "count_over_periods" => {
+                if args.len() != 1 {
+                    return Err(FormulaError::lower(format!("{func} takes 1 arg")));
+                }
+                let over = match func.as_str() {
+                    "sum_over_periods" => OverPeriodsKindSpec::Sum,
+                    "max_over_periods" => OverPeriodsKindSpec::Max,
+                    _ => OverPeriodsKindSpec::Count,
+                };
+                ScalarExprSpec::OverPeriods {
+                    over,
+                    value: Box::new(lower_to_scalar(&args[0], ctx)?),
+                    n: None,
+                }
+            }
+            "sum_top_n_over_periods" => {
+                if args.len() != 2 {
+                    return Err(FormulaError::lower(
+                        "sum_top_n_over_periods takes 2 args".to_string(),
+                    ));
+                }
+                ScalarExprSpec::OverPeriods {
+                    over: OverPeriodsKindSpec::SumTopN,
+                    value: Box::new(lower_to_scalar(&args[0], ctx)?),
+                    n: Some(Box::new(lower_to_scalar(&args[1], ctx)?)),
+                }
+            }
             "len" => {
                 let rel = match args.first() {
                     Some(Expr::Var(rel)) => rel.clone(),
@@ -1655,6 +1685,14 @@ fn promote_ints_to_decimal(expr: &mut ScalarExprSpec) {
         } => {
             promote_ints_to_decimal(then_expr);
             promote_ints_to_decimal(else_expr);
+        }
+        // A Sum / Max / SumTopN reduction is Decimal-typed, so promote integer
+        // literals in its inner value to keep it Decimal. `n` (SumTopN count) is
+        // an integer count and is deliberately left alone. Count reduces to an
+        // integer, but promoting literals in its (ignored) inner value is
+        // harmless, so we descend uniformly.
+        ScalarExprSpec::OverPeriods { value, .. } => {
+            promote_ints_to_decimal(value);
         }
         // Don't descend into:
         //   * Comparisons (operands compare by their own type)

--- a/src/formula.rs
+++ b/src/formula.rs
@@ -1447,6 +1447,11 @@ fn lower_to_scalar(e: &Expr, ctx: &LowerCtx) -> Result<ScalarExprSpec, FormulaEr
             // Over-periods reductions: reduce the inner expression across an
             // entity's own period axis. Meaningful only under the lifetime
             // execution surface; the per-period execution paths reject them.
+            // The kind is chosen by an EXHAUSTIVE match with an explicit error
+            // arm — never a wildcard falling through to `Count` — so a future
+            // one-arg reduction added to this arm's guard cannot silently parse
+            // as the period count. `sum_top_n_over_periods` (two args) is handled
+            // separately below.
             "sum_over_periods" | "max_over_periods" | "count_over_periods" => {
                 if args.len() != 1 {
                     return Err(FormulaError::lower(format!("{func} takes 1 arg")));
@@ -1454,7 +1459,12 @@ fn lower_to_scalar(e: &Expr, ctx: &LowerCtx) -> Result<ScalarExprSpec, FormulaEr
                 let over = match func.as_str() {
                     "sum_over_periods" => OverPeriodsKindSpec::Sum,
                     "max_over_periods" => OverPeriodsKindSpec::Max,
-                    _ => OverPeriodsKindSpec::Count,
+                    "count_over_periods" => OverPeriodsKindSpec::Count,
+                    other => {
+                        return Err(FormulaError::lower(format!(
+                            "unknown one-argument over-periods reduction `{other}`"
+                        )));
+                    }
                 };
                 ScalarExprSpec::OverPeriods {
                     over,
@@ -1588,6 +1598,15 @@ fn lower_to_scalar(e: &Expr, ctx: &LowerCtx) -> Result<ScalarExprSpec, FormulaEr
                     value,
                     where_clause: Some(Box::new(where_clause)),
                 }
+            }
+            // Any other `*_over_periods` name is an unrecognized reduction, not a
+            // generic unknown function: reject it explicitly so a typo or a
+            // not-yet-implemented reduction fails to parse loudly instead of
+            // being mistaken for a plain call.
+            other if other.ends_with("_over_periods") => {
+                return Err(FormulaError::lower(format!(
+                    "unknown over-periods reduction `{other}` (expected one of sum_over_periods, max_over_periods, count_over_periods, sum_top_n_over_periods)"
+                )));
             }
             _ => {
                 return Err(FormulaError::lower(format!("unknown function `{}`", func)));

--- a/src/model.rs
+++ b/src/model.rs
@@ -248,6 +248,38 @@ pub enum RelatedValueRef {
     Derived(String),
 }
 
+/// Which reduction an [`ScalarExpr::OverPeriods`] applies across an entity's
+/// own period axis. Valid only under the lifetime execution surface
+/// (`DenseCompiledProgram::execute_lifetime`); the per-period execution paths
+/// reject these because a single period has no period axis to reduce over.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum OverPeriodsKind {
+    /// Sum of the inner value across all supplied periods.
+    Sum,
+    /// Maximum of the inner value across all supplied periods.
+    Max,
+    /// Count of supplied periods (the inner value is evaluated but ignored).
+    Count,
+    /// Sum of the `n` largest per-period inner values. When fewer than `n`
+    /// periods are supplied, the missing periods contribute zero — mirroring
+    /// 42 USC 415(b), where the computation years count whether or not the
+    /// worker had earnings.
+    SumTopN,
+}
+
+impl OverPeriodsKind {
+    /// The formula builtin name that lowers to this reduction, used in
+    /// diagnostics (e.g. rejecting the node under per-period execution).
+    pub fn as_call_name(self) -> &'static str {
+        match self {
+            Self::Sum => "sum_over_periods",
+            Self::Max => "max_over_periods",
+            Self::Count => "count_over_periods",
+            Self::SumTopN => "sum_top_n_over_periods",
+        }
+    }
+}
+
 #[derive(Clone, Debug)]
 pub enum ScalarExpr {
     Literal(ScalarValue),
@@ -301,6 +333,17 @@ pub enum ScalarExpr {
         condition: Box<JudgmentExpr>,
         then_expr: Box<ScalarExpr>,
         else_expr: Box<ScalarExpr>,
+    },
+    /// Reduction over an entity's own period axis (lifetime execution only).
+    /// `value` is the inner per-period expression, evaluated once per supplied
+    /// period; `n` is present only for [`OverPeriodsKind::SumTopN`] and gives
+    /// the number of largest per-period values to sum. The per-period execution
+    /// paths reject this node — it is meaningful only when a batch is supplied
+    /// per period through `execute_lifetime`.
+    OverPeriods {
+        kind: OverPeriodsKind,
+        value: Box<ScalarExpr>,
+        n: Option<Box<ScalarExpr>>,
     },
 }
 
@@ -640,6 +683,12 @@ fn collect_input_slots_from_scalar_expr<'a>(expr: &'a ScalarExpr, slots: &mut Ha
             collect_input_slots_from_judgment_expr(condition, slots);
             collect_input_slots_from_scalar_expr(then_expr, slots);
             collect_input_slots_from_scalar_expr(else_expr, slots);
+        }
+        ScalarExpr::OverPeriods { value, n, .. } => {
+            collect_input_slots_from_scalar_expr(value, slots);
+            if let Some(n) = n {
+                collect_input_slots_from_scalar_expr(n, slots);
+            }
         }
     }
 }

--- a/src/model.rs
+++ b/src/model.rs
@@ -258,12 +258,15 @@ pub enum OverPeriodsKind {
     Sum,
     /// Maximum of the inner value across all supplied periods.
     Max,
-    /// Count of supplied periods (the inner value is evaluated but ignored).
+    /// Count, per entity, of the supplied periods whose inner value is nonzero
+    /// (a `Bool` inner value counts `true`). The inner value IS evaluated per
+    /// period and tested against zero — this is not a bare period count.
     Count,
-    /// Sum of the `n` largest per-period inner values. When fewer than `n`
-    /// periods are supplied, the missing periods contribute zero — mirroring
-    /// 42 USC 415(b), where the computation years count whether or not the
-    /// worker had earnings.
+    /// Sum of the `n` largest per-period inner values. `n` must satisfy
+    /// `1 <= n <= the supplied period count` (the strict n contract): an
+    /// over-length `n` would only pad with zeros — an arithmetic no-op — so it
+    /// is rejected as a likely data error rather than silently summing every
+    /// period. `n` must also be period-invariant.
     SumTopN,
 }
 

--- a/src/rulespec.rs
+++ b/src/rulespec.rs
@@ -169,9 +169,7 @@ pub enum RuleSpecError {
         target: String,
         value: String,
     },
-    #[error(
-        "RuleSpec relation `{name}` is declared with conflicting arities {existing} and {new}"
-    )]
+    #[error("RuleSpec relation `{name}` is declared with conflicting arities {existing} and {new}")]
     RelationArityConflict {
         name: String,
         existing: usize,
@@ -2018,6 +2016,12 @@ fn rewrite_relation_alias_in_scalar(expr: &mut ScalarExprSpec, alias: &str, rela
             rewrite_relation_alias_in_scalar(then_expr, alias, relation_name);
             rewrite_relation_alias_in_scalar(else_expr, alias, relation_name);
         }
+        ScalarExprSpec::OverPeriods { value, n, .. } => {
+            rewrite_relation_alias_in_scalar(value, alias, relation_name);
+            if let Some(n) = n {
+                rewrite_relation_alias_in_scalar(n, alias, relation_name);
+            }
+        }
     }
 }
 
@@ -2306,6 +2310,12 @@ fn collect_scalar_relation_names(expr: &ScalarExprSpec, names: &mut HashSet<Stri
             collect_scalar_relation_names(then_expr, names);
             collect_scalar_relation_names(else_expr, names);
         }
+        ScalarExprSpec::OverPeriods { value, n, .. } => {
+            collect_scalar_relation_names(value, names);
+            if let Some(n) = n {
+                collect_scalar_relation_names(n, names);
+            }
+        }
     }
 }
 
@@ -2496,6 +2506,24 @@ fn rewrite_scalar_relation_references(
                 derived_origin_targets,
             );
         }
+        ScalarExprSpec::OverPeriods { value, n, .. } => {
+            rewrite_scalar_relation_references(
+                value,
+                origin_target,
+                rewrites,
+                unambiguous_short_rewrites,
+                derived_origin_targets,
+            );
+            if let Some(n) = n {
+                rewrite_scalar_relation_references(
+                    n,
+                    origin_target,
+                    rewrites,
+                    unambiguous_short_rewrites,
+                    derived_origin_targets,
+                );
+            }
+        }
     }
 }
 
@@ -2679,6 +2707,12 @@ fn scalar_uses_imported_derived(
             judgment_uses_imported_derived(condition, origin_target, derived_origin_targets)
                 || scalar_uses_imported_derived(then_expr, origin_target, derived_origin_targets)
                 || scalar_uses_imported_derived(else_expr, origin_target, derived_origin_targets)
+        }
+        ScalarExprSpec::OverPeriods { value, n, .. } => {
+            scalar_uses_imported_derived(value, origin_target, derived_origin_targets)
+                || n.as_deref().is_some_and(|n| {
+                    scalar_uses_imported_derived(n, origin_target, derived_origin_targets)
+                })
         }
     }
 }

--- a/src/source.rs
+++ b/src/source.rs
@@ -82,10 +82,8 @@ impl ModuleSource for FsModuleSource {
         if !crate::rulespec::is_canonical_repo_prefix(prefix) {
             return Ok(None);
         }
-        let relative_path = std::path::PathBuf::from(format!(
-            "{}.yaml",
-            relative.trim().trim_matches('/')
-        ));
+        let relative_path =
+            std::path::PathBuf::from(format!("{}.yaml", relative.trim().trim_matches('/')));
         if relative_path.is_absolute()
             || relative_path
                 .components()

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -8,9 +8,9 @@ use thiserror::Error;
 
 use crate::model::{
     ComparisonOp, DType, DataSet, Derived, DerivedSemantics, DerivedVersion, IndexedParameter,
-    InputRecord, Interval, JudgmentExpr, JudgmentOutcome, ParameterVersion, Period, PeriodKind,
-    Program, RelatedValueRef, RelationDerivation, RelationRecord, RelationSchema, Rounding,
-    RoundingMode, ScalarExpr, ScalarValue, UnitDef, UnitKind,
+    InputRecord, Interval, JudgmentExpr, JudgmentOutcome, OverPeriodsKind, ParameterVersion,
+    Period, PeriodKind, Program, RelatedValueRef, RelationDerivation, RelationRecord,
+    RelationSchema, Rounding, RoundingMode, ScalarExpr, ScalarValue, UnitDef, UnitKind,
 };
 
 #[derive(Debug, Error)]
@@ -690,6 +690,47 @@ pub enum ScalarExprSpec {
         then_expr: Box<ScalarExprSpec>,
         else_expr: Box<ScalarExprSpec>,
     },
+    /// Reduction over an entity's own period axis (lifetime execution only).
+    /// `n` is present only for the `sum_top_n` reduction. Expression-level,
+    /// additive to the serialized surface — no artifact-format-version bump.
+    OverPeriods {
+        over: OverPeriodsKindSpec,
+        value: Box<ScalarExprSpec>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        n: Option<Box<ScalarExprSpec>>,
+    },
+}
+
+/// The over-periods reduction vocabulary, mirroring
+/// [`crate::model::OverPeriodsKind`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(rename_all = "snake_case")]
+pub enum OverPeriodsKindSpec {
+    Sum,
+    Max,
+    Count,
+    SumTopN,
+}
+
+impl OverPeriodsKindSpec {
+    fn to_model(self) -> OverPeriodsKind {
+        match self {
+            Self::Sum => OverPeriodsKind::Sum,
+            Self::Max => OverPeriodsKind::Max,
+            Self::Count => OverPeriodsKind::Count,
+            Self::SumTopN => OverPeriodsKind::SumTopN,
+        }
+    }
+
+    pub fn from_model(kind: OverPeriodsKind) -> Self {
+        match kind {
+            OverPeriodsKind::Sum => Self::Sum,
+            OverPeriodsKind::Max => Self::Max,
+            OverPeriodsKind::Count => Self::Count,
+            OverPeriodsKind::SumTopN => Self::SumTopN,
+        }
+    }
 }
 
 impl ScalarExprSpec {
@@ -786,6 +827,13 @@ impl ScalarExprSpec {
                 condition: Box::new(condition.to_model()?),
                 then_expr: Box::new(then_expr.to_model()?),
                 else_expr: Box::new(else_expr.to_model()?),
+            }),
+            Self::OverPeriods { over, value, n } => Ok(ScalarExpr::OverPeriods {
+                kind: over.to_model(),
+                value: Box::new(value.to_model()?),
+                n: n.as_ref()
+                    .map(|inner| inner.to_model().map(Box::new))
+                    .transpose()?,
             }),
         }
     }

--- a/tests/dense.rs
+++ b/tests/dense.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::str::FromStr;
 
 use axiom_rules_engine::api::{
-    execute_request, ExecutionMode, ExecutionQuery, ExecutionRequest, OutputValue,
+    ExecutionMode, ExecutionQuery, ExecutionRequest, OutputValue, execute_request,
 };
 use axiom_rules_engine::compile::CompiledProgramArtifact;
 use axiom_rules_engine::dense::{

--- a/tests/execution.rs
+++ b/tests/execution.rs
@@ -3,8 +3,8 @@ use std::process::{Command, Stdio};
 use std::str::FromStr;
 
 use axiom_rules_engine::api::{
-    execute_compiled_request, execute_request, CompiledExecutionRequest, ExecutionMode,
-    ExecutionQuery, ExecutionRequest, ExecutionResponse, OutputValue,
+    CompiledExecutionRequest, ExecutionMode, ExecutionQuery, ExecutionRequest, ExecutionResponse,
+    OutputValue, execute_compiled_request, execute_request,
 };
 use axiom_rules_engine::compile::CompiledProgramArtifact;
 use axiom_rules_engine::spec::{

--- a/tests/lifetime.rs
+++ b/tests/lifetime.rs
@@ -37,6 +37,23 @@ fn batch(input: &str, values: Vec<f64>) -> DenseBatchSpec {
     }
 }
 
+/// A batch with several named float inputs, all describing the same rows in the
+/// same order. Every column must have `row_count` entries.
+fn batch_multi(row_count: usize, columns: &[(&str, Vec<f64>)]) -> DenseBatchSpec {
+    let inputs = columns
+        .iter()
+        .map(|(name, values)| {
+            assert_eq!(values.len(), row_count, "column `{name}` has wrong length");
+            (name.to_string(), DenseColumn::Float(values.clone()))
+        })
+        .collect();
+    DenseBatchSpec {
+        row_count,
+        inputs,
+        relations: HashMap::new(),
+    }
+}
+
 fn compile(rulespec: &str, entity: &str) -> DenseCompiledProgram {
     let artifact =
         CompiledProgramArtifact::from_rulespec_str(rulespec).expect("rulespec module compiles");
@@ -637,4 +654,249 @@ fn decimal_mode_sums_exactly() {
         panic!("decimal mode must return a Decimal column");
     };
     assert_eq!(values, &vec![Decimal::from_str_exact("0.3").unwrap()]);
+}
+
+// ---------------------------------------------------------------------------
+// Period-invariant binding of bare inputs outside a reduction
+//
+// A bare input evaluated outside any reduction has no single period in general.
+// But the derived counts real statutes build (42 USC 415(b)'s computation-year
+// count) bottom out in per-person-constant inputs supplied identically in every
+// period. Lifetime execution binds such an input when — and only when — its
+// value is verified identical across all supplied periods for each row; a value
+// that actually varies across periods still errors, naming the input.
+// ---------------------------------------------------------------------------
+
+/// The 415(b) benefit-computation-year count shape, as a standalone module: a
+/// derived integer count built from two per-person-constant inputs (the years a
+/// worker attains 21 and 62), then that count is used both as the `n` of
+/// `sum_top_n_over_periods` AND as a divisor in the outer formula. The count is
+/// reached only through a derived chain and sits outside every reduction — the
+/// exact pattern the amendment legalizes.
+const DERIVED_N_MODULE: &str = r#"
+format: rulespec/v1
+module:
+  summary: |-
+    Shape-mirror of 42 USC 415(b): a benefit-computation-year count derived from
+    per-person-constant inputs feeds sum_top_n_over_periods as a person-varying n
+    and divides the total to an AIME.
+rules:
+  - name: dropout_years
+    kind: parameter
+    dtype: Integer
+    versions:
+      - effective_from: '1979-01-01'
+        formula: '5'
+  - name: minimum_computation_years
+    kind: parameter
+    dtype: Integer
+    versions:
+      - effective_from: '1979-01-01'
+        formula: '2'
+  - name: months_per_year
+    kind: parameter
+    dtype: Integer
+    versions:
+      - effective_from: '1979-01-01'
+        formula: '12'
+  - name: elapsed_years
+    kind: derived
+    entity: Worker
+    dtype: Integer
+    period: Year
+    versions:
+      - effective_from: '1979-01-01'
+        formula: |-
+          year_attained_62 - max(1950, year_attained_21)
+  - name: computation_year_count
+    kind: derived
+    entity: Worker
+    dtype: Integer
+    period: Year
+    versions:
+      - effective_from: '1979-01-01'
+        formula: |-
+          max(minimum_computation_years, elapsed_years - dropout_years)
+  - name: earnings_total
+    kind: derived
+    entity: Worker
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '1979-01-01'
+        formula: |-
+          sum_top_n_over_periods(indexed_earnings, computation_year_count)
+  - name: aime
+    kind: derived
+    entity: Worker
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '1979-01-01'
+        formula: |-
+          floor(earnings_total / (months_per_year * computation_year_count))
+"#;
+
+#[test]
+fn per_person_constant_input_binds_outside_a_reduction() {
+    // A single per-person-constant input used directly in the outer formula
+    // (added to a reduction). The input is the same in every period, so it binds
+    // to that value. base_year = 2000 (constant); sum = 10 + 20 + 30 = 60;
+    // result = 60 + 2000 = 2060.
+    let module = r#"
+format: rulespec/v1
+rules:
+  - name: shifted_total
+    kind: derived
+    entity: Worker
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          sum_over_periods(earnings) + base_year
+"#;
+    let program = compile(module, "Worker");
+    let periods = vec![year(2001), year(2002), year(2003)];
+    let batches = vec![
+        batch_multi(1, &[("earnings", vec![10.0]), ("base_year", vec![2000.0])]),
+        batch_multi(1, &[("earnings", vec![20.0]), ("base_year", vec![2000.0])]),
+        batch_multi(1, &[("earnings", vec![30.0]), ("base_year", vec![2000.0])]),
+    ];
+    let result = program
+        .execute_lifetime(&periods, batches, &["shifted_total".to_string()])
+        .expect("period-invariant input must bind");
+    assert_eq!(scalar_f64(&result, "shifted_total"), vec![2060.0]);
+}
+
+#[test]
+fn per_row_varying_but_per_period_constant_input_binds_per_row() {
+    // Two workers with DIFFERENT constant inputs. Each row's input is invariant
+    // across the three periods, but the rows differ from each other — the bind
+    // is per row. Row 0: base 100, sum 6 -> 106. Row 1: base 500, sum 60 -> 560.
+    let module = r#"
+format: rulespec/v1
+rules:
+  - name: shifted_total
+    kind: derived
+    entity: Worker
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          sum_over_periods(earnings) + base
+"#;
+    let program = compile(module, "Worker");
+    let periods = vec![year(2001), year(2002), year(2003)];
+    let batches = vec![
+        batch_multi(
+            2,
+            &[("earnings", vec![1.0, 10.0]), ("base", vec![100.0, 500.0])],
+        ),
+        batch_multi(
+            2,
+            &[("earnings", vec![2.0, 20.0]), ("base", vec![100.0, 500.0])],
+        ),
+        batch_multi(
+            2,
+            &[("earnings", vec![3.0, 30.0]), ("base", vec![100.0, 500.0])],
+        ),
+    ];
+    let result = program
+        .execute_lifetime(&periods, batches, &["shifted_total".to_string()])
+        .expect("per-row-constant input must bind per row");
+    assert_eq!(result.row_count, 2);
+    assert_eq!(scalar_f64(&result, "shifted_total"), vec![106.0, 560.0]);
+}
+
+#[test]
+fn period_varying_input_still_errors_naming_the_input() {
+    // The same input `base` is supplied a DIFFERENT value in period 1 than in
+    // period 0 for the (single) row. That is genuinely period-ambiguous outside
+    // a reduction, so it must error, and the message must name the input.
+    let module = r#"
+format: rulespec/v1
+rules:
+  - name: shifted_total
+    kind: derived
+    entity: Worker
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '1990-01-01'
+        formula: |-
+          sum_over_periods(earnings) + base
+"#;
+    let program = compile(module, "Worker");
+    let periods = vec![year(2001), year(2002)];
+    let batches = vec![
+        batch_multi(1, &[("earnings", vec![1.0]), ("base", vec![100.0])]),
+        // base changes from 100 to 200 across periods -> ambiguous.
+        batch_multi(1, &[("earnings", vec![2.0]), ("base", vec![200.0])]),
+    ];
+    let error = program
+        .execute_lifetime(&periods, batches, &["shifted_total".to_string()])
+        .expect_err("a period-varying input must error");
+    let message = error.to_string();
+    assert!(
+        message.contains("base")
+            && message.contains("not period-invariant")
+            && message.contains("100")
+            && message.contains("200"),
+        "unexpected error: {message}"
+    );
+}
+
+/// Two workers with genuinely different derived `n` (36 and 31) in one batch,
+/// mirroring the Python acceptance fixture and rulespec-us #541's 415(b) shape.
+/// The count is derived from per-person-constant inputs and used as the `n` of
+/// `sum_top_n_over_periods` and as an outer divisor. Hand-derived:
+///   Worker A: year21=1985, year62=2026 -> elapsed 41, count max(2,41-5)=36.
+///     Earnings: 96_000 x36 then 12_000, 6_000, 0, 0, 0 (41 periods).
+///     top-36 sum = 36*96_000 = 3_456_000.
+///     aime = floor(3_456_000 / (12*36=432)) = floor(8000.0) = 8000.
+///   Worker B: year21=1990, year62=2026 -> elapsed 36, count max(2,36-5)=31.
+///     Earnings: flat 62_000 (41 periods). top-31 sum = 31*62_000 = 1_922_000.
+///     aime = floor(1_922_000 / (12*31=372)) = floor(5166.666...) = 5166.
+///       (Statutory floor per 42 USC 415(b)(2)(A) / 20 CFR 404.211(d); NOT the
+///        round-half-up 5167 — no integer months divisor even yields 5167.)
+#[test]
+fn derived_n_from_constant_inputs_end_to_end() {
+    let program = compile(DERIVED_N_MODULE, "Worker");
+    let n_periods = 41;
+    let periods = (0..n_periods)
+        .map(|k| year(1985 + k as i32))
+        .collect::<Vec<_>>();
+
+    let mut a_earn = vec![96_000.0; 36];
+    a_earn.extend([12_000.0, 6_000.0, 0.0, 0.0, 0.0]);
+    let b_earn = vec![62_000.0; n_periods];
+
+    let batches = (0..n_periods)
+        .map(|k| {
+            batch_multi(
+                2,
+                &[
+                    ("indexed_earnings", vec![a_earn[k], b_earn[k]]),
+                    ("year_attained_21", vec![1985.0, 1990.0]),
+                    ("year_attained_62", vec![2026.0, 2026.0]),
+                ],
+            )
+        })
+        .collect::<Vec<_>>();
+
+    let result = program
+        .execute_lifetime(
+            &periods,
+            batches,
+            &["earnings_total".to_string(), "aime".to_string()],
+        )
+        .expect("derived-n lifetime execution succeeds");
+    assert_eq!(result.row_count, 2);
+    assert_eq!(
+        scalar_f64(&result, "earnings_total"),
+        vec![3_456_000.0, 1_922_000.0]
+    );
+    assert_eq!(scalar_f64(&result, "aime"), vec![8_000.0, 5_166.0]);
 }

--- a/tests/lifetime.rs
+++ b/tests/lifetime.rs
@@ -1,0 +1,594 @@
+//! Tests for the cross-period reduction surface (issue #67): the four
+//! over-periods builtins and `DenseCompiledProgram::execute_lifetime[_f64]`.
+//!
+//! The reductions run over an entity's own period axis — one positionally
+//! aligned input batch per period. Row `i` is the same entity in every period.
+
+use std::collections::HashMap;
+
+use axiom_rules_engine::compile::CompiledProgramArtifact;
+use axiom_rules_engine::dense::{
+    DenseBatchSpec, DenseColumn, DenseCompiledProgram, DenseOutputValue,
+};
+use axiom_rules_engine::model::{Period, PeriodKind};
+use rust_decimal::Decimal;
+use rust_decimal::prelude::ToPrimitive;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// A calendar-year period. Only the boundaries matter to parameter selection;
+/// the reductions themselves are period-count driven.
+fn year(y: i32) -> Period {
+    Period {
+        kind: PeriodKind::TaxYear,
+        start: chrono::NaiveDate::from_ymd_opt(y, 1, 1).expect("date"),
+        end: chrono::NaiveDate::from_ymd_opt(y, 12, 31).expect("date"),
+    }
+}
+
+/// One single-column input batch of `values` (one row per entity).
+fn batch(input: &str, values: Vec<f64>) -> DenseBatchSpec {
+    DenseBatchSpec {
+        row_count: values.len(),
+        inputs: HashMap::from([(input.to_string(), DenseColumn::Float(values))]),
+        relations: HashMap::new(),
+    }
+}
+
+fn compile(rulespec: &str, entity: &str) -> DenseCompiledProgram {
+    let artifact =
+        CompiledProgramArtifact::from_rulespec_str(rulespec).expect("rulespec module compiles");
+    DenseCompiledProgram::from_artifact(&artifact, Some(entity))
+        .expect("dense compilation succeeds")
+}
+
+/// Read a single-output scalar result as a `Vec<f64>`, accepting whichever
+/// numeric column variant the mode produced (`Decimal` for `execute_lifetime`,
+/// `Float` for `execute_lifetime_f64`, `Integer` for `count_over_periods`).
+fn scalar_f64(result: &axiom_rules_engine::dense::DenseExecutionResult, name: &str) -> Vec<f64> {
+    match result.outputs.get(name).expect("output present") {
+        DenseOutputValue::Scalar(DenseColumn::Decimal(values)) => {
+            values.iter().map(|value| value.to_f64().unwrap()).collect()
+        }
+        DenseOutputValue::Scalar(DenseColumn::Float(values)) => values.clone(),
+        DenseOutputValue::Scalar(DenseColumn::Integer(values)) => {
+            values.iter().map(|value| *value as f64).collect()
+        }
+        other => panic!("expected a numeric scalar column, got {other:?}"),
+    }
+}
+
+// A minimal single-rule module. `{FORMULA}` is spliced into the `aime`-style
+// derived rule so each test can vary only the reduction under test.
+fn single_rule_module(name: &str, dtype: &str, formula: &str) -> String {
+    format!(
+        r#"
+format: rulespec/v1
+rules:
+  - name: {name}
+    kind: derived
+    entity: Worker
+    dtype: {dtype}
+    period: Year
+    versions:
+      - effective_from: '1960-01-01'
+        formula: |-
+          {formula}
+"#
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Acceptance test — issue #67: AIME for a synthetic 40-year worker
+// ---------------------------------------------------------------------------
+
+/// 42 USC 415(b): AIME is the sum of the highest-35 years of indexed earnings
+/// divided by 420 (35 years x 12 months), rounded down.
+///
+/// Synthetic worker: 40 years of indexed earnings, year k (k = 1..=40) earns
+///   12_000 + 1_000 * (k - 1)  =>  12_000, 13_000, ..., 51_000.
+/// The top 35 of 40 drops the five smallest (12_000..16_000), keeping the
+/// arithmetic series 17_000, 18_000, ..., 51_000 (35 terms).
+///   sum(top 35) = 35 * (17_000 + 51_000) / 2 = 35 * 34_000 = 1_190_000
+///   AIME        = floor(1_190_000 / 420) = floor(2833.33...) = 2833
+const AIME_MODULE: &str = r#"
+format: rulespec/v1
+module:
+  summary: |-
+    Synthetic 42 USC 415(b) AIME: highest-35-years selection over a worker's
+    own earnings history. Acceptance fixture for cross-period reductions (#67).
+rules:
+  - name: computation_years
+    kind: parameter
+    dtype: Integer
+    versions:
+      - effective_from: '1960-01-01'
+        formula: '35'
+  - name: aime_divisor
+    kind: parameter
+    dtype: Integer
+    versions:
+      - effective_from: '1960-01-01'
+        formula: '420'
+  - name: aime
+    kind: derived
+    entity: Worker
+    dtype: Money
+    unit: USD
+    period: Year
+    source: 42 USC 415(b)
+    versions:
+      - effective_from: '1960-01-01'
+        formula: |-
+          floor(sum_top_n_over_periods(indexed_earnings, computation_years) / aime_divisor)
+"#;
+
+fn aime_worker() -> (Vec<Period>, Vec<DenseBatchSpec>) {
+    let periods = (1..=40).map(|k| year(1980 + k)).collect::<Vec<_>>();
+    let batches = (1..=40)
+        .map(|k| {
+            batch(
+                "indexed_earnings",
+                vec![12_000.0 + 1_000.0 * f64::from(k - 1)],
+            )
+        })
+        .collect::<Vec<_>>();
+    (periods, batches)
+}
+
+#[test]
+fn aime_40_year_worker_decimal() {
+    let program = compile(AIME_MODULE, "Worker");
+    let (periods, batches) = aime_worker();
+    let result = program
+        .execute_lifetime(&periods, batches, &["aime".to_string()])
+        .expect("lifetime execution succeeds");
+    assert_eq!(result.row_count, 1);
+    // Hand-derived above: floor(1_190_000 / 420) = 2833.
+    assert_eq!(scalar_f64(&result, "aime"), vec![2833.0]);
+}
+
+#[test]
+fn aime_40_year_worker_f64_matches_decimal() {
+    let program = compile(AIME_MODULE, "Worker");
+    let (periods, batches) = aime_worker();
+    let result = program
+        .execute_lifetime_f64(&periods, batches, &["aime".to_string()])
+        .expect("lifetime execution succeeds");
+    assert_eq!(scalar_f64(&result, "aime"), vec![2833.0]);
+}
+
+// ---------------------------------------------------------------------------
+// Each builtin
+// ---------------------------------------------------------------------------
+
+#[test]
+fn sum_over_periods_totals_the_period_axis() {
+    let module = single_rule_module("total", "Money", "sum_over_periods(earnings)");
+    let program = compile(&module, "Worker");
+    let periods = vec![year(2001), year(2002), year(2003)];
+    let batches = vec![
+        batch("earnings", vec![100.0]),
+        batch("earnings", vec![250.0]),
+        batch("earnings", vec![50.0]),
+    ];
+    let result = program
+        .execute_lifetime(&periods, batches, &["total".to_string()])
+        .expect("lifetime execution succeeds");
+    assert_eq!(scalar_f64(&result, "total"), vec![400.0]);
+}
+
+#[test]
+fn max_over_periods_takes_the_largest_period() {
+    let module = single_rule_module("peak", "Money", "max_over_periods(earnings)");
+    let program = compile(&module, "Worker");
+    let periods = vec![year(2001), year(2002), year(2003)];
+    let batches = vec![
+        batch("earnings", vec![100.0]),
+        batch("earnings", vec![250.0]),
+        batch("earnings", vec![50.0]),
+    ];
+    let result = program
+        .execute_lifetime(&periods, batches, &["peak".to_string()])
+        .expect("lifetime execution succeeds");
+    assert_eq!(scalar_f64(&result, "peak"), vec![250.0]);
+}
+
+#[test]
+fn count_over_periods_counts_supplied_periods() {
+    // The inner value is evaluated but ignored; the count is the period count,
+    // identical for every row.
+    let module = single_rule_module("years", "Integer", "count_over_periods(earnings)");
+    let program = compile(&module, "Worker");
+    let periods = vec![year(2001), year(2002), year(2003), year(2004)];
+    let batches = vec![
+        batch("earnings", vec![1.0, 9.0]),
+        batch("earnings", vec![2.0, 8.0]),
+        batch("earnings", vec![3.0, 7.0]),
+        batch("earnings", vec![4.0, 6.0]),
+    ];
+    let result = program
+        .execute_lifetime(&periods, batches, &["years".to_string()])
+        .expect("lifetime execution succeeds");
+    // Two entities (rows), each sees the same period count of 4.
+    assert_eq!(scalar_f64(&result, "years"), vec![4.0, 4.0]);
+}
+
+// ---------------------------------------------------------------------------
+// sum_top_n_over_periods edge cases
+// ---------------------------------------------------------------------------
+
+#[test]
+fn sum_top_n_selects_the_n_largest() {
+    let module = single_rule_module("top2", "Money", "sum_top_n_over_periods(earnings, 2)");
+    let program = compile(&module, "Worker");
+    let periods = vec![year(2001), year(2002), year(2003), year(2004)];
+    let batches = vec![
+        batch("earnings", vec![10.0]),
+        batch("earnings", vec![40.0]),
+        batch("earnings", vec![30.0]),
+        batch("earnings", vec![20.0]),
+    ];
+    let result = program
+        .execute_lifetime(&periods, batches, &["top2".to_string()])
+        .expect("lifetime execution succeeds");
+    // Two largest: 40 + 30 = 70.
+    assert_eq!(scalar_f64(&result, "top2"), vec![70.0]);
+}
+
+#[test]
+fn sum_top_n_with_ties_sums_the_right_multiplicity() {
+    // Four periods valued 50, 50, 50, 10; top 2 must be 50 + 50 = 100 even
+    // though the 50s tie. Sorting is by value; ties contribute their own copies.
+    let module = single_rule_module("top2", "Money", "sum_top_n_over_periods(earnings, 2)");
+    let program = compile(&module, "Worker");
+    let periods = vec![year(2001), year(2002), year(2003), year(2004)];
+    let batches = vec![
+        batch("earnings", vec![50.0]),
+        batch("earnings", vec![50.0]),
+        batch("earnings", vec![50.0]),
+        batch("earnings", vec![10.0]),
+    ];
+    let result = program
+        .execute_lifetime(&periods, batches, &["top2".to_string()])
+        .expect("lifetime execution succeeds");
+    assert_eq!(scalar_f64(&result, "top2"), vec![100.0]);
+}
+
+#[test]
+fn sum_top_n_zero_pads_when_fewer_periods_than_n() {
+    // n = 5 but only 3 periods supplied: the two missing computation years
+    // contribute zero, so the result is just the sum of the three (mirrors
+    // 415(b), where computation years count whether or not there were earnings).
+    let module = single_rule_module("top5", "Money", "sum_top_n_over_periods(earnings, 5)");
+    let program = compile(&module, "Worker");
+    let periods = vec![year(2001), year(2002), year(2003)];
+    let batches = vec![
+        batch("earnings", vec![100.0]),
+        batch("earnings", vec![200.0]),
+        batch("earnings", vec![300.0]),
+    ];
+    let result = program
+        .execute_lifetime(&periods, batches, &["top5".to_string()])
+        .expect("lifetime execution succeeds");
+    assert_eq!(scalar_f64(&result, "top5"), vec![600.0]);
+}
+
+#[test]
+fn sum_top_n_n_from_a_parameter_expression() {
+    // `n` may be any scalar expression; here a parameter table. top 3 of
+    // {5,4,3,2,1} = 5 + 4 + 3 = 12.
+    let module = r#"
+format: rulespec/v1
+rules:
+  - name: keep_n
+    kind: parameter
+    dtype: Integer
+    versions:
+      - effective_from: '2000-01-01'
+        formula: '3'
+  - name: top
+    kind: derived
+    entity: Worker
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '2000-01-01'
+        formula: |-
+          sum_top_n_over_periods(earnings, keep_n)
+"#;
+    let program = compile(module, "Worker");
+    let periods = vec![year(2001), year(2002), year(2003), year(2004), year(2005)];
+    let batches = vec![
+        batch("earnings", vec![5.0]),
+        batch("earnings", vec![4.0]),
+        batch("earnings", vec![3.0]),
+        batch("earnings", vec![2.0]),
+        batch("earnings", vec![1.0]),
+    ];
+    let result = program
+        .execute_lifetime(&periods, batches, &["top".to_string()])
+        .expect("lifetime execution succeeds");
+    assert_eq!(scalar_f64(&result, "top"), vec![12.0]);
+}
+
+#[test]
+fn sum_top_n_truncates_a_non_integer_n() {
+    // n = 2.9 truncates to 2, so top 2 of {5,4,3,2,1} = 5 + 4 = 9. Locks the
+    // "truncate to integer" contract (not round).
+    let module = r#"
+format: rulespec/v1
+rules:
+  - name: keep_n
+    kind: parameter
+    dtype: Rate
+    versions:
+      - effective_from: '2000-01-01'
+        formula: '2.9'
+  - name: top
+    kind: derived
+    entity: Worker
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '2000-01-01'
+        formula: |-
+          sum_top_n_over_periods(earnings, keep_n)
+"#;
+    let program = compile(module, "Worker");
+    let periods = vec![year(2001), year(2002), year(2003), year(2004), year(2005)];
+    let batches = vec![
+        batch("earnings", vec![5.0]),
+        batch("earnings", vec![4.0]),
+        batch("earnings", vec![3.0]),
+        batch("earnings", vec![2.0]),
+        batch("earnings", vec![1.0]),
+    ];
+    let result = program
+        .execute_lifetime(&periods, batches, &["top".to_string()])
+        .expect("lifetime execution succeeds");
+    assert_eq!(scalar_f64(&result, "top"), vec![9.0]);
+}
+
+#[test]
+fn sum_top_n_handles_negative_values() {
+    // With negatives present, "largest" still means greatest value. top 2 of
+    // {-10, -1, -5, -20} = (-1) + (-5) = -6.
+    let module = single_rule_module("top2", "Money", "sum_top_n_over_periods(earnings, 2)");
+    let program = compile(&module, "Worker");
+    let periods = vec![year(2001), year(2002), year(2003), year(2004)];
+    let batches = vec![
+        batch("earnings", vec![-10.0]),
+        batch("earnings", vec![-1.0]),
+        batch("earnings", vec![-5.0]),
+        batch("earnings", vec![-20.0]),
+    ];
+    let result = program
+        .execute_lifetime(&periods, batches, &["top2".to_string()])
+        .expect("lifetime execution succeeds");
+    assert_eq!(scalar_f64(&result, "top2"), vec![-6.0]);
+}
+
+#[test]
+fn sum_over_periods_handles_negatives() {
+    let module = single_rule_module("total", "Money", "sum_over_periods(earnings)");
+    let program = compile(&module, "Worker");
+    let periods = vec![year(2001), year(2002), year(2003)];
+    let batches = vec![
+        batch("earnings", vec![100.0]),
+        batch("earnings", vec![-40.0]),
+        batch("earnings", vec![-10.0]),
+    ];
+    let result = program
+        .execute_lifetime(&periods, batches, &["total".to_string()])
+        .expect("lifetime execution succeeds");
+    assert_eq!(scalar_f64(&result, "total"), vec![50.0]);
+}
+
+// ---------------------------------------------------------------------------
+// Multi-entity positional alignment
+// ---------------------------------------------------------------------------
+
+#[test]
+fn reduces_each_row_independently_across_periods() {
+    // Two workers (rows), three periods. Each row reduces over its own column
+    // slice: row 0 = {1, 3, 5}, row 1 = {10, 20, 30}.
+    let module = single_rule_module("total", "Money", "sum_over_periods(earnings)");
+    let program = compile(&module, "Worker");
+    let periods = vec![year(2001), year(2002), year(2003)];
+    let batches = vec![
+        batch("earnings", vec![1.0, 10.0]),
+        batch("earnings", vec![3.0, 20.0]),
+        batch("earnings", vec![5.0, 30.0]),
+    ];
+    let result = program
+        .execute_lifetime(&periods, batches, &["total".to_string()])
+        .expect("lifetime execution succeeds");
+    assert_eq!(result.row_count, 2);
+    assert_eq!(scalar_f64(&result, "total"), vec![9.0, 60.0]);
+}
+
+#[test]
+fn outer_formula_combines_reduction_with_parameter_and_literal() {
+    // Exercise the outer-formula path: a reduction divided by a parameter, then
+    // floored (the AIME shape) but with a simpler hand value.
+    // sum = 300 + 300 + 300 = 900; 900 / 400 = 2.25; floor = 2.
+    let module = r#"
+format: rulespec/v1
+rules:
+  - name: divisor
+    kind: parameter
+    dtype: Integer
+    versions:
+      - effective_from: '2000-01-01'
+        formula: '400'
+  - name: average
+    kind: derived
+    entity: Worker
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '2000-01-01'
+        formula: |-
+          floor(sum_over_periods(earnings) / divisor)
+"#;
+    let program = compile(module, "Worker");
+    let periods = vec![year(2001), year(2002), year(2003)];
+    let batches = vec![
+        batch("earnings", vec![300.0]),
+        batch("earnings", vec![300.0]),
+        batch("earnings", vec![300.0]),
+    ];
+    let result = program
+        .execute_lifetime(&periods, batches, &["average".to_string()])
+        .expect("lifetime execution succeeds");
+    assert_eq!(scalar_f64(&result, "average"), vec![2.0]);
+}
+
+// ---------------------------------------------------------------------------
+// Validation / error paths
+// ---------------------------------------------------------------------------
+
+#[test]
+fn errors_when_row_counts_differ_across_periods() {
+    let module = single_rule_module("total", "Money", "sum_over_periods(earnings)");
+    let program = compile(&module, "Worker");
+    let periods = vec![year(2001), year(2002)];
+    // Period 0 has 2 rows, period 1 has 3 — positional alignment is impossible.
+    let batches = vec![
+        batch("earnings", vec![1.0, 2.0]),
+        batch("earnings", vec![1.0, 2.0, 3.0]),
+    ];
+    let error = program
+        .execute_lifetime(&periods, batches, &["total".to_string()])
+        .expect_err("row-count mismatch must error");
+    let message = error.to_string();
+    assert!(
+        message.contains("same entity row count") && message.contains("period 1"),
+        "unexpected error: {message}"
+    );
+}
+
+#[test]
+fn errors_when_period_and_batch_counts_differ() {
+    let module = single_rule_module("total", "Money", "sum_over_periods(earnings)");
+    let program = compile(&module, "Worker");
+    let periods = vec![year(2001), year(2002), year(2003)];
+    let batches = vec![batch("earnings", vec![1.0]), batch("earnings", vec![2.0])];
+    let error = program
+        .execute_lifetime(&periods, batches, &["total".to_string()])
+        .expect_err("period/batch mismatch must error");
+    assert!(
+        error.to_string().contains("one input batch per period"),
+        "unexpected error: {error}"
+    );
+}
+
+#[test]
+fn errors_when_no_periods_supplied() {
+    let module = single_rule_module("total", "Money", "sum_over_periods(earnings)");
+    let program = compile(&module, "Worker");
+    let error = program
+        .execute_lifetime(&[], Vec::new(), &["total".to_string()])
+        .expect_err("empty periods must error");
+    assert!(
+        error.to_string().contains("at least one period"),
+        "unexpected error: {error}"
+    );
+}
+
+#[test]
+fn errors_when_output_has_no_over_periods_reduction() {
+    // `plain` is a per-period formula with no reduction; lifetime execution must
+    // refuse it and point at the per-period entry points.
+    let module = single_rule_module("plain", "Money", "earnings * 2");
+    let program = compile(&module, "Worker");
+    let periods = vec![year(2001), year(2002)];
+    let batches = vec![batch("earnings", vec![1.0]), batch("earnings", vec![2.0])];
+    let error = program
+        .execute_lifetime(&periods, batches, &["plain".to_string()])
+        .expect_err("non-reduction output must error under lifetime execution");
+    let message = error.to_string();
+    assert!(
+        message.contains("over-periods reduction") && message.contains("execute_f64"),
+        "unexpected error: {message}"
+    );
+}
+
+#[test]
+fn errors_when_sum_top_n_n_is_less_than_one() {
+    let module = single_rule_module("top", "Money", "sum_top_n_over_periods(earnings, 0)");
+    let program = compile(&module, "Worker");
+    let periods = vec![year(2001), year(2002)];
+    let batches = vec![batch("earnings", vec![1.0]), batch("earnings", vec![2.0])];
+    let error = program
+        .execute_lifetime(&periods, batches, &["top".to_string()])
+        .expect_err("n < 1 must error");
+    assert!(
+        error.to_string().contains("requires n >= 1"),
+        "unexpected error: {error}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Per-period execution rejects the builtins
+// ---------------------------------------------------------------------------
+
+#[test]
+fn per_period_execute_rejects_over_periods_reduction() {
+    let module = single_rule_module("total", "Money", "sum_over_periods(earnings)");
+    let program = compile(&module, "Worker");
+    let error = program
+        .execute(
+            &year(2001),
+            batch("earnings", vec![1.0]),
+            &["total".to_string()],
+        )
+        .expect_err("per-period execution must reject the reduction");
+    let message = error.to_string();
+    assert!(
+        message.contains("sum_over_periods") && message.contains("lifetime execution"),
+        "unexpected error: {message}"
+    );
+}
+
+#[test]
+fn per_period_execute_f64_rejects_over_periods_reduction() {
+    let module = single_rule_module("peak", "Money", "max_over_periods(earnings)");
+    let program = compile(&module, "Worker");
+    let error = program
+        .execute_f64(
+            &year(2001),
+            batch("earnings", vec![1.0]),
+            &["peak".to_string()],
+        )
+        .expect_err("per-period f64 execution must reject the reduction");
+    assert!(
+        error.to_string().contains("max_over_periods"),
+        "unexpected error: {error}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Decimal exactness: the canonical mode is exact where f64 would drift
+// ---------------------------------------------------------------------------
+
+#[test]
+fn decimal_mode_sums_exactly() {
+    // 0.1 + 0.2 is 0.3 exactly in Decimal (f64 would give 0.30000000000000004).
+    let module = single_rule_module("total", "Money", "sum_over_periods(earnings)");
+    let program = compile(&module, "Worker");
+    let periods = vec![year(2001), year(2002)];
+    let batches = vec![batch("earnings", vec![0.1]), batch("earnings", vec![0.2])];
+    let result = program
+        .execute_lifetime(&periods, batches, &["total".to_string()])
+        .expect("lifetime execution succeeds");
+    let DenseOutputValue::Scalar(DenseColumn::Decimal(values)) =
+        result.outputs.get("total").expect("output present")
+    else {
+        panic!("decimal mode must return a Decimal column");
+    };
+    assert_eq!(values, &vec![Decimal::from_str_exact("0.3").unwrap()]);
+}

--- a/tests/lifetime.rs
+++ b/tests/lifetime.rs
@@ -44,6 +44,17 @@ fn compile(rulespec: &str, entity: &str) -> DenseCompiledProgram {
         .expect("dense compilation succeeds")
 }
 
+/// Attempt dense compilation, returning the error string on failure. The
+/// rulespec layer itself compiles; the dense compiler is where nesting is
+/// rejected.
+fn try_compile_error(rulespec: &str, entity: &str) -> String {
+    let artifact =
+        CompiledProgramArtifact::from_rulespec_str(rulespec).expect("rulespec module compiles");
+    DenseCompiledProgram::from_artifact(&artifact, Some(entity))
+        .expect_err("dense compilation must fail")
+        .to_string()
+}
+
 /// Read a single-output scalar result as a `Vec<f64>`, accepting whichever
 /// numeric column variant the mode produced (`Decimal` for `execute_lifetime`,
 /// `Float` for `execute_lifetime_f64`, `Integer` for `count_over_periods`).
@@ -529,6 +540,41 @@ fn errors_when_sum_top_n_n_is_less_than_one() {
     assert!(
         error.to_string().contains("requires n >= 1"),
         "unexpected error: {error}"
+    );
+}
+
+#[test]
+fn rejects_directly_nested_over_periods_at_compile_time() {
+    // A reduction consumes the period axis, so nesting another reduction in its
+    // argument is meaningless. The dense compiler rejects it with a precise
+    // message naming both the outer and inner reduction.
+    let module = single_rule_module(
+        "nested",
+        "Money",
+        "sum_over_periods(max_over_periods(earnings))",
+    );
+    let message = try_compile_error(&module, "Worker");
+    assert!(
+        message.contains("cannot be nested")
+            && message.contains("sum_over_periods")
+            && message.contains("max_over_periods"),
+        "unexpected error: {message}"
+    );
+}
+
+#[test]
+fn rejects_nested_over_periods_in_the_n_argument() {
+    // The `n` of sum_top_n is also an argument that consumes no period axis;
+    // a reduction there is likewise rejected.
+    let module = single_rule_module(
+        "nested_n",
+        "Money",
+        "sum_top_n_over_periods(earnings, count_over_periods(earnings))",
+    );
+    let message = try_compile_error(&module, "Worker");
+    assert!(
+        message.contains("cannot be nested") && message.contains("count_over_periods"),
+        "unexpected error: {message}"
     );
 }
 

--- a/tests/lifetime.rs
+++ b/tests/lifetime.rs
@@ -225,23 +225,45 @@ fn max_over_periods_takes_the_largest_period() {
 }
 
 #[test]
-fn count_over_periods_counts_supplied_periods() {
-    // The inner value is evaluated but ignored; the count is the period count,
-    // identical for every row.
+fn count_over_periods_counts_nonzero_periods_per_row() {
+    // count_over_periods evaluates its argument per period and counts, PER ROW,
+    // the periods whose value is nonzero — it is not a bare supplied-period
+    // count. Review reproduction: mixed zero/nonzero earnings per row.
+    // Row 0 earnings: [0, 20, 0, 40] -> 2 nonzero years.
+    // Row 1 earnings: [9, 0, 7, 6]   -> 3 nonzero years.
     let module = single_rule_module("years", "Integer", "count_over_periods(earnings)");
     let program = compile(&module, "Worker");
     let periods = vec![year(2001), year(2002), year(2003), year(2004)];
     let batches = vec![
-        batch("earnings", vec![1.0, 9.0]),
-        batch("earnings", vec![2.0, 8.0]),
-        batch("earnings", vec![3.0, 7.0]),
-        batch("earnings", vec![4.0, 6.0]),
+        batch("earnings", vec![0.0, 9.0]),
+        batch("earnings", vec![20.0, 0.0]),
+        batch("earnings", vec![0.0, 7.0]),
+        batch("earnings", vec![40.0, 6.0]),
     ];
     let result = program
         .execute_lifetime(&periods, batches, &["years".to_string()])
         .expect("lifetime execution succeeds");
-    // Two entities (rows), each sees the same period count of 4.
-    assert_eq!(scalar_f64(&result, "years"), vec![4.0, 4.0]);
+    assert_eq!(scalar_f64(&result, "years"), vec![2.0, 3.0]);
+}
+
+#[test]
+fn count_over_periods_all_zero_is_zero() {
+    // A row whose value is zero in every supplied period counts zero — the
+    // count is over nonzero periods, so an all-zero history is 0, not the
+    // period count.
+    let module = single_rule_module("years", "Integer", "count_over_periods(earnings)");
+    let program = compile(&module, "Worker");
+    let periods = vec![year(2001), year(2002), year(2003)];
+    let batches = vec![
+        batch("earnings", vec![0.0, 5.0]),
+        batch("earnings", vec![0.0, 0.0]),
+        batch("earnings", vec![0.0, 8.0]),
+    ];
+    let result = program
+        .execute_lifetime(&periods, batches, &["years".to_string()])
+        .expect("lifetime execution succeeds");
+    // Row 0 is zero in all three periods -> 0; row 1 has two nonzero periods.
+    assert_eq!(scalar_f64(&result, "years"), vec![0.0, 2.0]);
 }
 
 // ---------------------------------------------------------------------------
@@ -286,10 +308,11 @@ fn sum_top_n_with_ties_sums_the_right_multiplicity() {
 }
 
 #[test]
-fn sum_top_n_zero_pads_when_fewer_periods_than_n() {
-    // n = 5 but only 3 periods supplied: the two missing computation years
-    // contribute zero, so the result is just the sum of the three (mirrors
-    // 415(b), where computation years count whether or not there were earnings).
+fn sum_top_n_errors_when_n_exceeds_the_period_count() {
+    // Strict n contract: n = 5 with only 3 supplied periods is out of range.
+    // Padding the two missing slots with zeros would be an arithmetic no-op, so
+    // an over-length n is rejected as a likely data error rather than silently
+    // summing every period.
     let module = single_rule_module("top5", "Money", "sum_top_n_over_periods(earnings, 5)");
     let program = compile(&module, "Worker");
     let periods = vec![year(2001), year(2002), year(2003)];
@@ -298,10 +321,14 @@ fn sum_top_n_zero_pads_when_fewer_periods_than_n() {
         batch("earnings", vec![200.0]),
         batch("earnings", vec![300.0]),
     ];
-    let result = program
+    let error = program
         .execute_lifetime(&periods, batches, &["top5".to_string()])
-        .expect("lifetime execution succeeds");
-    assert_eq!(scalar_f64(&result, "top5"), vec![600.0]);
+        .expect_err("n > period count must error");
+    let message = error.to_string();
+    assert!(
+        message.contains("1 <= n <=") && message.contains("3 supplied periods"),
+        "unexpected error: {message}"
+    );
 }
 
 #[test]
@@ -554,9 +581,11 @@ fn errors_when_sum_top_n_n_is_less_than_one() {
     let error = program
         .execute_lifetime(&periods, batches, &["top".to_string()])
         .expect_err("n < 1 must error");
+    // Strict n contract: n outside 1..=period_count is an out-of-range error.
+    let message = error.to_string();
     assert!(
-        error.to_string().contains("requires n >= 1"),
-        "unexpected error: {error}"
+        message.contains("1 <= n <=") && message.contains("supplied periods"),
+        "unexpected error: {message}"
     );
 }
 
@@ -899,4 +928,200 @@ fn derived_n_from_constant_inputs_end_to_end() {
         vec![3_456_000.0, 1_922_000.0]
     );
     assert_eq!(scalar_f64(&result, "aime"), vec![8_000.0, 5_166.0]);
+}
+
+// ---------------------------------------------------------------------------
+// Review reproductions: the exact failing cases from PR #68's review, now
+// pinned to their FIXED (post-review) semantics.
+// ---------------------------------------------------------------------------
+
+/// A named derived reused both inside a reduction and bare outside it means the
+/// same thing in both positions: its body inlined in the lifetime context.
+/// Review's live case — `credit = rate + earnings` (rate a period-keyed
+/// parameter, 100 from 2000 and 200 from 2003), and the reuse
+/// `combined = sum_over_periods(credit) plus credit` over 2001-2003 — used to
+/// return 600 (400 from the per-period reduction and 200 from a
+/// reference-period-only outside evaluation), a value no consistent semantics
+/// produces. Under referential transparency the bare `credit` inlines
+/// `rate + earnings`; `earnings` is a period-VARYING input outside every
+/// reduction, so the whole output errors loudly instead of silently computing
+/// 600.
+#[test]
+fn derived_reused_inside_and_outside_reduction_errors_on_period_varying_input() {
+    let module = r#"
+format: rulespec/v1
+rules:
+  - name: rate
+    kind: parameter
+    dtype: Integer
+    versions:
+      - effective_from: '2000-01-01'
+        formula: '100'
+      - effective_from: '2003-01-01'
+        formula: '200'
+  - name: credit
+    kind: derived
+    entity: Worker
+    dtype: Integer
+    period: Year
+    versions:
+      - effective_from: '2000-01-01'
+        formula: |-
+          rate + earnings
+  - name: combined
+    kind: derived
+    entity: Worker
+    dtype: Integer
+    period: Year
+    versions:
+      - effective_from: '2000-01-01'
+        formula: |-
+          sum_over_periods(credit) + credit
+"#;
+    let program = compile(module, "Worker");
+    let periods = vec![year(2001), year(2002), year(2003)];
+    // earnings varies by period (10, 20, 30), so the bare `credit` outside the
+    // reduction is period-ambiguous and must error rather than silently pinning.
+    let batches = vec![
+        batch("earnings", vec![10.0]),
+        batch("earnings", vec![20.0]),
+        batch("earnings", vec![30.0]),
+    ];
+    let error = program
+        .execute_lifetime(&periods, batches, &["combined".to_string()])
+        .expect_err("a period-varying input reached outside a reduction must error");
+    let message = error.to_string();
+    assert!(
+        message.contains("earnings") && message.contains("not period-invariant"),
+        "unexpected error: {message}"
+    );
+}
+
+/// Supplied periods must be strictly ascending by start date; a descending pair
+/// is rejected naming the offending adjacent periods, rather than silently
+/// resolving parameters (and any top-N n) at the wrong — positionally last but
+/// chronologically earlier — year.
+#[test]
+fn errors_when_periods_are_not_strictly_ascending() {
+    let module = single_rule_module("total", "Money", "sum_over_periods(earnings)");
+    let program = compile(&module, "Worker");
+    // Descending: 2020 then 2019.
+    let periods = vec![year(2020), year(2019)];
+    let batches = vec![
+        batch("earnings", vec![100.0]),
+        batch("earnings", vec![200.0]),
+    ];
+    let error = program
+        .execute_lifetime(&periods, batches, &["total".to_string()])
+        .expect_err("descending periods must error");
+    let message = error.to_string();
+    assert!(
+        message.contains("strictly ascending")
+            && message.contains("2020")
+            && message.contains("2019"),
+        "unexpected error: {message}"
+    );
+}
+
+/// The strict n contract holds identically in the Decimal path: n = 45 with 41
+/// supplied periods is out of range (padding the four missing slots with zeros
+/// is a no-op), so `execute_lifetime` errors rather than silently summing every
+/// period into a plausible-but-wrong AIME.
+#[test]
+fn sum_top_n_n_exceeds_period_count_errors_in_decimal_path() {
+    let module = single_rule_module("top", "Money", "sum_top_n_over_periods(earnings, 45)");
+    let program = compile(&module, "Worker");
+    let periods = (0..41).map(|k| year(1985 + k)).collect::<Vec<_>>();
+    let batches = (0..41)
+        .map(|_| batch("earnings", vec![1_000.0]))
+        .collect::<Vec<_>>();
+    let error = program
+        .execute_lifetime(&periods, batches, &["top".to_string()])
+        .expect_err("n=45 over 41 periods must error");
+    let message = error.to_string();
+    assert!(
+        message.contains("1 <= n <=") && message.contains("41 supplied periods"),
+        "unexpected error: {message}"
+    );
+}
+
+/// The same n=45-over-41-periods case errors identically in the f64 throughput
+/// path — the contract is enforced in both dtype paths, not just Decimal.
+#[test]
+fn sum_top_n_n_exceeds_period_count_errors_in_f64_path() {
+    let module = single_rule_module("top", "Money", "sum_top_n_over_periods(earnings, 45)");
+    let program = compile(&module, "Worker");
+    let periods = (0..41).map(|k| year(1985 + k)).collect::<Vec<_>>();
+    let batches = (0..41)
+        .map(|_| batch("earnings", vec![1_000.0]))
+        .collect::<Vec<_>>();
+    let error = program
+        .execute_lifetime_f64(&periods, batches, &["top".to_string()])
+        .expect_err("n=45 over 41 periods must error (f64 path)");
+    let message = error.to_string();
+    assert!(
+        message.contains("1 <= n <=") && message.contains("41 supplied periods"),
+        "unexpected error: {message}"
+    );
+}
+
+/// A parameter-sourced n that varies by period is a data error under the strict
+/// n contract — held to the same period-invariance requirement as an
+/// input-sourced n — not silently pinned to the reference period.
+#[test]
+fn sum_top_n_period_varying_parameter_n_errors() {
+    let module = r#"
+format: rulespec/v1
+rules:
+  - name: keep_n
+    kind: parameter
+    dtype: Integer
+    versions:
+      - effective_from: '2000-01-01'
+        formula: '2'
+      - effective_from: '2003-01-01'
+        formula: '3'
+  - name: top
+    kind: derived
+    entity: Worker
+    dtype: Money
+    period: Year
+    versions:
+      - effective_from: '2000-01-01'
+        formula: |-
+          sum_top_n_over_periods(earnings, keep_n)
+"#;
+    let program = compile(module, "Worker");
+    // keep_n is 2 in 2001/2002 and 3 from 2003 -> not period-invariant.
+    let periods = vec![year(2001), year(2002), year(2003), year(2004)];
+    let batches = vec![
+        batch("earnings", vec![5.0]),
+        batch("earnings", vec![4.0]),
+        batch("earnings", vec![3.0]),
+        batch("earnings", vec![2.0]),
+    ];
+    let error = program
+        .execute_lifetime(&periods, batches, &["top".to_string()])
+        .expect_err("a period-varying parameter n must error");
+    let message = error.to_string();
+    assert!(
+        message.contains("not period-invariant") && message.contains("sum_top_n_over_periods"),
+        "unexpected error: {message}"
+    );
+}
+
+/// An unknown `*_over_periods` reduction name fails to PARSE (the rulespec /
+/// formula layer), not at some later stage: the builtin match is exhaustive with
+/// an explicit error arm, so a typo or not-yet-implemented reduction cannot be
+/// mistaken for the period count or a plain call.
+#[test]
+fn unknown_over_periods_reduction_fails_to_parse() {
+    let module = single_rule_module("bad", "Money", "avg_over_periods(earnings)");
+    let error = CompiledProgramArtifact::from_rulespec_str(&module)
+        .expect_err("an unknown over-periods reduction must fail to parse");
+    let message = error.to_string();
+    assert!(
+        message.contains("avg_over_periods") && message.contains("over-periods reduction"),
+        "unexpected error: {message}"
+    );
 }

--- a/tests/module_source.rs
+++ b/tests/module_source.rs
@@ -215,12 +215,11 @@ fn in_memory_module_source_compiles_and_executes_without_filesystem() {
             )
     }));
 
-    let artifact =
-        CompiledProgramArtifact::from_rulespec_with_source(
-            "us-co:policies/cdhs/snap/fy-2026-benefit",
-            &source,
-        )
-        .expect("in-memory modules compile");
+    let artifact = CompiledProgramArtifact::from_rulespec_with_source(
+        "us-co:policies/cdhs/snap/fy-2026-benefit",
+        &source,
+    )
+    .expect("in-memory modules compile");
     let output_id =
         "us-co:policies/cdhs/snap/fy-2026-benefit#snap_regular_month_allotment".to_string();
     assert!(
@@ -277,7 +276,9 @@ fn in_memory_module_source_compiles_and_executes_without_filesystem() {
     })
     .expect("in-memory program executes");
 
-    let OutputValue::Scalar { name, id, value, .. } = response.results[0]
+    let OutputValue::Scalar {
+        name, id, value, ..
+    } = response.results[0]
         .outputs
         .get(&output_id)
         .expect("snap_regular_month_allotment output")
@@ -567,12 +568,17 @@ rules:
     assert!(program.parameters.iter().any(|parameter| {
         parameter.id.as_deref() == Some("us:statutes/7/2014/base#base_amount")
     }));
-    assert!(program.parameters.iter().any(|parameter| {
-        parameter.id.as_deref() == Some("us:statutes/7/2015/peer#peer_rate")
-    }));
-    assert!(program.derived.iter().any(|derived| {
-        derived.id.as_deref() == Some("us:statutes/7/2015/e#total_amount")
-    }));
+    assert!(
+        program.parameters.iter().any(|parameter| {
+            parameter.id.as_deref() == Some("us:statutes/7/2015/peer#peer_rate")
+        })
+    );
+    assert!(
+        program
+            .derived
+            .iter()
+            .any(|derived| { derived.id.as_deref() == Some("us:statutes/7/2015/e#total_amount") })
+    );
 }
 
 #[test]
@@ -699,7 +705,10 @@ rules:
 
     let error = load_rulespec_with_source("us:policies/a", &source)
         .expect_err("cyclic imports are rejected");
-    assert!(matches!(error, RuleSpecError::ImportCycle { .. }), "{error}");
+    assert!(
+        matches!(error, RuleSpecError::ImportCycle { .. }),
+        "{error}"
+    );
 }
 
 #[test]
@@ -729,7 +738,10 @@ rules:
 
     let error = load_rulespec_with_source("us:policies/never-written", &source)
         .expect_err("missing root module errors");
-    assert!(matches!(error, RuleSpecError::ModuleNotFound { .. }), "{error}");
+    assert!(
+        matches!(error, RuleSpecError::ModuleNotFound { .. }),
+        "{error}"
+    );
 }
 
 /// `FsModuleSource` + the pure loader must agree with the path-based loader

--- a/tests/monorepo_env_resolution.rs
+++ b/tests/monorepo_env_resolution.rs
@@ -17,8 +17,7 @@ fn env_root_at_monorepo_resolves_jurisdiction_dirs() {
     let artifact_path = temp_root.join("program.compiled.json");
 
     std::fs::create_dir_all(us_path.parent().expect("us parent")).expect("us dir");
-    std::fs::create_dir_all(program_path.parent().expect("program parent"))
-        .expect("program dir");
+    std::fs::create_dir_all(program_path.parent().expect("program parent")).expect("program dir");
     std::fs::write(
         &us_path,
         r#"

--- a/tests/rulespec.rs
+++ b/tests/rulespec.rs
@@ -1,10 +1,10 @@
 use axiom_rules_engine::api::{
-    execute_request, ExecutionMode, ExecutionQuery, ExecutionRequest, OutputValue,
+    ExecutionMode, ExecutionQuery, ExecutionRequest, OutputValue, execute_request,
 };
 use axiom_rules_engine::compile::{
-    compile_program_file_to_json, CompileError, CompiledProgramArtifact,
+    CompileError, CompiledProgramArtifact, compile_program_file_to_json,
 };
-use axiom_rules_engine::rulespec::{lower_rulespec_str, RuleSpecError, ValidationStatus};
+use axiom_rules_engine::rulespec::{RuleSpecError, ValidationStatus, lower_rulespec_str};
 use axiom_rules_engine::spec::{
     DatasetSpec, DerivedSemanticsSpec, InputRecordSpec, IntervalSpec, PeriodKindSpec, PeriodSpec,
     ScalarExprSpec, ScalarValueSpec,
@@ -121,14 +121,19 @@ rules:
     let program = &artifact.program;
     assert_eq!(program.parameters.len(), 2);
     assert_eq!(program.derived.len(), 7);
-    assert!(program
-        .relations
-        .iter()
-        .any(|r| r.name == "us-tx:policies/hhsc/snap/overlay-subset#relation.member_of_household"));
-    assert!(artifact
-        .metadata
-        .evaluation_order
-        .contains(&"snap_allotment".to_string()));
+    assert!(
+        program
+            .relations
+            .iter()
+            .any(|r| r.name
+                == "us-tx:policies/hhsc/snap/overlay-subset#relation.member_of_household")
+    );
+    assert!(
+        artifact
+            .metadata
+            .evaluation_order
+            .contains(&"snap_allotment".to_string())
+    );
 }
 
 #[test]
@@ -1296,16 +1301,20 @@ rules:
 
     let artifact =
         CompiledProgramArtifact::from_rulespec_file(&program_file).expect("RuleSpec compiles");
-    assert!(artifact
-        .program
-        .relations
-        .iter()
-        .any(|relation| relation.name == "us:statutes/26/63/c#relation.member_of_tax_unit"));
-    assert!(artifact
-        .program
-        .relations
-        .iter()
-        .any(|relation| relation.name == "member_of_tax_unit"));
+    assert!(
+        artifact
+            .program
+            .relations
+            .iter()
+            .any(|relation| relation.name == "us:statutes/26/63/c#relation.member_of_tax_unit")
+    );
+    assert!(
+        artifact
+            .program
+            .relations
+            .iter()
+            .any(|relation| relation.name == "member_of_tax_unit")
+    );
 
     let _ = fs::remove_dir_all(root);
 }
@@ -1864,11 +1873,13 @@ rules:
     assert_eq!(derivation.entity.as_deref(), Some("SnapUnit"));
     assert_eq!(derivation.member_relation.as_deref(), Some("members"));
     assert_eq!(derivation.slot_entities, vec!["Person", "Household"]);
-    assert!(artifact
-        .program
-        .relations
-        .iter()
-        .all(|relation| relation.name != "members"));
+    assert!(
+        artifact
+            .program
+            .relations
+            .iter()
+            .all(|relation| relation.name != "members")
+    );
 
     let snap_unit_size = artifact
         .program
@@ -2114,11 +2125,13 @@ rules:
 
     let artifact = compile_program_file_to_json(&co_path, &artifact_path)
         .expect("RuleSpec file with canonical import compiles");
-    assert!(artifact
-        .program
-        .parameters
-        .iter()
-        .any(|parameter| parameter.name == "snap_maximum_allotment_table"));
+    assert!(
+        artifact
+            .program
+            .parameters
+            .iter()
+            .any(|parameter| parameter.name == "snap_maximum_allotment_table")
+    );
     assert!(
         artifact
             .program
@@ -2129,18 +2142,22 @@ rules:
                     "us:policies/usda/snap/fy-2026-cola/maximum-allotments#snap_maximum_allotment_table"
                 ))
     );
-    assert!(artifact
-        .program
-        .derived
-        .iter()
-        .any(|derived| derived.name == "snap_regular_month_allotment"));
+    assert!(
+        artifact
+            .program
+            .derived
+            .iter()
+            .any(|derived| derived.name == "snap_regular_month_allotment")
+    );
     let output_id =
         "us-co:policies/cdhs/snap/fy-2026-benefit#snap_regular_month_allotment".to_string();
-    assert!(artifact
-        .program
-        .derived
-        .iter()
-        .any(|derived| derived.id.as_deref() == Some(output_id.as_str())));
+    assert!(
+        artifact
+            .program
+            .derived
+            .iter()
+            .any(|derived| derived.id.as_deref() == Some(output_id.as_str()))
+    );
 
     let period = PeriodSpec {
         kind: PeriodKindSpec::Month,


### PR DESCRIPTION
Closes #67.

## What

Adds reductions over an entity's **own period axis**, so 42 USC 415(b) AIME (the highest-35-years selection) computes end to end from a RuleSpec encoding. Until now the formula language could aggregate across entity members within a single period (`sum_where`, `count_where`, `max`, `min`) but had no way to window, sort, or top-N across a person's time series.

## Semantics (post-review)

Six confirmed review findings are addressed; the following are the settled, corrected semantics (they supersede the historical `## Semantics` and `## Tests` notes below, which describe the pre-review design). Each is pinned to a test.

- **Referential transparency.** A derived referenced **outside** a reduction is evaluated by inlining its body in the lifetime context: parameters resolve at the reference period, and bare inputs in that body go through the per-row period-invariance guard. So a parameter-bearing derived reused **both inside a reduction and bare outside it** denotes exactly its definition in both positions. The review's 600-case (`combined = sum_over_periods(credit) + credit`, `credit = rate + earnings`, `earnings` period-varying) now **errors loudly** on the period-varying input instead of silently returning 600.
- **Ordering validation.** `execute_lifetime[_f64]` require the supplied periods to be **strictly ascending by start date** and error (`LifetimePeriodsNotAscending`, naming the offending adjacent pair) on an unsorted or descending list — rather than resolving a parameter or `n` at a positionally-last-but-chronologically-earlier year. The **reference period is the chronologically-last** supplied period.
- **`count_over_periods` counts nonzero.** It evaluates its argument per period and counts, **per row, the periods whose value is nonzero** (a `Bool` inner value counts `true`; text/date have no zero and are rejected). It is **not** a bare supplied-period count — an all-zero history counts `0`.
- **Strict `n` contract for `sum_top_n_over_periods`** (enforced identically in the Decimal and f64 paths). After truncation toward zero to an exact `i64`, `n` must satisfy **`1 <= n <= the supplied period count`**. A non-finite or out-of-range `n` (`try_to_i64_trunc` → `None`), an **over-length** `n`, and an `n` that is **not period-invariant** all raise typed errors (`OverPeriodsTopNOutOfRange`, `OverPeriodsTopNPeriodVarying`) — **no clamp to `i64::MAX`, no silent reference-period pin, no zero-padding past the period count** (which would be an arithmetic no-op masking a bad count). Parameter- and input-sourced `n` are held to the identical invariance requirement (each is evaluated under every period's executor).

Additionally, the one-argument over-periods parse is an **exhaustive match with an explicit error arm** (no wildcard falling through to `Count`), and any other `*_over_periods` name **fails to parse** with a reduction-specific error. `DECISIONS.md` gains one most-recent-first entry documenting this surface. Post-review tests: the 600-case error, unsorted-periods error, count-nonzero (mixed and all-zero per row), `n=45` over 41 periods in both dtype paths, a period-varying parameter `n`, and an unknown reduction name failing to parse — as Rust (`tests/lifetime.rs`) and Python (`python/tests/test_dense_lifetime.py`) cases. Clippy finding multiset is byte-identical to branch tip `984a4e0` (zero new); the acceptance script prints `earnings_total [3456000, 1922000]`, `aime [8000, 5166]`.

## Semantics

A new expression node — `ScalarExpr::OverPeriods { kind, value, n }` — is threaded through the whole pipeline (model → spec/serde → formula parser → dense compiler), with four builtins:

- `sum_over_periods(x)` — sum of `x` across all supplied periods
- `max_over_periods(x)` — maximum of `x` across all supplied periods
- `count_over_periods(x)` — number of periods supplied (inner value evaluated but ignored)
- `sum_top_n_over_periods(x, n)` — sum of the `n` largest per-period values of `x`. When **fewer than `n` periods are supplied, the missing periods contribute zero** — mirroring 415(b), where the computation years count whether or not the worker had earnings. `n` may be any scalar expression (e.g. a parameter); it is truncated toward zero to an integer and rejected if `< 1`.

These builtins are valid **only** under a new lifetime execution surface. The per-period, sparse, and bulk fast paths reject them with a clear error pointing the caller at lifetime execution.

## Lifetime execution surface

`DenseCompiledProgram::execute_lifetime(periods, batches, outputs)` and `execute_lifetime_f64(...)`, plus the PyO3 `execute_lifetime_f64` (exactly parallel to `execute_f64`) and its Python wrapper.

- `periods: &[Period]` and one `DenseBatchSpec` **per period**, with **identical entity row order and count** (v1 positional alignment — row `i` is the same entity in every period). Row-count mismatches, period/batch-count mismatches, and empty period lists error clearly.
- Each reduction's inner expression is evaluated once per period with the existing per-period `DenseExecutor`; the per-period vectors are stacked and reduced row-wise. Scalars combined with a reduction that need a period (parameters, derived values) resolve at the **last** supplied period.
- Lifetime execution only supports outputs whose formula contains at least one over-periods reduction (transitively, through derived references); purely per-period outputs error and are directed to `execute` / `execute_f64`.

## Limitations (v1)

- **Positional alignment only.** Batches must describe the same rows in the same order; there is no key-based join yet.
- **Lifetime-only builtins.** The four reductions are rejected outside lifetime execution.
- A period-ambiguous **bare input** used **outside** a reduction is now bound when it is verified **period-invariant** — the same value in every supplied period, checked per row (see "Period-invariant binding of inputs" below). Other period-specific leaves (`period_start`/`period_end`, `date_add_days`/`days_between`, a relation aggregation) used outside a reduction are still rejected rather than silently bound to a period.
- No RuleSpec schema changes: this is expression-level only. The declarative `over: periods` schema form is a separate future conversation. The compiled-artifact JSON Schema regenerates additively (new `over_periods` variant of `ScalarExprSpec`); no `artifact_format_version` bump.

## Period-invariant binding of inputs (amendment)

The original design rejected **every** bare leaf used outside a reduction. But 42 USC 415(b)'s benefit-computation-year count is a derived scalar built from per-person-constant inputs (the years a worker attains 21 and 62) and must feed `sum_top_n_over_periods` as its **`n`** — a bare input, reached through a derived chain, sitting outside every reduction. That blanket rejection blocked real 415(b) logic (confirmed failing empirically).

Under lifetime execution a bare `Input` / `InputOrElse` outside a reduction is now evaluated under **every** period's executor and checked **per row**:

- if a row's value is **identical across all supplied periods**, that value is bound for the row (dtype preserved), and it composes normally through any surrounding arithmetic, a derived chain, or the `n` position of `sum_top_n_over_periods`;
- if a row's value **differs** across periods, execution errors with a new `LifetimePeriodVaryingInput`, naming the input and the first two differing period labels and values.

Truly period-varying inputs therefore still fail loudly — the amendment only legalizes provably unambiguous bindings. The invariance check is exact (numeric variants are compared by value, so `1985` and `1985.0` agree). **Parameters keep their existing last-supplied-period behavior unchanged**, and there is **no behavior change for the per-period `execute` / `execute_f64` paths**.

## Acceptance test (issue #67)

A synthetic 40-year worker's AIME, computed end to end from a compiled RuleSpec module whose rule is `aime = floor(sum_top_n_over_periods(indexed_earnings, 35) / 420)`, asserted in both Rust (`tests/lifetime.rs`) and Python (`python/tests/test_dense_lifetime.py`):

Indexed earnings for year `k` (1..40) are `12_000 + 1_000·(k−1)` → `12_000, 13_000, …, 51_000`. The top 35 of 40 drops the five smallest, keeping `17_000, 18_000, …, 51_000` (35 terms): `sum = 35·(17_000+51_000)/2 = 1_190_000`; `AIME = floor(1_190_000 / 420) = 2833`. The hand derivation lives in a comment beside the test.

## Tests

- **Rust** (`tests/lifetime.rs`, 28 tests): each builtin; `sum_top_n` ties, `n` greater than the period count (zero-padding), `n` as a parameter expression, non-integer `n` truncation, negative values; multi-row positional alignment; outer formula combining a reduction with a parameter and literal; alignment / period-batch / empty-periods / `n < 1` / non-reduction-output validation errors; compile-time rejection of directly-nested reductions; per-period `execute` and `execute_f64` rejection; Decimal exactness (`0.1 + 0.2` → `0.3`); and, for the amendment: a per-person-constant input binding outside a reduction, a per-row-varying-but-per-period-constant input binding per row, a period-varying input erroring (message names the input), and the derived-`n`-from-constant-inputs chain end to end (two workers, `n` = 36 and 31).
- **Python** (`python/tests/test_dense_lifetime.py`, 6 tests): the AIME acceptance test, a two-worker row-alignment check, the period/batch-count and row-count mismatch error paths, and — for the amendment — the two-worker derived-`n` case plus a period-varying-input error naming the input.

## Open question for review

**Reference period for non-reduction scalars.** When the outer formula combines a reduction with a period-specific scalar (a parameter lookup or a derived scalar), that scalar is resolved at the **last supplied period**. The rationale: over-periods reductions are the lifetime axis, and a value combined with the reduction (a bend point, a divisor) is naturally the one in force at the determination period, i.e. the most recent supplied period. For the AIME acceptance formula this choice is not exercised — the outer formula only combines the reduction with a literal (`420`) — so it does not affect the headline result, but it is worth a look before this generalizes to formulas that mix reductions with period-indexed parameters. This **reference-period-for-parameters convention is unchanged** by the amendment below.

**Bare-input handling (amendment).** Period-invariant binding replaces the earlier blanket rejection of bare inputs: an input used outside a reduction now binds when its supplied value is verified identical across all periods (per row), and errors naming the input otherwise. The other period-ambiguous leaves (`period_start`/`period_end`, `date_add_days`/`days_between`, a relation aggregation) remain deliberately rejected rather than silently bound to a period.

## Verification

`cargo fmt --check`, `cargo build`, `cargo test` (default + `--features schema`), `cargo check --manifest-path python-ext/Cargo.toml`, and `cargo check --target wasm32-unknown-unknown --no-default-features` all pass. Clippy's actual lint findings are byte-identical to the branch tip before the amendment — zero new warnings. All 38 Python tests and the 28 Rust lifetime tests pass against the maturin-rebuilt extension.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


