### PR TITLE
Carry source links into compiled artifacts; join corpus provision URLs at compile time

### DIFF
--- a/schemas/compiled-artifact.v1.schema.json
+++ b/schemas/compiled-artifact.v1.schema.json
@@ -89,6 +89,13 @@
         }
       ],
       "properties": {
+        "corpus_citation_path": {
+          "description": "Corpus provision path of the rule's origin module\n(`module.source_verification.corpus_citation_path`), carried per rule\nso artifact consumers can join the rule to its legal source.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "dtype": {
           "$ref": "#/$defs/DTypeSpec"
         },
@@ -257,6 +264,13 @@
     },
     "IndexedParameterSpec": {
       "properties": {
+        "corpus_citation_path": {
+          "description": "Corpus provision path of the rule's origin module\n(`module.source_verification.corpus_citation_path`), carried per rule\nso artifact consumers can join the parameter to its legal source.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "id": {
           "type": [
             "string",
@@ -272,6 +286,20 @@
         },
         "name": {
           "type": "string"
+        },
+        "source": {
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "source_url": {
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "unit": {
           "type": [

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -61,6 +61,15 @@ pub enum CompileError {
         found: u32,
         supported: u32,
     },
+    #[cfg(feature = "fs")]
+    #[error("failed to read corpus provisions `{path}`: {error}")]
+    ReadProvisionsFile { path: String, error: std::io::Error },
+    #[error("failed to parse corpus provision record at `{path}` line {line}: {error}")]
+    ParseProvisionRecord {
+        path: String,
+        line: usize,
+        error: serde_json::Error,
+    },
 }
 
 /// Format version stamped into every artifact this engine compiles.
@@ -222,6 +231,148 @@ impl CompiledProgramArtifact {
             error,
         })
     }
+
+    /// Resolve each rule's and parameter's `corpus_citation_path` to a
+    /// `source_url` through a corpus provision index, filling only entries
+    /// whose `source_url` is not already set (an inline URL always wins).
+    /// Returns how many URLs were filled. Purely a lookup over the given
+    /// index — no network, no clock — so the same artifact plus the same
+    /// provisions always produce byte-identical output.
+    pub fn resolve_source_urls(&mut self, provisions: &CorpusProvisionIndex) -> usize {
+        let mut resolved = 0;
+        let mut fill = |citation_path: &Option<String>, source_url: &mut Option<String>| {
+            if source_url.is_some() {
+                return;
+            }
+            let Some(url) = citation_path
+                .as_deref()
+                .and_then(|citation_path| provisions.source_url(citation_path))
+            else {
+                return;
+            };
+            *source_url = Some(url.to_string());
+            resolved += 1;
+        };
+        for parameter in &mut self.program.parameters {
+            fill(&parameter.corpus_citation_path, &mut parameter.source_url);
+        }
+        for derived in &mut self.program.derived {
+            fill(&derived.corpus_citation_path, &mut derived.source_url);
+        }
+        resolved
+    }
+}
+
+/// An index of corpus provision records, mapping a `citation_path` (the join
+/// key modules declare as `source_verification.corpus_citation_path`) to the
+/// provision's `source_url`. Built from the JSONL provision files published
+/// in axiom-corpus (`data/corpus/provisions/**/*.jsonl`); records without a
+/// `citation_path` or `source_url` are skipped. When the same citation path
+/// appears more than once, the record loaded later wins, so loading dated
+/// snapshot files in sorted order keeps the newest snapshot's URL —
+/// deterministically, since the input order alone decides.
+#[derive(Clone, Debug, Default)]
+pub struct CorpusProvisionIndex {
+    urls: BTreeMap<String, String>,
+}
+
+/// The subset of a corpus provision record the join reads. Every other field
+/// in the JSONL record is ignored.
+#[derive(Deserialize)]
+struct ProvisionRecord {
+    #[serde(default)]
+    citation_path: Option<String>,
+    #[serde(default)]
+    source_url: Option<String>,
+}
+
+impl CorpusProvisionIndex {
+    /// The `source_url` recorded for `citation_path`, if any.
+    pub fn source_url(&self, citation_path: &str) -> Option<&str> {
+        self.urls.get(citation_path).map(String::as_str)
+    }
+
+    /// Number of citation paths with a resolvable URL.
+    pub fn len(&self) -> usize {
+        self.urls.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.urls.is_empty()
+    }
+
+    /// Add every record in a JSONL provisions document. `path` names the
+    /// document for error reporting only. Blank lines are skipped; a line
+    /// that is not a JSON object is an error.
+    pub fn add_jsonl_str(&mut self, text: &str, path: &str) -> Result<(), CompileError> {
+        for (index, line) in text.lines().enumerate() {
+            if line.trim().is_empty() {
+                continue;
+            }
+            let record: ProvisionRecord = serde_json::from_str(line).map_err(|error| {
+                CompileError::ParseProvisionRecord {
+                    path: path.to_string(),
+                    line: index + 1,
+                    error,
+                }
+            })?;
+            let (Some(citation_path), Some(source_url)) = (record.citation_path, record.source_url)
+            else {
+                continue;
+            };
+            self.urls.insert(citation_path, source_url);
+        }
+        Ok(())
+    }
+
+    /// Add provision records from `path`: a JSONL file, or a directory
+    /// scanned recursively for `*.jsonl` files in sorted path order (so a
+    /// directory of dated snapshots loads deterministically, newest last).
+    #[cfg(feature = "fs")]
+    pub fn add_path(&mut self, path: impl AsRef<Path>) -> Result<(), CompileError> {
+        let path = path.as_ref();
+        let read_error = |error: std::io::Error| CompileError::ReadProvisionsFile {
+            path: path.display().to_string(),
+            error,
+        };
+        if path.is_dir() {
+            let mut files = Vec::new();
+            collect_jsonl_files(path, &mut files).map_err(read_error)?;
+            files.sort();
+            for file in files {
+                self.add_path(&file)?;
+            }
+            return Ok(());
+        }
+        let text = fs::read_to_string(path).map_err(read_error)?;
+        self.add_jsonl_str(&text, &path.display().to_string())
+    }
+
+    /// Build an index from `paths`, each a JSONL file or a directory of
+    /// them, loaded in the order given.
+    #[cfg(feature = "fs")]
+    pub fn from_paths(
+        paths: impl IntoIterator<Item = impl AsRef<Path>>,
+    ) -> Result<Self, CompileError> {
+        let mut index = Self::default();
+        for path in paths {
+            index.add_path(path)?;
+        }
+        Ok(index)
+    }
+}
+
+#[cfg(feature = "fs")]
+fn collect_jsonl_files(dir: &Path, files: &mut Vec<std::path::PathBuf>) -> std::io::Result<()> {
+    for entry in fs::read_dir(dir)? {
+        let path = entry?.path();
+        if path.is_dir() {
+            collect_jsonl_files(&path, files)?;
+        } else if path.extension().is_some_and(|extension| extension == "jsonl") {
+            files.push(path);
+        }
+    }
+    Ok(())
 }
 
 fn evaluation_order(program: &ProgramSpec) -> Result<Vec<String>, CompileError> {

--- a/src/formula.rs
+++ b/src/formula.rs
@@ -1156,6 +1156,11 @@ pub fn lower_module(module: &Module) -> Result<ProgramSpec, FormulaError> {
             name: v.path.clone(),
             unit: v.unit.clone(),
             indexed_by: v.indexed_by.clone(),
+            source: v.source.clone(),
+            source_url: v.source_url.clone(),
+            // The formula-source layer doesn't carry the origin module's
+            // citation path; it is reattached by name in `apply_rule_ids`.
+            corpus_citation_path: None,
             versions,
         });
     }
@@ -1223,6 +1228,9 @@ pub fn lower_module(module: &Module) -> Result<ProgramSpec, FormulaError> {
             rounding: None,
             source: v.source.clone(),
             source_url: v.source_url.clone(),
+            // As with rounding, the origin module's citation path is
+            // reattached by name in `apply_rule_ids`.
+            corpus_citation_path: None,
             semantics,
             versions,
         });

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ use axiom_rules_engine::api::{
     CompiledExecutionRequest, ExecutionRequest, execute_compiled_request, execute_request,
 };
 use axiom_rules_engine::compile::{
-    CompiledProgramArtifact, compile_program_file_to_json, compile_summary_lines,
+    CompiledProgramArtifact, CorpusProvisionIndex, compile_summary_lines,
 };
 
 fn main() {
@@ -36,9 +36,27 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
+const COMPILE_USAGE: &str = "\
+usage: axiom-rules-engine compile --program <rules.yaml> --output <compiled.json> [--corpus-provisions <path>]...
+
+  --program <path>            RuleSpec module or program YAML to compile.
+  --output <path>             Where to write the compiled artifact JSON.
+  --corpus-provisions <path>  Optional, repeatable. A corpus provisions JSONL
+                              file, or a directory scanned recursively for
+                              *.jsonl files in sorted path order. Each record's
+                              citation_path -> source_url mapping resolves the
+                              source_url of every rule/parameter whose origin
+                              module declares that corpus_citation_path and
+                              that has no inline source_url. When the same
+                              citation path appears more than once, the record
+                              loaded later wins. Purely a compile-time lookup:
+                              same inputs always produce a byte-identical
+                              artifact.";
+
 fn run_compile(args: Vec<String>) -> Result<(), Box<dyn std::error::Error>> {
     let mut program_path: Option<PathBuf> = None;
     let mut output_path: Option<PathBuf> = None;
+    let mut provisions_paths: Vec<PathBuf> = Vec::new();
 
     let mut iter = args.into_iter();
     while let Some(arg) = iter.next() {
@@ -49,8 +67,19 @@ fn run_compile(args: Vec<String>) -> Result<(), Box<dyn std::error::Error>> {
             "--output" => {
                 output_path = iter.next().map(PathBuf::from);
             }
+            "--corpus-provisions" => {
+                provisions_paths.push(
+                    iter.next()
+                        .map(PathBuf::from)
+                        .ok_or("`--corpus-provisions` requires a path argument")?,
+                );
+            }
+            "--help" | "-h" => {
+                println!("{COMPILE_USAGE}");
+                return Ok(());
+            }
             _ => {
-                return Err(format!("unknown compile argument `{arg}`").into());
+                return Err(format!("unknown compile argument `{arg}`\n{COMPILE_USAGE}").into());
             }
         }
     }
@@ -60,7 +89,14 @@ fn run_compile(args: Vec<String>) -> Result<(), Box<dyn std::error::Error>> {
     let output_path =
         output_path.ok_or("missing required `--output /path/to/compiled.json` argument")?;
 
-    let artifact = compile_program_file_to_json(&program_path, &output_path)?;
+    let mut artifact = CompiledProgramArtifact::from_rulespec_file(&program_path)?;
+    if !provisions_paths.is_empty() {
+        let provisions = CorpusProvisionIndex::from_paths(&provisions_paths)?;
+        let resolved = artifact.resolve_source_urls(&provisions);
+        println!("corpus_provisions_indexed: {}", provisions.len());
+        println!("corpus_source_urls_resolved: {resolved}");
+    }
+    artifact.write_json_file(&output_path)?;
     println!("compiled_program: {}", output_path.display());
     for (key, value) in compile_summary_lines(&artifact) {
         println!("{key}: {value}");

--- a/src/model.rs
+++ b/src/model.rs
@@ -395,6 +395,9 @@ pub struct Derived {
     pub rounding: Option<Rounding>,
     pub source: Option<String>,
     pub source_url: Option<String>,
+    /// Corpus provision path of the rule's origin module, for joining the
+    /// rule to its legal source. Descriptive only; never read by execution.
+    pub corpus_citation_path: Option<String>,
     pub semantics: DerivedSemantics,
     pub versions: Vec<DerivedVersion>,
 }
@@ -442,6 +445,12 @@ pub struct IndexedParameter {
     pub name: String,
     pub unit: Option<String>,
     pub indexed_by: Option<String>,
+    pub source: Option<String>,
+    pub source_url: Option<String>,
+    /// Corpus provision path of the parameter's origin module, for joining
+    /// the parameter to its legal source. Descriptive only; never read by
+    /// execution.
+    pub corpus_citation_path: Option<String>,
     pub versions: Vec<ParameterVersion>,
 }
 

--- a/src/rulespec.rs
+++ b/src/rulespec.rs
@@ -454,6 +454,11 @@ pub struct RuleDefinition {
     pub name: String,
     #[serde(skip)]
     pub origin_target: Option<String>,
+    /// `source_verification.corpus_citation_path` of the module the rule was
+    /// declared in, stamped at load time alongside `origin_target` so the
+    /// module-level join key survives import merging.
+    #[serde(skip)]
+    pub origin_citation_path: Option<String>,
     #[serde(default)]
     pub kind: Option<RuleKind>,
     #[serde(default, deserialize_with = "deserialize_optional_string_like")]
@@ -1056,8 +1061,18 @@ impl RulesDocument {
     }
 
     fn assign_origin_target(&mut self, origin_target: Option<String>) {
+        // The module-level corpus citation path rides onto every rule here,
+        // because `merge_rules_documents` keeps only the root module's
+        // metadata: without stamping, an imported module's join key would be
+        // lost with its `module:` block.
+        let citation_path = self
+            .module
+            .as_ref()
+            .and_then(|module| module.source_verification.as_ref())
+            .and_then(|verification| verification.corpus_citation_path.clone());
         for rule in &mut self.rules {
             rule.origin_target = origin_target.clone();
+            rule.origin_citation_path = citation_path.clone();
         }
     }
 
@@ -1200,6 +1215,21 @@ impl RulesDocument {
                     }
                 }
             }
+            // The origin module's corpus citation path is reattached by name
+            // the same way, so every parameter and derived rule carries the
+            // join key to its legal source in the corpus.
+            if let Some(citation_path) = rule.origin_citation_path.as_ref() {
+                for parameter in &mut program.parameters {
+                    if parameter.name == rule.name {
+                        parameter.corpus_citation_path = Some(citation_path.clone());
+                    }
+                }
+                for derived in &mut program.derived {
+                    if derived.name == rule.name {
+                        derived.corpus_citation_path = Some(citation_path.clone());
+                    }
+                }
+            }
             let Some(rule_id) = rule.canonical_rule_id() else {
                 continue;
             };
@@ -1328,11 +1358,17 @@ impl RuleDefinition {
                 name: self.name.clone(),
             });
         }
+        let (source, source_url) = self.effective_source();
         Ok(IndexedParameterSpec {
             id: self.canonical_rule_id(),
             name: self.name.clone(),
             unit: self.unit.clone(),
             indexed_by: Some(indexed_by),
+            source,
+            source_url,
+            // Reattached by name in `apply_rule_ids`, like the scalar
+            // parameters lowered through the formula layer.
+            corpus_citation_path: None,
             versions,
         })
     }

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -290,6 +290,15 @@ pub struct IndexedParameterSpec {
     #[serde(default)]
     pub indexed_by: Option<String>,
     #[serde(default)]
+    pub source: Option<String>,
+    #[serde(default)]
+    pub source_url: Option<String>,
+    /// Corpus provision path of the rule's origin module
+    /// (`module.source_verification.corpus_citation_path`), carried per rule
+    /// so artifact consumers can join the parameter to its legal source.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub corpus_citation_path: Option<String>,
+    #[serde(default)]
     pub versions: Vec<ParameterVersionSpec>,
 }
 
@@ -300,6 +309,9 @@ impl IndexedParameterSpec {
             name: self.name.clone(),
             unit: self.unit.clone(),
             indexed_by: self.indexed_by.clone(),
+            source: self.source.clone(),
+            source_url: self.source_url.clone(),
+            corpus_citation_path: self.corpus_citation_path.clone(),
             versions: self
                 .versions
                 .iter()
@@ -353,6 +365,11 @@ pub struct DerivedSpec {
     pub source: Option<String>,
     #[serde(default)]
     pub source_url: Option<String>,
+    /// Corpus provision path of the rule's origin module
+    /// (`module.source_verification.corpus_citation_path`), carried per rule
+    /// so artifact consumers can join the rule to its legal source.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub corpus_citation_path: Option<String>,
     #[serde(flatten)]
     pub semantics: DerivedSemanticsSpec,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -372,6 +389,7 @@ impl DerivedSpec {
             rounding: None,
             source: self.source.clone(),
             source_url: self.source_url.clone(),
+            corpus_citation_path: self.corpus_citation_path.clone(),
             semantics: self.semantics.to_model()?,
             versions: self
                 .versions

--- a/tests/dense.rs
+++ b/tests/dense.rs
@@ -2707,6 +2707,7 @@ fn dense_date_add_days_matches_explain_mode() {
         source: None,
         period: None,
         source_url: None,
+        corpus_citation_path: None,
         semantics: DerivedSemanticsSpec::Scalar {
             expr: ScalarExprSpec::DateAddDays {
                 date: Box::new(ScalarExprSpec::Input {
@@ -2729,6 +2730,7 @@ fn dense_date_add_days_matches_explain_mode() {
         source: None,
         period: None,
         source_url: None,
+        corpus_citation_path: None,
         semantics: DerivedSemanticsSpec::Judgment {
             expr: JudgmentExprSpec::Comparison {
                 left: Box::new(ScalarExprSpec::Derived {

--- a/tests/execution.rs
+++ b/tests/execution.rs
@@ -165,6 +165,7 @@ fn fast_mode_coerces_integer_and_decimal_if_branches() {
             source: None,
             period: None,
             source_url: None,
+            corpus_citation_path: None,
             semantics: DerivedSemanticsSpec::Scalar {
                 expr: ScalarExprSpec::If {
                     condition: Box::new(axiom_rules_engine::spec::JudgmentExprSpec::Comparison {
@@ -281,6 +282,7 @@ fn derived_formula_versions_select_by_query_period() {
             source: None,
             period: None,
             source_url: None,
+            corpus_citation_path: None,
             semantics: true_semantics.clone(),
             versions: vec![
                 DerivedVersionSpec {
@@ -383,6 +385,7 @@ fn fast_mode_falls_back_to_explain_when_bulk_support_is_missing() {
                 source: None,
                 period: None,
                 source_url: None,
+                corpus_citation_path: None,
                 semantics: DerivedSemanticsSpec::Scalar {
                     expr: ScalarExprSpec::Input {
                         name: "income".to_string(),
@@ -400,6 +403,7 @@ fn fast_mode_falls_back_to_explain_when_bulk_support_is_missing() {
                 source: None,
                 period: None,
                 source_url: None,
+                corpus_citation_path: None,
                 semantics: DerivedSemanticsSpec::Scalar {
                     expr: ScalarExprSpec::SumRelated {
                         relation: "member_of_household".to_string(),
@@ -512,6 +516,7 @@ fn fast_mode_falls_back_for_filtered_relation_counts() {
             source: None,
             period: None,
             source_url: None,
+            corpus_citation_path: None,
             semantics: DerivedSemanticsSpec::Judgment {
                 expr: axiom_rules_engine::spec::JudgmentExprSpec::Comparison {
                     left: Box::new(ScalarExprSpec::CountRelated {

--- a/tests/source_links.rs
+++ b/tests/source_links.rs
@@ -1,0 +1,384 @@
+//! Source links in compiled artifacts: parameters keep their `source` /
+//! `source_url` citations, every rule and parameter carries its origin
+//! module's `source_verification.corpus_citation_path`, and the optional
+//! compile-time corpus-provision join resolves citation paths to source
+//! URLs deterministically.
+
+use std::collections::HashMap;
+use std::fs;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use axiom_rules_engine::compile::{CompileError, CompiledProgramArtifact, CorpusProvisionIndex};
+use axiom_rules_engine::rulespec::load_rulespec_with_source;
+use axiom_rules_engine::source::{ModuleSource, SourceError};
+
+struct InMemoryModuleSource {
+    modules: HashMap<String, String>,
+}
+
+impl InMemoryModuleSource {
+    fn new(modules: &[(&str, &str)]) -> Self {
+        Self {
+            modules: modules
+                .iter()
+                .map(|(target, text)| (target.to_string(), text.to_string()))
+                .collect(),
+        }
+    }
+}
+
+impl ModuleSource for InMemoryModuleSource {
+    fn load(&self, target: &str) -> Result<Option<String>, SourceError> {
+        Ok(self.modules.get(target).cloned())
+    }
+}
+
+const CITED_MODULE: &str = r#"
+format: rulespec/v1
+module:
+  id: us-co:regulations/10-ccr-2506-1/4.402.2
+  source_verification:
+    corpus_citation_path: us-co/regulation/10-ccr-2506-1/4.402.2
+rules:
+  - name: snap_income_annualization_months
+    kind: parameter
+    dtype: Count
+    source: 10 CCR 2506-1, 4.402.2(A)(1)-(2)
+    versions:
+      - effective_from: 2025-10-01
+        formula: "12"
+  - name: snap_maximum_allotment_table
+    kind: parameter
+    dtype: Money
+    unit: USD
+    indexed_by: household_size
+    source: USDA SNAP FY 2026 COLA maximum monthly allotment table
+    source_url: https://www.fns.usda.gov/snap/fy-2026-cola
+    versions:
+      - effective_from: 2025-10-01
+        values:
+          1: 298
+          2: 546
+  - name: snap_average_monthly_income
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    source: 10 CCR 2506-1, 4.402.2 introductory paragraph
+    versions:
+      - effective_from: 2025-10-01
+        formula: income_intended_to_cover_specific_period / snap_income_annualization_months
+"#;
+
+fn cited_artifact() -> CompiledProgramArtifact {
+    CompiledProgramArtifact::from_rulespec_str(CITED_MODULE).expect("RuleSpec compiles")
+}
+
+#[test]
+fn parameters_keep_source_citations() {
+    let artifact = cited_artifact();
+    let scalar = artifact
+        .program
+        .parameters
+        .iter()
+        .find(|parameter| parameter.name == "snap_income_annualization_months")
+        .expect("scalar parameter is present");
+    assert_eq!(
+        scalar.source.as_deref(),
+        Some("10 CCR 2506-1, 4.402.2(A)(1)-(2)")
+    );
+    assert_eq!(scalar.source_url, None);
+
+    let table = artifact
+        .program
+        .parameters
+        .iter()
+        .find(|parameter| parameter.name == "snap_maximum_allotment_table")
+        .expect("indexed parameter is present");
+    assert_eq!(
+        table.source.as_deref(),
+        Some("USDA SNAP FY 2026 COLA maximum monthly allotment table")
+    );
+    assert_eq!(
+        table.source_url.as_deref(),
+        Some("https://www.fns.usda.gov/snap/fy-2026-cola")
+    );
+}
+
+#[test]
+fn rules_and_parameters_carry_their_module_corpus_citation_path() {
+    let artifact = cited_artifact();
+    for parameter in &artifact.program.parameters {
+        assert_eq!(
+            parameter.corpus_citation_path.as_deref(),
+            Some("us-co/regulation/10-ccr-2506-1/4.402.2"),
+            "parameter `{}` should carry its module's citation path",
+            parameter.name
+        );
+    }
+    for derived in &artifact.program.derived {
+        assert_eq!(
+            derived.corpus_citation_path.as_deref(),
+            Some("us-co/regulation/10-ccr-2506-1/4.402.2"),
+            "derived rule `{}` should carry its module's citation path",
+            derived.name
+        );
+    }
+}
+
+#[test]
+fn imported_rules_keep_their_own_module_citation_path() {
+    // Two modules with different citation paths: every rule must carry the
+    // path of the module it was declared in, not the root module's.
+    let federal = r#"
+format: rulespec/v1
+module:
+  id: us:policies/usda/snap/fy-2026-cola/maximum-allotments
+  source_verification:
+    corpus_citation_path: us/guidance/usda/fns/snap-fy2026-cola/page-1
+rules:
+  - name: snap_maximum_allotment_base
+    kind: parameter
+    dtype: Money
+    unit: USD
+    versions:
+      - effective_from: 2025-10-01
+        formula: "298"
+"#;
+    let state = r#"
+format: rulespec/v1
+module:
+  id: us-co:regulations/10-ccr-2506-1/4.602
+  source_verification:
+    corpus_citation_path: us-co/regulation/10-ccr-2506-1/4.602
+imports:
+  - us:policies/usda/snap/fy-2026-cola/maximum-allotments
+rules:
+  - name: snap_regular_month_allotment
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    versions:
+      - effective_from: 2025-10-01
+        formula: max(0, snap_maximum_allotment_base - net_income)
+"#;
+    let source = InMemoryModuleSource::new(&[
+        (
+            "us:policies/usda/snap/fy-2026-cola/maximum-allotments",
+            federal,
+        ),
+        ("us-co:regulations/10-ccr-2506-1/4.602", state),
+    ]);
+    let program = load_rulespec_with_source("us-co:regulations/10-ccr-2506-1/4.602", &source)
+        .expect("modules load");
+    let artifact = CompiledProgramArtifact::compile(program).expect("program compiles");
+
+    let parameter = artifact
+        .program
+        .parameters
+        .iter()
+        .find(|parameter| parameter.name == "snap_maximum_allotment_base")
+        .expect("imported parameter is present");
+    assert_eq!(
+        parameter.corpus_citation_path.as_deref(),
+        Some("us/guidance/usda/fns/snap-fy2026-cola/page-1")
+    );
+
+    let derived = artifact
+        .program
+        .derived
+        .iter()
+        .find(|derived| derived.name == "snap_regular_month_allotment")
+        .expect("root derived rule is present");
+    assert_eq!(
+        derived.corpus_citation_path.as_deref(),
+        Some("us-co/regulation/10-ccr-2506-1/4.602")
+    );
+}
+
+#[test]
+fn modules_without_source_verification_emit_no_citation_path() {
+    let rulespec = r#"
+format: rulespec/v1
+rules:
+  - name: snap_household_food_contribution_rate
+    kind: parameter
+    dtype: Rate
+    versions:
+      - effective_from: 2008-10-01
+        formula: "0.30"
+"#;
+    let artifact = CompiledProgramArtifact::from_rulespec_str(rulespec).expect("RuleSpec compiles");
+    assert_eq!(artifact.program.parameters[0].corpus_citation_path, None);
+}
+
+const PROVISIONS_JSONL: &str = concat!(
+    r#"{"citation_path": "us-co/regulation/10-ccr-2506-1/4.402.2", "source_url": "https://www.sos.state.co.us/CCR/GenerateRulePdf.do?ruleVersionId=12299", "kind": "section"}"#,
+    "\n",
+    r#"{"citation_path": "us-co/regulation", "source_url": null, "kind": "collection"}"#,
+    "\n\n",
+    r#"{"citation_path": "us-co/regulation/10-ccr-2506-1/4.602", "source_url": "https://www.sos.state.co.us/CCR/GenerateRulePdf.do?ruleVersionId=12299#4.602"}"#,
+    "\n",
+);
+
+#[test]
+fn corpus_provisions_join_resolves_source_urls_without_overriding_inline_urls() {
+    let mut artifact = cited_artifact();
+    let mut provisions = CorpusProvisionIndex::default();
+    provisions
+        .add_jsonl_str(PROVISIONS_JSONL, "<memory>")
+        .expect("provisions parse");
+    // The null-source_url collection record is skipped.
+    assert_eq!(provisions.len(), 2);
+
+    let resolved = artifact.resolve_source_urls(&provisions);
+    // The scalar parameter and the derived rule resolve through the join;
+    // the table parameter keeps its inline URL.
+    assert_eq!(resolved, 2);
+    let scalar = artifact
+        .program
+        .parameters
+        .iter()
+        .find(|parameter| parameter.name == "snap_income_annualization_months")
+        .expect("scalar parameter is present");
+    assert_eq!(
+        scalar.source_url.as_deref(),
+        Some("https://www.sos.state.co.us/CCR/GenerateRulePdf.do?ruleVersionId=12299")
+    );
+    assert_eq!(
+        scalar.source.as_deref(),
+        Some("10 CCR 2506-1, 4.402.2(A)(1)-(2)"),
+        "resolving the URL must not disturb the citation"
+    );
+    let table = artifact
+        .program
+        .parameters
+        .iter()
+        .find(|parameter| parameter.name == "snap_maximum_allotment_table")
+        .expect("indexed parameter is present");
+    assert_eq!(
+        table.source_url.as_deref(),
+        Some("https://www.fns.usda.gov/snap/fy-2026-cola"),
+        "an inline source_url always wins over the join"
+    );
+    let derived = artifact
+        .program
+        .derived
+        .iter()
+        .find(|derived| derived.name == "snap_average_monthly_income")
+        .expect("derived rule is present");
+    assert_eq!(
+        derived.source_url.as_deref(),
+        Some("https://www.sos.state.co.us/CCR/GenerateRulePdf.do?ruleVersionId=12299")
+    );
+}
+
+#[test]
+fn corpus_provisions_join_is_deterministic() {
+    let compile_and_resolve = || {
+        let mut artifact = cited_artifact();
+        let mut provisions = CorpusProvisionIndex::default();
+        provisions
+            .add_jsonl_str(PROVISIONS_JSONL, "<memory>")
+            .expect("provisions parse");
+        artifact.resolve_source_urls(&provisions);
+        // Strip the engine version stamp so this asserts on the join and
+        // program serialization alone.
+        let mut artifact = artifact;
+        artifact.engine_version = None;
+        serde_json::to_string_pretty(&artifact).expect("artifact serializes")
+    };
+    assert_eq!(
+        compile_and_resolve(),
+        compile_and_resolve(),
+        "same inputs must produce a byte-identical artifact"
+    );
+}
+
+#[test]
+fn corpus_provisions_later_records_win_for_the_same_citation_path() {
+    let mut provisions = CorpusProvisionIndex::default();
+    provisions
+        .add_jsonl_str(
+            concat!(
+                r#"{"citation_path": "us-co/regulation/10-ccr-2506-1/4.402.2", "source_url": "https://example.org/older-snapshot"}"#,
+                "\n",
+                r#"{"citation_path": "us-co/regulation/10-ccr-2506-1/4.402.2", "source_url": "https://example.org/newer-snapshot"}"#,
+            ),
+            "<memory>",
+        )
+        .expect("provisions parse");
+    assert_eq!(
+        provisions.source_url("us-co/regulation/10-ccr-2506-1/4.402.2"),
+        Some("https://example.org/newer-snapshot")
+    );
+}
+
+#[test]
+fn corpus_provisions_reject_malformed_records_with_line_numbers() {
+    let mut provisions = CorpusProvisionIndex::default();
+    let error = provisions
+        .add_jsonl_str(
+            concat!(
+                r#"{"citation_path": "us-co/regulation", "source_url": "https://example.org"}"#,
+                "\n",
+                "not json",
+            ),
+            "provisions.jsonl",
+        )
+        .expect_err("malformed line is rejected");
+    let CompileError::ParseProvisionRecord { path, line, .. } = error else {
+        panic!("expected ParseProvisionRecord, got {error:?}");
+    };
+    assert_eq!(path, "provisions.jsonl");
+    assert_eq!(line, 2);
+}
+
+#[test]
+fn corpus_provisions_load_from_files_and_directories() {
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time after unix epoch")
+        .as_nanos();
+    let root = std::env::temp_dir().join(format!("axiom-rules-engine-provisions-{nonce}"));
+    let nested = root.join("us-co").join("regulation");
+    fs::create_dir_all(&nested).expect("create provisions directory");
+    // Dated snapshots: sorted path order loads the newer file last, so its
+    // record wins for the shared citation path.
+    fs::write(
+        nested.join("2026-03-01-10-ccr-2506-1.jsonl"),
+        concat!(
+            r#"{"citation_path": "us-co/regulation/10-ccr-2506-1/4.402.2", "source_url": "https://example.org/older-snapshot"}"#,
+            "\n",
+        ),
+    )
+    .expect("write older snapshot");
+    fs::write(
+        nested.join("2026-04-29-10-ccr-2506-1.jsonl"),
+        concat!(
+            r#"{"citation_path": "us-co/regulation/10-ccr-2506-1/4.402.2", "source_url": "https://example.org/newer-snapshot"}"#,
+            "\n",
+        ),
+    )
+    .expect("write newer snapshot");
+    fs::write(nested.join("notes.txt"), "not provisions").expect("write non-jsonl file");
+
+    let provisions = CorpusProvisionIndex::from_paths([&root]).expect("directory loads");
+    assert_eq!(provisions.len(), 1);
+    assert_eq!(
+        provisions.source_url("us-co/regulation/10-ccr-2506-1/4.402.2"),
+        Some("https://example.org/newer-snapshot")
+    );
+
+    let single = CorpusProvisionIndex::from_paths([nested.join("2026-03-01-10-ccr-2506-1.jsonl")])
+        .expect("single file loads");
+    assert_eq!(
+        single.source_url("us-co/regulation/10-ccr-2506-1/4.402.2"),
+        Some("https://example.org/older-snapshot")
+    );
+
+    fs::remove_dir_all(&root).expect("clean up provisions directory");
+}


### PR DESCRIPTION
Closes #87.

## What

1. **Parameters keep their citations.** `IndexedParameterSpec` (`src/spec.rs`) and `IndexedParameter` (`src/model.rs`) gain `source` / `source_url`, threaded through both lowering paths — scalar parameters via the formula layer (`src/formula.rs`) and indexed tables via `to_indexed_parameter_spec` (`src/rulespec.rs`) — mirroring the existing derived-rule flow.
2. **The join key is emitted.** Every rule and parameter in the artifact now carries `corpus_citation_path`, taken from its origin module's `source_verification.corpus_citation_path`. It is stamped per rule at module load time alongside `origin_target` (so import merging, which keeps only the root `module:` block, cannot lose it) and reattached by name in `apply_rule_ids`, the same way rule ids and rounding modes are.
3. **Optional compile-time URL join.** `compile --corpus-provisions <path>` — repeatable; each path is a provisions JSONL file or a directory scanned recursively for `*.jsonl` in sorted path order (documented in `compile --help`). Records map `citation_path -> source_url`; the join fills each rule's/parameter's `source_url` only where not already set inline. When the same citation path appears more than once, the record loaded later wins, so a directory of dated snapshots deterministically keeps the newest. No network, no clock: same inputs produce a byte-identical artifact.

The compiled-artifact JSON schema is regenerated (`schemas/compiled-artifact.v1.schema.json`); the module schema needed no change (`corpus_citation_path` was already modeled under `source_verification`).

## Verification

Composed + compiled the `us-co/snap` fy-2026 program against the axiom-corpus provisions tree (50,978 indexed citation paths):

| | before (no flag) | after (`--corpus-provisions`) |
|---|---|---|
| derived with `source_url` | 0 / 319 | **315 / 319** |
| parameters with `source_url` | 0 / 127 | **121 / 127** |
| derived with `corpus_citation_path` | 315 / 319 | 315 / 319 |
| parameters with `corpus_citation_path` | 121 / 127 | 121 / 127 |

(On main, parameters carried no `source` at all; with this branch all 319 derived and all 127 parameters keep their `source` citation.) The uncited remainder are modules that declare no `source_verification` (the FY-2026 income-eligibility-standards module — upstream data gap) plus the composition wrapper rule.

Sample join, byte-equal to the provision record:

```
snap_monthly_income_conversion_factor
  corpus_citation_path: us-co/regulation/10-ccr-2506-1/4.402
  source_url: https://www.sos.state.co.us/CCR/GenerateRulePdf.do?ruleVersionId=12299&fileName=10%20CCR%202506-1
```

Recompiling twice with the flag produces byte-identical artifacts.

## Tests

New `tests/source_links.rs` (8 tests): parameter citation retention (scalar + table), per-rule citation paths across imports (each module keeps its own), no-op without `source_verification`, join fills only unset URLs, determinism, later-record-wins, malformed-record line-numbered errors, and file/directory loading. Full suite green: `cargo test --release -q` and `cargo test --release -q --features schema` (177 passed, 0 failed); `cargo build --release --bin axiom-rules-engine` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)