### PR TITLE
Seed GHp (Ghana pesewas) as a currency unit

### DIFF
--- a/src/formula.rs
+++ b/src/formula.rs
@@ -1101,6 +1101,10 @@ pub fn lower_module(module: &Module) -> Result<ProgramSpec, FormulaError> {
         ("USD", UnitKindSpec::Currency { minor_units: 2 }),
         ("EUR", UnitKindSpec::Currency { minor_units: 2 }),
         ("GHS", UnitKindSpec::Currency { minor_units: 2 }),
+        // Ghana pesewas: the Energy Sector Levies Act, 2025 schedule states
+        // its per-litre and per-kilogramme rates in GHp, so modules ground
+        // those amounts in the schedule's own unit (100 GHp = 1 GHS).
+        ("GHp", UnitKindSpec::Currency { minor_units: 0 }),
         ("NGN", UnitKindSpec::Currency { minor_units: 2 }),
         ("count", UnitKindSpec::Count),
         ("person", UnitKindSpec::Count),

--- a/tests/rulespec.rs
+++ b/tests/rulespec.rs
@@ -197,6 +197,37 @@ rules:
 }
 
 #[test]
+fn rulespec_lowers_ghana_pesewa_money_parameter() {
+    // Ghana pesewas (GHp, 100 GHp = 1 GHS) must be a seeded currency unit:
+    // the Energy Sector Levies Act, 2025 schedule states its per-litre and
+    // per-kilogramme fuel-levy rates in GHp, and rulespec-gh grounds those
+    // amounts in the schedule's own unit.
+    let rulespec = r#"
+format: rulespec/v1
+module:
+  id: gh:statutes/act-1141/energy-sector-levies-amendment-2025/schedule
+  title: Energy Sector Levies 2025 schedule (GHp unit check)
+rules:
+  - name: petrol_shortfall_debt_repayment_levy_rate_per_litre
+    kind: parameter
+    dtype: Money
+    unit: GHp
+    source: "Energy Sector Levies (Amendment) Act, 2025, Schedule second row"
+    versions:
+      - effective_from: 2025-06-04
+        formula: "195"
+"#;
+
+    let artifact =
+        CompiledProgramArtifact::from_rulespec_str(rulespec).expect("GHp RuleSpec compiles");
+    assert_eq!(artifact.program.parameters.len(), 1);
+    assert!(
+        artifact.program.units.iter().any(|u| u.name == "GHp"),
+        "GHp should be a seeded currency unit"
+    );
+}
+
+#[test]
 fn rulespec_source_metadata_allows_quoted_phrases() {
     let rulespec = r#"
 format: rulespec/v1


### PR DESCRIPTION
rulespec-gh's fuel-levy module grounds the Energy Sector Levies Act, 2025 schedule rates in the schedule's own unit (GHp — petrol 195/l per Act 1141, Road Fund 48, Energy Fund 1; 100 GHp = 1 GHS). Mirrors the NGN seed (#86); lowering test included (50/50 rulespec tests green locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)