### PR TITLE
Seed UGX (Uganda Shilling) as a currency unit

### DIFF
--- a/src/formula.rs
+++ b/src/formula.rs
@@ -1106,6 +1106,9 @@ pub fn lower_module(module: &Module) -> Result<ProgramSpec, FormulaError> {
         // those amounts in the schedule's own unit (100 GHp = 1 GHS).
         ("GHp", UnitKindSpec::Currency { minor_units: 0 }),
         ("NGN", UnitKindSpec::Currency { minor_units: 2 }),
+        // Uganda Shilling: ISO 4217 lists no minor unit in circulation
+        // (exponent 0); Ugandan statutes state amounts in whole shillings.
+        ("UGX", UnitKindSpec::Currency { minor_units: 0 }),
         ("count", UnitKindSpec::Count),
         ("person", UnitKindSpec::Count),
         ("ratio", UnitKindSpec::Ratio),

--- a/tests/rulespec.rs
+++ b/tests/rulespec.rs
@@ -167,6 +167,37 @@ rules:
 }
 
 #[test]
+fn rulespec_lowers_ugandan_shilling_money_parameter() {
+    // Uganda Shilling (UGX, ISO 4217, exponent 0 — no minor unit in
+    // circulation) must be a seeded currency so rulespec-ug modules can
+    // declare `unit: UGX` without a repo inline unit declaration, exactly
+    // like USD/GBP/EUR/GHS/NGN.
+    let rulespec = r#"
+format: rulespec/v1
+module:
+  id: ug:statutes/cap-340/income-tax/third-schedule
+  title: Uganda income tax third schedule (UGX unit check)
+rules:
+  - name: paye_annual_threshold
+    kind: parameter
+    dtype: Money
+    unit: UGX
+    source: "Income Tax Act (Cap 340), Third Schedule Part I"
+    versions:
+      - effective_from: 2025-07-01
+        formula: "2820000"
+"#;
+
+    let artifact =
+        CompiledProgramArtifact::from_rulespec_str(rulespec).expect("UGX RuleSpec compiles");
+    assert_eq!(artifact.program.parameters.len(), 1);
+    assert!(
+        artifact.program.units.iter().any(|u| u.name == "UGX"),
+        "UGX should be a seeded currency unit"
+    );
+}
+
+#[test]
 fn rulespec_lowers_nigerian_naira_money_parameter() {
     // Nigerian Naira (NGN, ISO 4217, 2 minor units = kobo) must be a seeded
     // currency so rulespec-ng modules can declare `unit: NGN` without a repo


### PR DESCRIPTION
## Summary
- seeds `("UGX", UnitKindSpec::Currency { minor_units: 0 })` — ISO 4217 lists no minor unit in circulation for the Uganda Shilling, and Ugandan statutes state amounts in whole shillings
- unblocks the rulespec-ug lane (next SOUTHMOD country after Ghana per the program roster), exactly as GHS (#78) and GHp (#90) unblocked rulespec-gh
- adds the seeded-unit compile test mirroring the GHS/NGN ones (`rulespec_lowers_ugandan_shilling_money_parameter`); full suite green locally (169 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
