### PR TITLE
Link the PyO3 dense extension on macOS via build.rs (fix #92)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,9 +39,40 @@ jobs:
 
       # The PyO3 extension is a separate crate that CI otherwise never
       # compiles — a core enum change once broke it silently (the
-      # DenseColumn::Float arm). Type-check it on every run.
+      # DenseColumn::Float arm). Type-check it on every run. `cargo check`
+      # never links, so the macOS extension-module link is guarded separately
+      # by the `python-ext-macos` job below.
       - name: cargo check (python-ext)
         run: cargo check --manifest-path python-ext/Cargo.toml --verbose
+
+  python-ext-macos:
+    name: PyO3 extension build (macOS)
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v6.0.2
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Set up Python
+        uses: actions/setup-python@v6.2.0
+        with:
+          python-version: "3.14"
+
+      - name: Cache cargo registry and build
+        uses: Swatinem/rust-cache@v2.9.1
+        with:
+          workspaces: python-ext
+
+      # Guards issue #92. The `extension-module` cdylib leaves the Python
+      # C-API symbols undefined at link time; on macOS the linker rejects them
+      # unless it gets `-undefined dynamic_lookup`, which python-ext/build.rs
+      # emits (pyo3 0.27 no longer auto-emits them). Unlike the Linux
+      # `cargo check` above, `cargo build` actually links the cdylib, so a
+      # regression in that link setup fails CI here instead of only surfacing
+      # in a developer's local `cargo build` / `maturin develop`.
+      - name: cargo build (python-ext extension-module cdylib)
+        run: cargo build --manifest-path python-ext/Cargo.toml --verbose
 
   wasm:
     name: wasm32 core check

--- a/python-ext/Cargo.lock
+++ b/python-ext/Cargo.lock
@@ -55,6 +55,7 @@ dependencies = [
  "chrono",
  "numpy",
  "pyo3",
+ "pyo3-build-config",
  "rust_decimal",
 ]
 

--- a/python-ext/Cargo.toml
+++ b/python-ext/Cargo.toml
@@ -13,3 +13,10 @@ numpy = "0.27.0"
 pyo3 = { version = "0.27.0", features = ["chrono", "extension-module"] }
 axiom-rules-engine = { path = ".." }
 rust_decimal = "1.38.0"
+
+# Used by build.rs to emit the macOS `-undefined dynamic_lookup` cdylib link
+# args so `cargo build`/`cargo rustc` can link the extension-module outside
+# maturin (pyo3 0.27 no longer auto-emits them). See build.rs for the full
+# rationale. Version-matched to `pyo3` above; a no-op on Linux/Windows.
+[build-dependencies]
+pyo3-build-config = "0.27"

--- a/python-ext/build.rs
+++ b/python-ext/build.rs
@@ -1,0 +1,20 @@
+//! Build script for the dense PyO3 extension (`axiom_rules_engine_dense`).
+//!
+//! PyO3's `extension-module` feature deliberately leaves the Python C-API
+//! symbols unresolved at link time — the host interpreter supplies them when it
+//! loads the module. On macOS the system linker rejects those undefined symbols
+//! unless it is told to defer them, so an extension-module `cdylib` must be
+//! linked with `-undefined dynamic_lookup`. maturin injects those flags itself,
+//! which is why `maturin develop` works, but a plain `cargo build` /
+//! `cargo rustc` (used in CI and to read full compiler diagnostics locally)
+//! does not — pyo3 0.27 no longer auto-emits them; a crate that wants to build
+//! outside maturin must opt in from its own build script. Without this the
+//! macOS `cdylib` link fails with "symbol(s) not found for architecture arm64"
+//! (cargo exit status 101).
+//!
+//! `add_extension_module_link_args()` only emits flags for macOS (and
+//! wasm32-unknown-emscripten); it is a no-op on Linux and Windows, so this is
+//! safe on every target the workspace builds.
+fn main() {
+    pyo3_build_config::add_extension_module_link_args();
+}


### PR DESCRIPTION
Fixes #92.

## Root cause

`cargo build --manifest-path python-ext/Cargo.toml` failed on macOS with `ld: symbol(s) not found for architecture arm64` (cargo exit status 101), on a long list of Python C-API symbols (`_PyThreadState_Get`, `_PyType_FromSpec`, ...).

This is **not** a core-API drift and **not** a regression:

- `cargo check --manifest-path python-ext/Cargo.toml` passes clean on `main` — the extension type-checks against the current core crate. The failure is purely at the **link** step, after all Rust code compiles.
- A bare `cargo build` of the extension fails **identically at `e8fb3bd`** (the commit called out as "builds clean"). The build-relevant files (`python-ext/Cargo.toml`, both `Cargo.lock`s) are byte-identical between `e8fb3bd` and `main`; only `python-ext/src/lib.rs` changed (the `execute_lifetime_f64` addition), and that compiles fine.
- `maturin develop --release` **succeeds** on `main` in a clean checkout, because maturin injects the macOS link args itself.

The real gap: PyO3's `extension-module` feature intentionally leaves the Python symbols undefined at link time for the host interpreter to resolve at load. macOS's linker rejects undefined symbols unless it is passed `-undefined dynamic_lookup`. **pyo3 0.27 no longer auto-emits these from its own build script** — an extension crate must opt in by calling `pyo3_build_config::add_extension_module_link_args()` from a `build.rs`. `python-ext` had no `build.rs`, so every non-maturin build path (bare `cargo build`/`cargo rustc`, used in CI and to read full compiler diagnostics) hit the link wall on macOS.

## Fix

- Add `python-ext/build.rs` calling `pyo3_build_config::add_extension_module_link_args()`, plus the version-matched `pyo3-build-config` build-dependency. The call only emits flags for macOS (and wasm32-unknown-emscripten); it is a no-op on Linux/Windows, so it is safe on every target. The extension now links under a bare `cargo build`, and `maturin develop` is unaffected (duplicate link args are harmless). No core functionality or Python-facing behavior changes.
- Add a **macOS CI job** that `cargo build`s `python-ext`, so the `extension-module` link is exercised on every run. The existing Linux `cargo check (python-ext)` never links the cdylib, which is exactly why CI did not catch this; the new job guards it going forward.

## Verification (macOS arm64, Python 3.14)

- `cargo build --manifest-path python-ext/Cargo.toml` — clean (exit 0), produces `libaxiom_rules_engine_dense.dylib`.
- `cargo test` and `cargo test --features schema` — green.
- `maturin develop --release --manifest-path python-ext/Cargo.toml` + `uv pip install python/` — build and install the wheel + wrapper.
- Smoke test against `rulespec-be` pilot pipeline (`entity="Person"`, 0 relations, 7 root inputs): `execute_f64` for `belgium_pit_pilot_federal_and_local_tax_before_withholding` with `belgium_pit_article_23_worker_remuneration = [0, 30000]` and all other inputs `0`/`false` returns `[0.0, 1911.3776948]` — finite and positive, and the 30 000 value matches the checked-in oracle case in `pilot_worker_oracle_pipeline.test.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
