### PR TITLE
Seed ZMW (Zambian Kwacha) as a currency unit

### DIFF
--- a/src/formula.rs
+++ b/src/formula.rs
@@ -1109,6 +1109,9 @@ pub fn lower_module(module: &Module) -> Result<ProgramSpec, FormulaError> {
         // Uganda Shilling: ISO 4217 lists no minor unit in circulation
         // (exponent 0); Ugandan statutes state amounts in whole shillings.
         ("UGX", UnitKindSpec::Currency { minor_units: 0 }),
+        // Zambian Kwacha (rebased 2013): ISO 4217 exponent 2 (100 ngwee
+        // = 1 kwacha); Zambian statutes state amounts in kwacha and ngwee.
+        ("ZMW", UnitKindSpec::Currency { minor_units: 2 }),
         ("count", UnitKindSpec::Count),
         ("person", UnitKindSpec::Count),
         ("ratio", UnitKindSpec::Ratio),

--- a/tests/rulespec.rs
+++ b/tests/rulespec.rs
@@ -198,6 +198,36 @@ rules:
 }
 
 #[test]
+fn rulespec_lowers_zambian_kwacha_money_parameter() {
+    // Zambian Kwacha (ZMW, ISO 4217, 2 minor units = ngwee) must be a
+    // seeded currency so rulespec-zm modules can declare `unit: ZMW`
+    // without a repo inline unit declaration, exactly like USD/GHS/UGX.
+    let rulespec = r#"
+format: rulespec/v1
+module:
+  id: zm:statutes/cap-323/income-tax/charging-schedule
+  title: Zambia income tax charging schedule (ZMW unit check)
+rules:
+  - name: paye_exempt_threshold
+    kind: parameter
+    dtype: Money
+    unit: ZMW
+    source: "Income Tax Act (Cap 323), Charging Schedule"
+    versions:
+      - effective_from: 2025-01-01
+        formula: "61200"
+"#;
+
+    let artifact =
+        CompiledProgramArtifact::from_rulespec_str(rulespec).expect("ZMW RuleSpec compiles");
+    assert_eq!(artifact.program.parameters.len(), 1);
+    assert!(
+        artifact.program.units.iter().any(|u| u.name == "ZMW"),
+        "ZMW should be a seeded currency unit"
+    );
+}
+
+#[test]
 fn rulespec_lowers_nigerian_naira_money_parameter() {
     // Nigerian Naira (NGN, ISO 4217, 2 minor units = kobo) must be a seeded
     // currency so rulespec-ng modules can declare `unit: NGN` without a repo


### PR DESCRIPTION
Zambia joins the SOUTHMOD program (MicroZAMOD parity lane, follows Ghana rulespec-gh#10 and Uganda rulespec-ug#1). Zambian statutes state amounts in kwacha and ngwee — ISO 4217 exponent 2 — so `unit: ZMW` must be seeded like GHS (#78), GHp (#90), and UGX (#91). Includes the compile test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)