### PR TITLE
Seed RWF (Rwandan Franc) as a currency unit

### DIFF
--- a/src/formula.rs
+++ b/src/formula.rs
@@ -1115,6 +1115,9 @@ pub fn lower_module(module: &Module) -> Result<ProgramSpec, FormulaError> {
         // Ethiopian Birr: ISO 4217 exponent 2 (100 santim = 1 birr);
         // Ethiopian proclamations state amounts in birr.
         ("ETB", UnitKindSpec::Currency { minor_units: 2 }),
+        // Rwandan Franc: ISO 4217 lists no minor unit in circulation
+        // (exponent 0); Rwandan laws state amounts in whole francs.
+        ("RWF", UnitKindSpec::Currency { minor_units: 0 }),
         ("count", UnitKindSpec::Count),
         ("person", UnitKindSpec::Count),
         ("ratio", UnitKindSpec::Ratio),

--- a/tests/rulespec.rs
+++ b/tests/rulespec.rs
@@ -228,6 +228,37 @@ rules:
 }
 
 #[test]
+fn rulespec_lowers_rwandan_franc_money_parameter() {
+    // Rwandan Franc (RWF, ISO 4217, exponent 0 — no minor unit in
+    // circulation) must be a seeded currency so rulespec-rw modules can
+    // declare `unit: RWF` without a repo inline unit declaration,
+    // exactly like UGX (the other exponent-0 seed).
+    let rulespec = r#"
+format: rulespec/v1
+module:
+  id: rw:laws/law-2022-027/taxes-on-income
+  title: Rwanda income tax schedule (RWF unit check)
+rules:
+  - name: employment_income_exempt_bound
+    kind: parameter
+    dtype: Money
+    unit: RWF
+    source: "Law No 027/2022 of 20/10/2022 establishing taxes on income, Article 56"
+    versions:
+      - effective_from: 2022-10-28
+        formula: "60000"
+"#;
+
+    let artifact =
+        CompiledProgramArtifact::from_rulespec_str(rulespec).expect("RWF RuleSpec compiles");
+    assert_eq!(artifact.program.parameters.len(), 1);
+    assert!(
+        artifact.program.units.iter().any(|u| u.name == "RWF"),
+        "RWF should be a seeded currency unit"
+    );
+}
+
+#[test]
 fn rulespec_lowers_zambian_kwacha_money_parameter() {
     // Zambian Kwacha (ZMW, ISO 4217, 2 minor units = ngwee) must be a
     // seeded currency so rulespec-zm modules can declare `unit: ZMW`


### PR DESCRIPTION
Rwanda joins the SOUTHMOD program (RWAMOD parity lane, follows Ghana #78/UGX #91/ZMW #94/ETB #95). Rwandan laws state amounts in whole francs — ISO 4217 lists RWF at exponent 0 (no minor unit in circulation), so this seeds `minor_units: 0` exactly like UGX.

- `src/formula.rs`: seed `("RWF", Currency { minor_units: 0 })`
- `tests/rulespec.rs`: compile test `rulespec_lowers_rwandan_franc_money_parameter` (Law No 027/2022 Article 56 employment-income bound as the sample parameter)

Full suite: 172 passed / 0 failed locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
