### PR TITLE
Seed TZS (Tanzanian Shilling) as a currency unit

### DIFF
--- a/src/formula.rs
+++ b/src/formula.rs
@@ -1118,6 +1118,9 @@ pub fn lower_module(module: &Module) -> Result<ProgramSpec, FormulaError> {
         // Rwandan Franc: ISO 4217 lists no minor unit in circulation
         // (exponent 0); Rwandan laws state amounts in whole francs.
         ("RWF", UnitKindSpec::Currency { minor_units: 0 }),
+        // Tanzanian Shilling: ISO 4217 exponent 2 (100 senti = 1
+        // shilingi); Tanzanian statutes state amounts in shillings.
+        ("TZS", UnitKindSpec::Currency { minor_units: 2 }),
         ("count", UnitKindSpec::Count),
         ("person", UnitKindSpec::Count),
         ("ratio", UnitKindSpec::Ratio),

--- a/tests/rulespec.rs
+++ b/tests/rulespec.rs
@@ -228,6 +228,36 @@ rules:
 }
 
 #[test]
+fn rulespec_lowers_tanzanian_shilling_money_parameter() {
+    // Tanzanian Shilling (TZS, ISO 4217, 2 minor units = senti) must be
+    // a seeded currency so rulespec-tz modules can declare `unit: TZS`
+    // without a repo inline unit declaration, exactly like ZMW/ETB.
+    let rulespec = r#"
+format: rulespec/v1
+module:
+  id: tz:statutes/cap-332/income-tax-act
+  title: Tanzania income tax schedule (TZS unit check)
+rules:
+  - name: resident_individual_exempt_bound
+    kind: parameter
+    dtype: Money
+    unit: TZS
+    source: "Income Tax Act (Cap 332), First Schedule paragraph 1(1)"
+    versions:
+      - effective_from: 2020-07-01
+        formula: "3240000"
+"#;
+
+    let artifact =
+        CompiledProgramArtifact::from_rulespec_str(rulespec).expect("TZS RuleSpec compiles");
+    assert_eq!(artifact.program.parameters.len(), 1);
+    assert!(
+        artifact.program.units.iter().any(|u| u.name == "TZS"),
+        "TZS should be a seeded currency unit"
+    );
+}
+
+#[test]
 fn rulespec_lowers_rwandan_franc_money_parameter() {
     // Rwandan Franc (RWF, ISO 4217, exponent 0 — no minor unit in
     // circulation) must be a seeded currency so rulespec-rw modules can


### PR DESCRIPTION
Tanzania joins the SOUTHMOD program (TAZMOD parity lane, follows Ghana #78/UGX #91/ZMW #94/ETB #95/RWF #96). Tanzanian statutes state amounts in shillings — ISO 4217 lists TZS at exponent 2 (100 senti = 1 shilingi), so this seeds `minor_units: 2` like ZMW/ETB.

- `src/formula.rs`: seed `("TZS", Currency { minor_units: 2 })`
- `tests/rulespec.rs`: compile test `rulespec_lowers_tanzanian_shilling_money_parameter` (Income Tax Act Cap 332 First Schedule exempt bound as the sample parameter)

Full suite passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
