### PR TITLE
Add exclusive RuleSpec root resolution

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,9 +8,10 @@ description = "Prototype temporal-relational Axiom Rules Engine in Rust"
 [features]
 default = ["fs"]
 # Filesystem-backed module resolution (FsModuleSource, the *_file loading and
-# artifact APIs, AXIOM_RULESPEC_REPO_ROOTS) and the CLI binary. With this
-# feature off, the core has no std::fs / std::env usage and checks cleanly for
-# wasm32-unknown-unknown; hosts supply modules through source::ModuleSource.
+# artifact APIs, AXIOM_RULESPEC_REPO_ROOTS, exclusive-root mode) and the CLI
+# binary. With this feature off, the core has no std::fs / std::env usage and
+# checks cleanly for wasm32-unknown-unknown; hosts supply modules through
+# source::ModuleSource.
 fs = []
 # JSON Schema generation for the serialized RuleSpec/artifact surface
 # (`schema` module, the `emit-schemas` CLI subcommand, and the golden/

--- a/docs/jurisdiction-repos.md
+++ b/docs/jurisdiction-repos.md
@@ -42,7 +42,10 @@ rules: []
 Import targets follow the same path identity scheme as rule IDs, without the
 optional `#rule_name` suffix. The runtime resolves `us:` to `rulespec-us`,
 `us-tn:` to `rulespec-us-tn`, etc., using sibling checkouts and
-`AXIOM_RULESPEC_REPO_ROOTS`.
+`AXIOM_RULESPEC_REPO_ROOTS`. To restrict canonical-import lookup to configured
+roots, pass `axiom-rules-engine compile --exclusive-rulespec-roots` with one or
+more non-empty `AXIOM_RULESPEC_REPO_ROOTS` entries; this disables ambient
+ancestor, cwd, and sibling-checkout fallback for canonical imports.
 
 Rule files are named by the legal or policy unit they encode. Companion tests use
 the same stem:

--- a/docs/rulespec.md
+++ b/docs/rulespec.md
@@ -166,6 +166,18 @@ The loader searches sibling checkouts and any roots listed in
 `AXIOM_RULESPEC_REPO_ROOTS` (each entry may be a jurisdiction repo, a
 country monorepo, or a directory containing either).
 
+To restrict canonical-import lookup to configured roots, pass
+`--exclusive-rulespec-roots` to the `compile` command, or set
+`AXIOM_RULESPEC_REPO_ROOTS_EXCLUSIVE=1` when using the filesystem API.
+Exclusive mode requires `AXIOM_RULESPEC_REPO_ROOTS` to contain at least one
+path and no empty entries, and searches only canonical-import candidates
+derived from those configured roots. It never falls through to importer
+ancestors, the current working directory, or sibling checkouts for a canonical
+import. This setting is not a general filesystem sandbox for relative or
+absolute imports or `extends`. The command-line flag is also a capability
+handshake: engines that predate exclusive resolution reject it. The same
+canonical-import policy applies to `FsModuleSource`.
+
 Filesystem search is one host strategy, not part of the core. A host can
 instead supply module text directly through the `source::ModuleSource` trait
 and the `load_rulespec_with_source` /

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ use axiom_rules_engine::api::{
 use axiom_rules_engine::compile::{
     CompiledProgramArtifact, CorpusProvisionIndex, compile_summary_lines,
 };
+use axiom_rules_engine::rulespec::AXIOM_RULESPEC_REPO_ROOTS_EXCLUSIVE_ENV;
 
 fn main() {
     if let Err(error) = run() {
@@ -37,10 +38,13 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 const COMPILE_USAGE: &str = "\
-usage: axiom-rules-engine compile --program <rules.yaml> --output <compiled.json> [--corpus-provisions <path>]...
+usage: axiom-rules-engine compile --program <rules.yaml> --output <compiled.json> [--exclusive-rulespec-roots] [--corpus-provisions <path>]...
 
   --program <path>            RuleSpec module or program YAML to compile.
   --output <path>             Where to write the compiled artifact JSON.
+  --exclusive-rulespec-roots  Resolve canonical imports only through non-empty
+                              AXIOM_RULESPEC_REPO_ROOTS entries. Never fall back
+                              to importer ancestors, cwd, or sibling checkouts.
   --corpus-provisions <path>  Optional, repeatable. A corpus provisions JSONL
                               file, or a directory scanned recursively for
                               *.jsonl files in sorted path order. Each record's
@@ -57,6 +61,7 @@ fn run_compile(args: Vec<String>) -> Result<(), Box<dyn std::error::Error>> {
     let mut program_path: Option<PathBuf> = None;
     let mut output_path: Option<PathBuf> = None;
     let mut provisions_paths: Vec<PathBuf> = Vec::new();
+    let mut exclusive_rulespec_roots = false;
 
     let mut iter = args.into_iter();
     while let Some(arg) = iter.next() {
@@ -74,6 +79,9 @@ fn run_compile(args: Vec<String>) -> Result<(), Box<dyn std::error::Error>> {
                         .ok_or("`--corpus-provisions` requires a path argument")?,
                 );
             }
+            "--exclusive-rulespec-roots" => {
+                exclusive_rulespec_roots = true;
+            }
             "--help" | "-h" => {
                 println!("{COMPILE_USAGE}");
                 return Ok(());
@@ -88,6 +96,12 @@ fn run_compile(args: Vec<String>) -> Result<(), Box<dyn std::error::Error>> {
         program_path.ok_or("missing required `--program /path/to/rules` argument")?;
     let output_path =
         output_path.ok_or("missing required `--output /path/to/compiled.json` argument")?;
+
+    if exclusive_rulespec_roots {
+        // SAFETY: the single-threaded CLI has not spawned any worker threads;
+        // compilation reads this process-local setting synchronously below.
+        unsafe { env::set_var(AXIOM_RULESPEC_REPO_ROOTS_EXCLUSIVE_ENV, "1") };
+    }
 
     let mut artifact = CompiledProgramArtifact::from_rulespec_file(&program_path)?;
     if !provisions_paths.is_empty() {

--- a/src/rulespec.rs
+++ b/src/rulespec.rs
@@ -18,6 +18,13 @@ use crate::spec::{
     ScalarValueSpec, UnitSpec,
 };
 
+#[cfg(feature = "fs")]
+/// Search roots for filesystem-backed canonical RuleSpec imports.
+pub const AXIOM_RULESPEC_REPO_ROOTS_ENV: &str = "AXIOM_RULESPEC_REPO_ROOTS";
+#[cfg(feature = "fs")]
+/// Enables fail-closed, configured-root-only canonical import resolution.
+pub const AXIOM_RULESPEC_REPO_ROOTS_EXCLUSIVE_ENV: &str = "AXIOM_RULESPEC_REPO_ROOTS_EXCLUSIVE";
+
 #[derive(Debug, Error)]
 pub enum RuleSpecError {
     #[error("yaml parse error: {0}")]
@@ -27,6 +34,9 @@ pub enum RuleSpecError {
     #[cfg(feature = "fs")]
     #[error("failed to read RuleSpec file `{path}`: {error}")]
     ReadFile { path: String, error: std::io::Error },
+    #[cfg(feature = "fs")]
+    #[error("invalid RuleSpec repository root configuration: {message}")]
+    RepositoryRootConfiguration { message: String },
     #[error("RuleSpec import `{target}` in `{path}` could not be resolved")]
     UnresolvedImport { path: String, target: String },
     #[error("RuleSpec import cycle detected at `{path}`")]
@@ -575,6 +585,7 @@ pub fn lower_rulespec_str(source: &str) -> Result<ProgramSpec, RuleSpecError> {
 #[cfg(feature = "fs")]
 pub fn load_rulespec_file(path: impl AsRef<Path>) -> Result<ProgramSpec, RuleSpecError> {
     let path = path.as_ref();
+    validate_rule_repo_root_configuration()?;
     let mut context = RuleSpecLoadContext::default();
     let document = load_rulespec_document_inner(path, &mut context)?;
     document.to_program_spec()
@@ -882,7 +893,9 @@ fn resolve_canonical_rulespec_import(
         });
     }
 
-    for root in candidate_rule_repo_roots(importer_path, prefix) {
+    let roots = candidate_rule_repo_roots(importer_path, prefix)
+        .map_err(|message| RuleSpecError::RepositoryRootConfiguration { message })?;
+    for root in roots {
         let target_path = root.join(&relative_path);
         if target_path.exists() {
             return Ok(target_path);
@@ -989,7 +1002,55 @@ fn is_absolute_rulespec_ref(value: &str) -> bool {
 }
 
 #[cfg(feature = "fs")]
-pub(crate) fn candidate_rule_repo_roots(importer_path: &Path, prefix: &str) -> Vec<PathBuf> {
+#[derive(Debug)]
+struct RuleRepoRootConfiguration {
+    configured_roots: Vec<PathBuf>,
+    exclusive: bool,
+}
+
+#[cfg(feature = "fs")]
+fn rule_repo_root_configuration() -> Result<RuleRepoRootConfiguration, String> {
+    let exclusive = match env::var_os(AXIOM_RULESPEC_REPO_ROOTS_EXCLUSIVE_ENV) {
+        None => false,
+        Some(value) if value == "1" => true,
+        Some(_) => {
+            return Err(format!(
+                "{AXIOM_RULESPEC_REPO_ROOTS_EXCLUSIVE_ENV} must be exactly `1` when set"
+            ));
+        }
+    };
+    let configured_roots = env::var_os(AXIOM_RULESPEC_REPO_ROOTS_ENV)
+        .map(|roots| env::split_paths(&roots).collect::<Vec<_>>())
+        .unwrap_or_default();
+    if exclusive
+        && (configured_roots.is_empty()
+            || configured_roots
+                .iter()
+                .any(|root| root.as_os_str().is_empty()))
+    {
+        return Err(format!(
+            "{AXIOM_RULESPEC_REPO_ROOTS_EXCLUSIVE_ENV}=1 requires \
+             {AXIOM_RULESPEC_REPO_ROOTS_ENV} to contain at least one path and no empty entries"
+        ));
+    }
+    Ok(RuleRepoRootConfiguration {
+        configured_roots,
+        exclusive,
+    })
+}
+
+#[cfg(feature = "fs")]
+pub(crate) fn validate_rule_repo_root_configuration() -> Result<(), RuleSpecError> {
+    rule_repo_root_configuration()
+        .map(|_| ())
+        .map_err(|message| RuleSpecError::RepositoryRootConfiguration { message })
+}
+
+#[cfg(feature = "fs")]
+pub(crate) fn candidate_rule_repo_roots(
+    importer_path: &Path,
+    prefix: &str,
+) -> Result<Vec<PathBuf>, String> {
     // A jurisdiction's content root is either a legacy standalone repo
     // named rulespec-<prefix> (content at its root), or the <prefix>/
     // directory inside a country monorepo named rulespec-<country>
@@ -1007,22 +1068,24 @@ pub(crate) fn candidate_rule_repo_roots(importer_path: &Path, prefix: &str) -> V
         }
     };
 
-    if let Some(env_roots) = env::var_os("AXIOM_RULESPEC_REPO_ROOTS") {
-        for raw_root in env::split_paths(&env_roots) {
-            if raw_root
-                .file_name()
-                .is_some_and(|name| name == repo_name.as_str())
-            {
-                add(raw_root.clone());
-            } else {
-                add(raw_root.join(&repo_name));
-            }
-            if is_country_monorepo_root(&raw_root, country) {
-                add(raw_root.join(prefix));
-            } else {
-                add(raw_root.join(&monorepo_name).join(prefix));
-            }
+    let configuration = rule_repo_root_configuration()?;
+    for raw_root in configuration.configured_roots {
+        if raw_root
+            .file_name()
+            .is_some_and(|name| name == repo_name.as_str())
+        {
+            add(raw_root.clone());
+        } else {
+            add(raw_root.join(&repo_name));
         }
+        if is_country_monorepo_root(&raw_root, country) {
+            add(raw_root.join(prefix));
+        } else {
+            add(raw_root.join(&monorepo_name).join(prefix));
+        }
+    }
+    if configuration.exclusive {
+        return Ok(candidates);
     }
 
     for ancestor in importer_path.ancestors() {
@@ -1049,7 +1112,7 @@ pub(crate) fn candidate_rule_repo_roots(importer_path: &Path, prefix: &str) -> V
         add(cwd.join("_axiom").join(&repo_name));
         add(cwd.join("_axiom").join(&monorepo_name).join(prefix));
     }
-    candidates
+    Ok(candidates)
 }
 
 impl RulesDocument {

--- a/src/source.rs
+++ b/src/source.rs
@@ -55,7 +55,8 @@ pub trait ModuleSource {
 ///
 /// Candidate repo roots are discovered from the anchor's ancestors plus the
 /// environment, exactly like `load_rulespec_file` discovers them from an
-/// importing file's path.
+/// importing file's path. When `AXIOM_RULESPEC_REPO_ROOTS_EXCLUSIVE=1`, only
+/// the non-empty roots configured by `AXIOM_RULESPEC_REPO_ROOTS` are searched.
 #[cfg(feature = "fs")]
 pub struct FsModuleSource {
     anchor: std::path::PathBuf,
@@ -64,8 +65,8 @@ pub struct FsModuleSource {
 #[cfg(feature = "fs")]
 impl FsModuleSource {
     /// Create a source anchored at `anchor` — typically the root module file
-    /// or the directory the host is working in. Repo-root discovery walks the
-    /// anchor's ancestors.
+    /// or the directory the host is working in. Additive repo-root discovery
+    /// walks the anchor's ancestors; exclusive mode deliberately ignores it.
     pub fn new(anchor: impl Into<std::path::PathBuf>) -> Self {
         Self {
             anchor: anchor.into(),
@@ -91,7 +92,9 @@ impl ModuleSource for FsModuleSource {
         {
             return Ok(None);
         }
-        for root in crate::rulespec::candidate_rule_repo_roots(&self.anchor, prefix) {
+        let roots = crate::rulespec::candidate_rule_repo_roots(&self.anchor, prefix)
+            .map_err(|message| SourceError::new(target, message))?;
+        for root in roots {
             let candidate = root.join(&relative_path);
             if candidate.exists() {
                 return std::fs::read_to_string(&candidate)

--- a/tests/exclusive_root_resolution.rs
+++ b/tests/exclusive_root_resolution.rs
@@ -1,0 +1,252 @@
+//! Exclusive RuleSpec root resolution must never fall through to ambient
+//! ancestor/cwd/sibling repositories. Kept in one integration-test binary
+//! because the direct `FsModuleSource` checks mutate process environment.
+
+use std::ffi::OsString;
+use std::path::Path;
+use std::process::{Command, Output};
+
+use axiom_rules_engine::rulespec::{
+    AXIOM_RULESPEC_REPO_ROOTS_ENV, AXIOM_RULESPEC_REPO_ROOTS_EXCLUSIVE_ENV, RuleSpecError,
+    load_rulespec_with_source,
+};
+use axiom_rules_engine::source::FsModuleSource;
+
+const BASE_MODULE: &str = r#"
+format: rulespec/v1
+rules:
+  - name: base_amount
+    kind: parameter
+    dtype: Money
+    unit: USD
+    versions:
+      - effective_from: 2026-01-01
+        formula: "10"
+"#;
+
+const PROGRAM_MODULE: &str = r#"
+format: rulespec/v1
+imports:
+  - us:policies/base
+rules:
+  - name: adjusted_amount
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    versions:
+      - effective_from: 2026-01-01
+        formula: base_amount + amount
+"#;
+
+fn compile_command(program: &Path, artifact: &Path) -> Command {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_axiom-rules-engine"));
+    command.args([
+        "compile",
+        "--program",
+        program.to_str().expect("utf8 program path"),
+        "--output",
+        artifact.to_str().expect("utf8 artifact path"),
+    ]);
+    command
+}
+
+fn stderr(output: &Output) -> String {
+    String::from_utf8_lossy(&output.stderr).into_owned()
+}
+
+fn restore_env(name: &str, previous: Option<OsString>) {
+    // SAFETY: this integration-test binary contains one test and does not
+    // spawn threads while mutating its process environment.
+    unsafe {
+        if let Some(value) = previous {
+            std::env::set_var(name, value);
+        } else {
+            std::env::remove_var(name);
+        }
+    }
+}
+
+#[test]
+fn exclusive_roots_block_ambient_fallback_and_form_a_cli_capability_handshake() {
+    let temp_root = std::env::temp_dir().join(format!(
+        "axiom-rules-engine-exclusive-roots-{}",
+        std::process::id()
+    ));
+    std::fs::remove_dir_all(&temp_root).ok();
+
+    // The importer lives under `temp_root/work`, so ordinary ancestor
+    // discovery sees `temp_root/rulespec-us`. The configured monorepo starts
+    // empty and therefore proves whether resolution falls through to ambient.
+    let program_path = temp_root.join("work/program.yaml");
+    let ambient_module = temp_root.join("rulespec-us/us/policies/base.yaml");
+    let configured_monorepo = temp_root.join("work/configured/rulespec-us");
+    std::fs::create_dir_all(program_path.parent().expect("program parent"))
+        .expect("program directory");
+    std::fs::create_dir_all(ambient_module.parent().expect("ambient parent"))
+        .expect("ambient module directory");
+    std::fs::create_dir_all(&configured_monorepo).expect("configured monorepo directory");
+    std::fs::write(&program_path, PROGRAM_MODULE).expect("program module is written");
+    std::fs::write(&ambient_module, BASE_MODULE).expect("ambient module is written");
+
+    // FsModuleSource uses the same candidate-root policy as path-based
+    // compilation: additive mode finds the ambient ancestor, exclusive mode
+    // refuses it when the configured root lacks the module.
+    let previous_roots = std::env::var_os(AXIOM_RULESPEC_REPO_ROOTS_ENV);
+    let previous_exclusive = std::env::var_os(AXIOM_RULESPEC_REPO_ROOTS_EXCLUSIVE_ENV);
+    // SAFETY: this integration-test binary contains one test and does not
+    // spawn threads while mutating its process environment.
+    unsafe {
+        std::env::set_var(AXIOM_RULESPEC_REPO_ROOTS_ENV, &configured_monorepo);
+        std::env::remove_var(AXIOM_RULESPEC_REPO_ROOTS_EXCLUSIVE_ENV);
+    }
+    let source = FsModuleSource::new(&program_path);
+    let additive_source_result = load_rulespec_with_source("us:policies/base", &source);
+    // SAFETY: same single-threaded environment mutation described above.
+    unsafe { std::env::set_var(AXIOM_RULESPEC_REPO_ROOTS_EXCLUSIVE_ENV, "1") };
+    let exclusive_source_result = load_rulespec_with_source("us:policies/base", &source);
+    restore_env(AXIOM_RULESPEC_REPO_ROOTS_ENV, previous_roots);
+    restore_env(AXIOM_RULESPEC_REPO_ROOTS_EXCLUSIVE_ENV, previous_exclusive);
+
+    assert!(
+        additive_source_result.is_ok(),
+        "ordinary source resolution should retain ambient fallback: {additive_source_result:?}"
+    );
+    assert!(
+        matches!(
+            exclusive_source_result,
+            Err(RuleSpecError::ModuleNotFound { ref target }) if target == "us:policies/base"
+        ),
+        "exclusive FsModuleSource must not load the ambient module: {exclusive_source_result:?}"
+    );
+
+    let additive_artifact = temp_root.join("additive.compiled.json");
+    let additive_output = compile_command(&program_path, &additive_artifact)
+        .env(AXIOM_RULESPEC_REPO_ROOTS_ENV, &configured_monorepo)
+        .env_remove(AXIOM_RULESPEC_REPO_ROOTS_EXCLUSIVE_ENV)
+        .output()
+        .expect("additive compile command runs");
+    assert!(
+        additive_output.status.success(),
+        "ordinary resolution should preserve ambient fallback: {}",
+        stderr(&additive_output)
+    );
+
+    let exclusive_artifact = temp_root.join("exclusive.compiled.json");
+    let exclusive_output = compile_command(&program_path, &exclusive_artifact)
+        .env(AXIOM_RULESPEC_REPO_ROOTS_ENV, &configured_monorepo)
+        .env(AXIOM_RULESPEC_REPO_ROOTS_EXCLUSIVE_ENV, "1")
+        .output()
+        .expect("exclusive env compile command runs");
+    assert!(!exclusive_output.status.success());
+    assert!(
+        stderr(&exclusive_output).contains("could not be resolved"),
+        "exclusive env mode should report the blocked import: {}",
+        stderr(&exclusive_output)
+    );
+    assert!(!exclusive_artifact.exists());
+
+    let invalid_mode_artifact = temp_root.join("invalid-mode.compiled.json");
+    let invalid_mode_output = compile_command(&program_path, &invalid_mode_artifact)
+        .env(AXIOM_RULESPEC_REPO_ROOTS_ENV, &configured_monorepo)
+        .env(AXIOM_RULESPEC_REPO_ROOTS_EXCLUSIVE_ENV, "true")
+        .output()
+        .expect("invalid-exclusive-mode compile command runs");
+    assert!(!invalid_mode_output.status.success());
+    assert!(
+        stderr(&invalid_mode_output)
+            .contains("AXIOM_RULESPEC_REPO_ROOTS_EXCLUSIVE must be exactly `1` when set"),
+        "invalid exclusive mode must fail closed: {}",
+        stderr(&invalid_mode_output)
+    );
+    assert!(!invalid_mode_artifact.exists());
+
+    let no_roots_artifact = temp_root.join("no-roots.compiled.json");
+    let no_roots_output = compile_command(&program_path, &no_roots_artifact)
+        .env_remove(AXIOM_RULESPEC_REPO_ROOTS_ENV)
+        .env(AXIOM_RULESPEC_REPO_ROOTS_EXCLUSIVE_ENV, "1")
+        .output()
+        .expect("missing-roots compile command runs");
+    assert!(!no_roots_output.status.success());
+    assert!(
+        stderr(&no_roots_output).contains(
+            "AXIOM_RULESPEC_REPO_ROOTS to contain at least one path and no empty entries"
+        ),
+        "exclusive mode must fail closed without configured roots: {}",
+        stderr(&no_roots_output)
+    );
+    assert!(!no_roots_artifact.exists());
+
+    let roots_with_empty_entry =
+        std::env::join_paths([configured_monorepo.as_path(), Path::new("")])
+            .expect("root list with empty entry");
+    let empty_entry_artifact = temp_root.join("empty-entry.compiled.json");
+    let empty_entry_output = compile_command(&program_path, &empty_entry_artifact)
+        .env(AXIOM_RULESPEC_REPO_ROOTS_ENV, roots_with_empty_entry)
+        .env(AXIOM_RULESPEC_REPO_ROOTS_EXCLUSIVE_ENV, "1")
+        .output()
+        .expect("empty-entry compile command runs");
+    assert!(!empty_entry_output.status.success());
+    assert!(
+        stderr(&empty_entry_output).contains("at least one path and no empty entries"),
+        "exclusive mode must reject empty configured-root entries: {}",
+        stderr(&empty_entry_output)
+    );
+    assert!(!empty_entry_artifact.exists());
+
+    // Once the module exists under the configured root, the CLI flag both
+    // enables exclusive mode and compiles successfully. Passing the flag is a
+    // capability handshake: older engines reject it as an unknown argument.
+    let configured_module = configured_monorepo.join("us/policies/base.yaml");
+    let decoy_monorepo = temp_root.join("work/decoy/rulespec-us");
+    std::fs::create_dir_all(configured_module.parent().expect("configured parent"))
+        .expect("configured module directory");
+    std::fs::create_dir_all(&decoy_monorepo).expect("decoy monorepo directory");
+    std::fs::write(&configured_module, BASE_MODULE).expect("configured module is written");
+    let configured_roots =
+        std::env::join_paths([decoy_monorepo.as_path(), configured_monorepo.as_path()])
+            .expect("two configured RuleSpec roots");
+
+    let previous_roots = std::env::var_os(AXIOM_RULESPEC_REPO_ROOTS_ENV);
+    let previous_exclusive = std::env::var_os(AXIOM_RULESPEC_REPO_ROOTS_EXCLUSIVE_ENV);
+    // SAFETY: same single-threaded environment mutation described above.
+    unsafe {
+        std::env::set_var(AXIOM_RULESPEC_REPO_ROOTS_ENV, &configured_roots);
+        std::env::set_var(AXIOM_RULESPEC_REPO_ROOTS_EXCLUSIVE_ENV, "1");
+    }
+    let configured_source_result = load_rulespec_with_source("us:policies/base", &source);
+    restore_env(AXIOM_RULESPEC_REPO_ROOTS_ENV, previous_roots);
+    restore_env(AXIOM_RULESPEC_REPO_ROOTS_EXCLUSIVE_ENV, previous_exclusive);
+    assert!(
+        configured_source_result.is_ok(),
+        "exclusive FsModuleSource should load configured modules: {configured_source_result:?}"
+    );
+
+    let flag_artifact = temp_root.join("flag.compiled.json");
+    let flag_output = compile_command(&program_path, &flag_artifact)
+        .arg("--exclusive-rulespec-roots")
+        .env(AXIOM_RULESPEC_REPO_ROOTS_ENV, &configured_roots)
+        .env_remove(AXIOM_RULESPEC_REPO_ROOTS_EXCLUSIVE_ENV)
+        .output()
+        .expect("exclusive flag compile command runs");
+    assert!(
+        flag_output.status.success(),
+        "configured-root import should compile in exclusive flag mode: {}",
+        stderr(&flag_output)
+    );
+    assert!(
+        std::fs::read_to_string(&flag_artifact)
+            .expect("flag artifact is readable")
+            .contains("us:policies/base#base_amount")
+    );
+
+    let help_output = Command::new(env!("CARGO_BIN_EXE_axiom-rules-engine"))
+        .args(["compile", "--help"])
+        .output()
+        .expect("compile help command runs");
+    assert!(help_output.status.success());
+    assert!(String::from_utf8_lossy(&help_output.stdout).contains("--exclusive-rulespec-roots"));
+
+    std::fs::remove_dir_all(&temp_root).ok();
+}


### PR DESCRIPTION
## Summary

- add an explicit configured-root-only mode for canonical RuleSpec imports
- expose `compile --exclusive-rulespec-roots` as a fail-closed capability handshake
- apply the same candidate-root policy to `FsModuleSource`
- reject missing, empty, and invalid exclusive-root configuration
- preserve the existing additive discovery behavior by default

## Why

Program artifact builds for TheAxiomFoundation/rulespec-us#782 need to prove that compilation cannot silently resolve canonical imports from ambient checkouts. The builder separately audits relative/absolute imports and `extends`; this engine mode intentionally scopes itself to canonical-import lookup.

## Validation

- `cargo test --all-features`
- `cargo test --test exclusive_root_resolution`
- module-source and country-monorepo focused suites
- `cargo test --no-default-features --lib`
- `cargo check --all-targets`
- changed-file rustfmt check

Independent review found no blocker. Repository-wide rustfmt and strict Clippy still expose only pre-existing issues in unchanged code.
