### PR TITLE
Seed DKK (Danish Krone) as a currency unit

### DIFF
--- a/src/formula.rs
+++ b/src/formula.rs
@@ -1121,6 +1121,9 @@ pub fn lower_module(module: &Module) -> Result<ProgramSpec, FormulaError> {
         // Tanzanian Shilling: ISO 4217 exponent 2 (100 senti = 1
         // shilingi); Tanzanian statutes state amounts in shillings.
         ("TZS", UnitKindSpec::Currency { minor_units: 2 }),
+        // Danish Krone: ISO 4217 exponent 2 (100 øre = 1 krone);
+        // Danish statutes state amounts in whole kroner.
+        ("DKK", UnitKindSpec::Currency { minor_units: 2 }),
         ("count", UnitKindSpec::Count),
         ("person", UnitKindSpec::Count),
         ("ratio", UnitKindSpec::Ratio),

--- a/tests/rulespec.rs
+++ b/tests/rulespec.rs
@@ -258,6 +258,36 @@ rules:
 }
 
 #[test]
+fn rulespec_lowers_danish_krone_money_parameter() {
+    // Danish Krone (DKK, ISO 4217, 2 minor units = øre) must be a
+    // seeded currency so rulespec-dk modules can declare `unit: DKK`
+    // without a repo inline unit declaration, exactly like ZMW/ETB/TZS.
+    let rulespec = r#"
+format: rulespec/v1
+module:
+  id: dk:statutes/lbk-603-2025/boerne-og-ungeydelsesloven
+  title: Danish child and youth benefit base amounts (DKK unit check)
+rules:
+  - name: child_benefit_annual_base_age_under_3
+    kind: parameter
+    dtype: Money
+    unit: DKK
+    source: "Børne- og ungeydelsesloven (LBK nr 603 af 12/05/2025) § 1, stk. 1"
+    versions:
+      - effective_from: 2025-05-12
+        formula: "16992"
+"#;
+
+    let artifact =
+        CompiledProgramArtifact::from_rulespec_str(rulespec).expect("DKK RuleSpec compiles");
+    assert_eq!(artifact.program.parameters.len(), 1);
+    assert!(
+        artifact.program.units.iter().any(|u| u.name == "DKK"),
+        "DKK should be a seeded currency unit"
+    );
+}
+
+#[test]
 fn rulespec_lowers_rwandan_franc_money_parameter() {
     // Rwandan Franc (RWF, ISO 4217, exponent 0 — no minor unit in
     // circulation) must be a seeded currency so rulespec-rw modules can

--- a/tests/rulespec.rs
+++ b/tests/rulespec.rs
@@ -7,7 +7,7 @@ use axiom_rules_engine::compile::{
 use axiom_rules_engine::rulespec::{RuleSpecError, ValidationStatus, lower_rulespec_str};
 use axiom_rules_engine::spec::{
     DatasetSpec, DerivedSemanticsSpec, InputRecordSpec, IntervalSpec, PeriodKindSpec, PeriodSpec,
-    ScalarExprSpec, ScalarValueSpec,
+    ScalarExprSpec, ScalarValueSpec, UnitKindSpec,
 };
 use std::fs;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -281,9 +281,16 @@ rules:
     let artifact =
         CompiledProgramArtifact::from_rulespec_str(rulespec).expect("DKK RuleSpec compiles");
     assert_eq!(artifact.program.parameters.len(), 1);
+    let dkk = artifact
+        .program
+        .units
+        .iter()
+        .find(|u| u.name == "DKK")
+        .expect("DKK should be a seeded currency unit");
     assert!(
-        artifact.program.units.iter().any(|u| u.name == "DKK"),
-        "DKK should be a seeded currency unit"
+        matches!(dkk.kind, UnitKindSpec::Currency { minor_units: 2 }),
+        "DKK must carry the ISO 4217 exponent (100 øre = 1 krone): {:?}",
+        dkk.kind
     );
 }
 


### PR DESCRIPTION
Denmark joins as the first non-English-source pilot jurisdiction (`rulespec-dk`, børne- og ungeydelsesloven lane — see TheAxiomFoundation/axiom-corpus#303). Danish statutes state amounts in whole kroner (ISO 4217 exponent 2, 100 øre = 1 krone); `rulespec-dk` modules need `unit: DKK` seeded exactly like GHS (#78), UGX (#91), ZMW (#94), ETB (#95), RWF (#96) and TZS (#97).

- `src/formula.rs`: DKK in the seeded currency table, `minor_units: 2`
- `tests/rulespec.rs`: `rulespec_lowers_danish_krone_money_parameter` compile test (mirrors the TZS/RWF tests; exercises a real § 1 base-amount parameter with Danish text in the source cite)

`cargo test --test rulespec rulespec_lowers_danish_krone`: 1 passed. `cargo fmt --check` clean on the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)