### PR TITLE
Backport effective_to enforcement to v0.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, release/v0.1]
   pull_request:
-    branches: [main]
+    branches: [main, release/v0.1]
 
 jobs:
   rust:

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -4,6 +4,39 @@ Short decision log for architecture choices. Publicly and internally, this is
 the Axiom Rules Engine; the Rust crate and executable are `axiom-rules-engine`. One
 entry per decision, most recent first.
 
+## 2026-07-21 — Artifact v2 makes `effective_to` executable and fail-closed
+
+**Decision.** Parameter and derived versions carry an optional inclusive
+`effective_to` through RuleSpec lowering, `ProgramSpec`, compiled artifacts,
+and runtime selection. A version applies when
+`effective_from <= period.start <= effective_to`, with the upper comparison
+omitted when `effective_to` is absent. Expired versions are not fallbacks: a
+gap produces the existing missing-parameter or missing-derived-version error.
+An upper bound before its lower bound is rejected at compile and artifact-load
+boundaries. `ARTIFACT_FORMAT_VERSION` advances from 1 to 2, and engines accept
+only their exact format version.
+
+**Why.** RuleSpec already accepted `effective_to`, but the formula parser and
+runtime IR discarded it, leaving a one-year rate or benefit rule live forever.
+Adding the field without a format bump would let a v1 engine deserialize a new
+artifact, ignore the unknown upper bound, and silently compute under expired
+law. Exact cross-version rejection is required by the 2026-06-09 artifact
+policy.
+
+**Consequences.**
+
+- Existing RuleSpec without `effective_to` retains its temporal behavior, but
+  every compiled artifact must be rebuilt as v2; this engine rejects stored v1
+  artifacts.
+- `schemas/compiled-artifact.v1.schema.json` remains byte-for-byte archived for
+  stored-data inspection. The derived current schema is
+  `compiled-artifact.v2.schema.json` and includes `effective_to` on parameter
+  and derived versions.
+- Explain and bulk-fast execution honor bounded derived versions. The
+  standalone dense compiler still rejects versioned derived formulas,
+  including a single bounded version; bounded parameter lookups are supported
+  in dense execution.
+
 ## 2026-07-05 — Lifetime execution surface: over-periods reductions and their semantics
 
 **Decision.** A `derived` formula may reduce a value across an entity's own

--- a/README.md
+++ b/README.md
@@ -143,14 +143,18 @@ formats the engine exchanges:
 - `rulespec-module.v1.schema.json` — the RuleSpec module/authoring format
   (`format: rulespec/v1`).
 - `rulespec-test.v1.schema.json` — the companion `*.test.yaml` case format.
-- `compiled-artifact.v1.schema.json` — `CompiledProgramArtifact` (the compiled
-  program, embedding the `ProgramSpec` IR).
+- `compiled-artifact.v2.schema.json` — the current `CompiledProgramArtifact`
+  contract, including executable version `effective_to` bounds.
+- `compiled-artifact.v1.schema.json` — the immutable archived v1 contract.
+  Current engines reject v1 artifacts rather than guessing at missing temporal
+  semantics.
 
 These are the single source of truth for consumers that would otherwise
-re-implement the shape by hand. They mirror the engine's serde **deserialization**
-acceptance: a document that deserializes validates, and vice versa. A document
-can still validate and fail lowering for semantic reasons (unknown rule `kind`,
-top-level `relations:`, missing `effective_from`).
+re-implement the shape by hand. Current schemas mirror the engine's serde
+**deserialization** acceptance: a document that deserializes validates, and
+vice versa. The archived v1 schema remains available only to describe stored
+v1 data. A document can still validate and fail lowering for semantic reasons
+(unknown rule `kind`, top-level `relations:`, missing `effective_from`).
 
 Schema generation lives behind the non-default `schema` feature, so pure-runtime
 consumers do not compile `schemars`. Regenerate the checked-in files with:

--- a/docs/bitemporal.md
+++ b/docs/bitemporal.md
@@ -1,8 +1,9 @@
 # Bitemporal semantics: valid time and assessment time
 
 The engine currently has one time axis. Parameter and derived rules carry
-`versions[]` with `effective_from`, and the query's `period` selects whichever
-version is live for the period being calculated. That single axis answers one
+`versions[]` with `effective_from` and optional inclusive `effective_to`, and
+the query's `period` selects whichever version is live for the period being
+calculated. That single axis answers one
 question — "what does the law say about this benefit period?" — while silently
 assuming a second answer: that the assessor knows every enactment that will
 ever touch that period.
@@ -17,9 +18,9 @@ second one, and states exactly what is and is not implemented today.
 ## The two axes
 
 - **Valid time** — the benefit period the law governs. This is the existing
-  axis: the query's `period`, matched against each version's
-  `effective_from`. It answers: *which version of the rule was in force for
-  the period being calculated?*
+  axis: the query's `period`, matched against each version's effective range.
+  It answers: *which version of the rule was in force for the period being
+  calculated?*
 - **Decision/assessment time** — when the determination is made. This is the
   new axis: the query's `assessment_date`, matched against each version's
   enactment/knowledge date. It answers: *which enactments were visible to the
@@ -28,16 +29,15 @@ second one, and states exactly what is and is not implemented today.
 | | Valid time | Assessment time |
 |---|---|---|
 | Query field | `period` | `assessment_date` |
-| Version field | `effective_from` | `enacted_on` / `known_from` |
+| Version field | `effective_from` / `effective_to` | `enacted_on` / `known_from` |
 | Question | law in force during the period | law as known at determination |
 
-Today the engine conflates the two: selecting a version by
-`effective_from <= period.start` implicitly evaluates every query as an
-omniscient, end-of-history assessment. For a single point-in-time snapshot of
-the law that is correct. The moment an encoding contains a retroactive
-enactment — two versions claiming the same valid time, enacted at different
-moments — the single axis cannot say which one a March determination should
-have used.
+Today the engine conflates the two: selecting a version whose valid-time range
+contains `period.start` implicitly evaluates every query as an omniscient,
+end-of-history assessment. For a single point-in-time snapshot of the law that
+is correct. The moment an encoding contains a retroactive enactment — two
+versions claiming the same valid time, enacted at different moments — the
+single axis cannot say which one a March determination should have used.
 
 ## Why eligibility systems need both
 
@@ -121,13 +121,15 @@ divide the work:
 
 - `assessment_date` selects which enactments are **visible**: versions whose
   visibility date is on or before the assessment date.
-- `period` selects which visible version **applies**: the latest
-  `effective_from` at or before `period.start`, exactly as today.
+- `period` selects which visible version **applies**: among versions whose
+  inclusive valid-time range contains `period.start`, the one with the latest
+  `effective_from`, exactly as today.
 
 Normatively, once implemented:
 
 1. visible = versions where `visibility_date <= assessment_date`
-2. applicable = visible where `effective_from <= period.start`
+2. applicable = visible where `effective_from <= period.start` and
+   (`effective_to` is absent or `period.start <= effective_to`)
 3. select the maximum by (`effective_from`, then visibility date, then
    document order)
 
@@ -148,29 +150,32 @@ remains self-describing about the assessment it was computed under.
 **Implemented today:** the field is parsed, validated against `period.start`,
 and echoed (`src/api.rs`; mirrored in
 `python/axiom_rules_engine/models.py`). It has **no effect on evaluation**.
-Version selection still considers every version
-(`src/engine.rs`, `src/bulk.rs`, `src/dense.rs` all select by
-`effective_from` only). The point of reserving the field now is that requests,
-stored results, and calling code can start carrying assessment dates before
-any encoding depends on the semantics.
+Version selection still considers every version visible regardless of
+assessment date; it filters only by the implemented valid-time range
+(`effective_from` through inclusive `effective_to`). The point of reserving the
+field now is that requests, stored results, and calling code can start carrying
+assessment dates before any encoding depends on the semantics.
 
 ## Migration story
 
 Absent fields mean "known since forever": a version without `enacted_on` or
 `known_from` has a visibility date of negative infinity, is visible at every
 assessment date, and the selection rule above reduces exactly to today's
-`effective_from` rule — with or without an `assessment_date` on the query.
-Every existing encoding, request, artifact, and response is therefore
-unaffected:
+valid-time range rule — with or without an `assessment_date` on the query.
+Within the current v2 contract, encodings and requests that omit the future
+visibility fields are therefore unaffected. Artifact v1 was retired when
+executable `effective_to` bounds landed; it is not part of this future
+assessment-time migration:
 
 - Requests: `assessment_date` is optional and omitted from the wire when
   unset, so requests that do not use it are byte-identical to before.
 - Responses: the echo is likewise omitted when unset.
 - Encodings: `enacted_on`/`known_from` are optional; existing rule files are
   valid and mean what they always meant.
-- Compiled artifacts: today's engines ignore unknown fields, so an artifact
+- Compiled artifacts: a current v2 engine ignores unknown visibility fields,
+  so an artifact
   carrying visibility dates would *silently evaluate omnisciently* on an old
-  engine. When the engine starts honoring visibility dates,
+  v2 engine. When the engine starts honoring visibility dates,
   `ARTIFACT_FORMAT_VERSION` must bump so older engines reject such artifacts
   loudly (see the 2026-06-09 decision in `DECISIONS.md`).
 

--- a/docs/rulespec.md
+++ b/docs/rulespec.md
@@ -74,6 +74,19 @@ implicitly define their own durable outputs, so explicit `defines` records are
 only needed for span-level provenance that is not otherwise represented by an
 executable rule.
 
+Parameter and derived versions may declare an inclusive `effective_to` in
+addition to `effective_from`. Runtime selection uses the query period's start
+date and chooses the latest version whose complete range contains that date.
+After a bounded version expires, it does not remain as a fallback: a gap before
+the next version produces the ordinary missing-parameter or missing-derived-
+version error. An `effective_to` before its `effective_from` is rejected when
+the program is compiled or a compiled artifact is loaded.
+
+Explain and bulk-fast execution honor bounded derived versions directly. The
+standalone `DenseCompiledProgram` compiler continues to reject every versioned
+derived formula, including a single bounded version; callers using that surface
+must use generic execution until dated-derived dense compilation is added.
+
 RuleSpec files must not use top-level `relations:`. Runtime predicates are
 normal rule records:
 
@@ -428,10 +441,10 @@ Known hard gaps:
 
 - Formula strings are parsed by the internal `crate::formula` parser and
   normalised into `ProgramSpec`.
-- Current formula-string gaps include latest-only derived temporal formulas,
-  inferred relation slot orientation, and incomplete optimized support for
-  complex cross-scope derived-relation predicates. These should be closed in
-  RuleSpec and `ProgramSpec`, not by adding another source format.
+- Current formula-string gaps include inferred relation slot orientation and
+  incomplete optimized support for complex cross-scope derived-relation
+  predicates. These should be closed in RuleSpec and `ProgramSpec`, not by
+  adding another source format.
 
 ## Why This Instead Of Direct `ProgramSpec` YAML
 

--- a/python/axiom_rules_engine/models.py
+++ b/python/axiom_rules_engine/models.py
@@ -85,7 +85,7 @@ class CompiledProgramMetadata(BaseModel):
 
 
 class CompiledProgram(BaseModel):
-    artifact_format_version: int = 0
+    artifact_format_version: Literal[2]
     engine_version: str | None = None
     program: Program
     metadata: CompiledProgramMetadata

--- a/python/tests/test_client_timeout.py
+++ b/python/tests/test_client_timeout.py
@@ -7,6 +7,7 @@ import subprocess
 from pathlib import Path
 
 import pytest
+from pydantic import ValidationError
 
 from axiom_rules_engine.client import DEFAULT_TIMEOUT_SECONDS, AxiomRulesEngine
 from axiom_rules_engine.models import (
@@ -56,7 +57,7 @@ def test_timeout_defaults_on_and_is_configurable() -> None:
     assert AxiomRulesEngine(timeout=None).timeout is None
 
 
-def test_compiled_program_parses_legacy_artifact_without_version_fields() -> None:
+def test_compiled_program_rejects_missing_and_wrong_artifact_versions() -> None:
     legacy = {
         "program": {"units": [], "relations": [], "parameters": [], "derived": []},
         "metadata": {
@@ -64,6 +65,15 @@ def test_compiled_program_parses_legacy_artifact_without_version_fields() -> Non
             "fast_path": {"strategy": "generic_bulk", "compatible": True},
         },
     }
-    parsed = CompiledProgram.model_validate(legacy)
-    assert parsed.artifact_format_version == 0
-    assert parsed.engine_version is None
+    with pytest.raises(ValidationError):
+        CompiledProgram.model_validate(legacy)
+    for wrong_version in [0, 1, 3]:
+        with pytest.raises(ValidationError):
+            CompiledProgram.model_validate(
+                {**legacy, "artifact_format_version": wrong_version}
+            )
+
+    compiled = CompiledProgram.model_validate(
+        {**legacy, "artifact_format_version": 2}
+    )
+    assert compiled.artifact_format_version == 2

--- a/schemas/compiled-artifact.v2.schema.json
+++ b/schemas/compiled-artifact.v2.schema.json
@@ -1,0 +1,1390 @@
+{
+  "$defs": {
+    "ComparisonOpSpec": {
+      "enum": [
+        "lt",
+        "lte",
+        "gt",
+        "gte",
+        "eq",
+        "ne"
+      ],
+      "type": "string"
+    },
+    "CompiledProgramMetadata": {
+      "properties": {
+        "evaluation_order": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "fast_path": {
+          "$ref": "#/$defs/FastPathMetadata"
+        }
+      },
+      "required": [
+        "evaluation_order",
+        "fast_path"
+      ],
+      "type": "object"
+    },
+    "DTypeSpec": {
+      "description": "Output data type. Canonical: judgment, bool, integer, decimal, text, date. Aliases (accepted, but not emitted): PascalCase forms and Money/money/Rate/rate for decimal.",
+      "enum": [
+        "judgment",
+        "Judgment",
+        "bool",
+        "Bool",
+        "Boolean",
+        "boolean",
+        "integer",
+        "Integer",
+        "decimal",
+        "Decimal",
+        "Money",
+        "money",
+        "Rate",
+        "rate",
+        "text",
+        "Text",
+        "date",
+        "Date"
+      ],
+      "type": "string"
+    },
+    "DerivedSpec": {
+      "oneOf": [
+        {
+          "properties": {
+            "expr": {
+              "$ref": "#/$defs/ScalarExprSpec"
+            },
+            "semantics": {
+              "const": "scalar",
+              "type": "string"
+            }
+          },
+          "required": [
+            "semantics",
+            "expr"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "expr": {
+              "$ref": "#/$defs/JudgmentExprSpec"
+            },
+            "semantics": {
+              "const": "judgment",
+              "type": "string"
+            }
+          },
+          "required": [
+            "semantics",
+            "expr"
+          ],
+          "type": "object"
+        }
+      ],
+      "properties": {
+        "dtype": {
+          "$ref": "#/$defs/DTypeSpec"
+        },
+        "entity": {
+          "type": "string"
+        },
+        "id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "name": {
+          "type": "string"
+        },
+        "period": {
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "rounding": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RoundingModeSpec"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Opt-in output-rounding mode. When present AND `unit` is a declared\ncurrency, the rule's output is rounded to the unit's `minor_units` under\nthis mode in every execution path. Absent means today's behavior (no\nrounding). Declaring it on a non-currency unit is a compile error."
+        },
+        "source": {
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "source_url": {
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "unit": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "versions": {
+          "items": {
+            "$ref": "#/$defs/DerivedVersionSpec"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "name",
+        "entity",
+        "dtype"
+      ],
+      "type": "object"
+    },
+    "DerivedVersionSpec": {
+      "oneOf": [
+        {
+          "properties": {
+            "expr": {
+              "$ref": "#/$defs/ScalarExprSpec"
+            },
+            "semantics": {
+              "const": "scalar",
+              "type": "string"
+            }
+          },
+          "required": [
+            "semantics",
+            "expr"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "expr": {
+              "$ref": "#/$defs/JudgmentExprSpec"
+            },
+            "semantics": {
+              "const": "judgment",
+              "type": "string"
+            }
+          },
+          "required": [
+            "semantics",
+            "expr"
+          ],
+          "type": "object"
+        }
+      ],
+      "properties": {
+        "effective_from": {
+          "format": "date",
+          "type": "string"
+        },
+        "effective_to": {
+          "format": "date",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "effective_from"
+      ],
+      "type": "object"
+    },
+    "EncodingProvenance": {
+      "additionalProperties": false,
+      "description": "Who and what produced the encoding: tool (`encoder`, for example\n`axiom-encode/0.2.645`), `model`, `run_id`, and human `reviewed_by`.\nAll fields optional; unknown subfields are rejected so typos do not\nsilently pass for provenance.",
+      "properties": {
+        "encoder": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "model": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "reviewed_by": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "run_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "FastPathMetadata": {
+      "properties": {
+        "blockers": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "compatible": {
+          "type": "boolean"
+        },
+        "strategy": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "strategy",
+        "compatible",
+        "blockers"
+      ],
+      "type": "object"
+    },
+    "IndexedParameterSpec": {
+      "properties": {
+        "id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "indexed_by": {
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "name": {
+          "type": "string"
+        },
+        "unit": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "versions": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/ParameterVersionSpec"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "JudgmentExprSpec": {
+      "oneOf": [
+        {
+          "properties": {
+            "kind": {
+              "const": "comparison",
+              "type": "string"
+            },
+            "left": {
+              "$ref": "#/$defs/ScalarExprSpec"
+            },
+            "op": {
+              "$ref": "#/$defs/ComparisonOpSpec"
+            },
+            "right": {
+              "$ref": "#/$defs/ScalarExprSpec"
+            }
+          },
+          "required": [
+            "kind",
+            "left",
+            "op",
+            "right"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "kind": {
+              "const": "derived",
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "name"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "current_slot": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "kind": {
+              "const": "relation_member",
+              "type": "string"
+            },
+            "related_slot": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "relation": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "relation",
+            "current_slot",
+            "related_slot"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "items": {
+              "items": {
+                "$ref": "#/$defs/JudgmentExprSpec"
+              },
+              "type": "array"
+            },
+            "kind": {
+              "const": "and",
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "items"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "items": {
+              "items": {
+                "$ref": "#/$defs/JudgmentExprSpec"
+              },
+              "type": "array"
+            },
+            "kind": {
+              "const": "or",
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "items"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "item": {
+              "$ref": "#/$defs/JudgmentExprSpec"
+            },
+            "kind": {
+              "const": "not",
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "item"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "ModuleMetadata": {
+      "description": "Module-level metadata block of a RuleSpec document. Every field is\noptional; the whole block is descriptive and inert — it never affects\nlowering output names, compilation, or execution. The lowered\n[`ProgramSpec`] keeps the (merged) root module's metadata so tooling\nreading a loaded module or a compiled artifact can see it.",
+      "properties": {
+        "encoding_provenance": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/EncodingProvenance"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "source_verification": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SourceVerification"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "status": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "summary": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "title": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "validation": {
+          "items": {
+            "$ref": "#/$defs/ValidationRecord"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "OverPeriodsKindSpec": {
+      "description": "The over-periods reduction vocabulary, mirroring\n[`crate::model::OverPeriodsKind`].",
+      "enum": [
+        "sum",
+        "max",
+        "count",
+        "sum_top_n"
+      ],
+      "type": "string"
+    },
+    "ParameterVersionSpec": {
+      "properties": {
+        "effective_from": {
+          "format": "date",
+          "type": "string"
+        },
+        "effective_to": {
+          "format": "date",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "values": {
+          "additionalProperties": false,
+          "patternProperties": {
+            "^-?\\d+$": {
+              "$ref": "#/$defs/ScalarValueSpec"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "required": [
+        "effective_from",
+        "values"
+      ],
+      "type": "object"
+    },
+    "ProgramSpec": {
+      "properties": {
+        "derived": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/DerivedSpec"
+          },
+          "type": "array"
+        },
+        "extends": {
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "module": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ModuleMetadata"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Module-level metadata (source pinning, encoding provenance,\nvalidation status) carried through RuleSpec lowering for tooling and\nartifact pass-through. Compilation and execution never read it."
+        },
+        "parameters": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/IndexedParameterSpec"
+          },
+          "type": "array"
+        },
+        "relations": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/RelationSpec"
+          },
+          "type": "array"
+        },
+        "units": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/UnitSpec"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "RelatedValueRefSpec": {
+      "oneOf": [
+        {
+          "properties": {
+            "kind": {
+              "const": "input",
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "name"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "kind": {
+              "const": "derived",
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "name"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "RelationDerivationSpec": {
+      "properties": {
+        "current_slot": {
+          "format": "uint",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "entity": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "member_relation": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "predicate": {
+          "$ref": "#/$defs/JudgmentExprSpec"
+        },
+        "related_slot": {
+          "format": "uint",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "slot_entities": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "source_relation": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "source_relation",
+        "current_slot",
+        "related_slot",
+        "predicate"
+      ],
+      "type": "object"
+    },
+    "RelationSpec": {
+      "properties": {
+        "arity": {
+          "format": "uint",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "derivation": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RelationDerivationSpec"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "name": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "arity"
+      ],
+      "type": "object"
+    },
+    "RoundingModeSpec": {
+      "description": "The RuleSpec `rounding:` vocabulary, mirroring [`crate::model::RoundingMode`].",
+      "enum": [
+        "half_up",
+        "half_even",
+        "floor",
+        "ceil"
+      ],
+      "type": "string"
+    },
+    "ScalarExprSpec": {
+      "oneOf": [
+        {
+          "properties": {
+            "kind": {
+              "const": "literal",
+              "type": "string"
+            },
+            "value": {
+              "$ref": "#/$defs/ScalarValueSpec"
+            }
+          },
+          "required": [
+            "kind",
+            "value"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "kind": {
+              "const": "input",
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "name"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "default": {
+              "$ref": "#/$defs/ScalarValueSpec"
+            },
+            "kind": {
+              "const": "input_or_else",
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "name",
+            "default"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "kind": {
+              "const": "derived",
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "name"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "index": {
+              "$ref": "#/$defs/ScalarExprSpec"
+            },
+            "kind": {
+              "const": "parameter_lookup",
+              "type": "string"
+            },
+            "parameter": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "parameter",
+            "index"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "items": {
+              "items": {
+                "$ref": "#/$defs/ScalarExprSpec"
+              },
+              "type": "array"
+            },
+            "kind": {
+              "const": "add",
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "items"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "kind": {
+              "const": "sub",
+              "type": "string"
+            },
+            "left": {
+              "$ref": "#/$defs/ScalarExprSpec"
+            },
+            "right": {
+              "$ref": "#/$defs/ScalarExprSpec"
+            }
+          },
+          "required": [
+            "kind",
+            "left",
+            "right"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "kind": {
+              "const": "mul",
+              "type": "string"
+            },
+            "left": {
+              "$ref": "#/$defs/ScalarExprSpec"
+            },
+            "right": {
+              "$ref": "#/$defs/ScalarExprSpec"
+            }
+          },
+          "required": [
+            "kind",
+            "left",
+            "right"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "kind": {
+              "const": "div",
+              "type": "string"
+            },
+            "left": {
+              "$ref": "#/$defs/ScalarExprSpec"
+            },
+            "right": {
+              "$ref": "#/$defs/ScalarExprSpec"
+            }
+          },
+          "required": [
+            "kind",
+            "left",
+            "right"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "items": {
+              "items": {
+                "$ref": "#/$defs/ScalarExprSpec"
+              },
+              "type": "array"
+            },
+            "kind": {
+              "const": "max",
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "items"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "items": {
+              "items": {
+                "$ref": "#/$defs/ScalarExprSpec"
+              },
+              "type": "array"
+            },
+            "kind": {
+              "const": "min",
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "items"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "kind": {
+              "const": "ceil",
+              "type": "string"
+            },
+            "value": {
+              "$ref": "#/$defs/ScalarExprSpec"
+            }
+          },
+          "required": [
+            "kind",
+            "value"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "kind": {
+              "const": "floor",
+              "type": "string"
+            },
+            "value": {
+              "$ref": "#/$defs/ScalarExprSpec"
+            }
+          },
+          "required": [
+            "kind",
+            "value"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "kind": {
+              "const": "period_start",
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "kind": {
+              "const": "period_end",
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "date": {
+              "$ref": "#/$defs/ScalarExprSpec"
+            },
+            "days": {
+              "$ref": "#/$defs/ScalarExprSpec"
+            },
+            "kind": {
+              "const": "date_add_days",
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "date",
+            "days"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "from": {
+              "$ref": "#/$defs/ScalarExprSpec"
+            },
+            "kind": {
+              "const": "days_between",
+              "type": "string"
+            },
+            "to": {
+              "$ref": "#/$defs/ScalarExprSpec"
+            }
+          },
+          "required": [
+            "kind",
+            "from",
+            "to"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "current_slot": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "kind": {
+              "const": "count_related",
+              "type": "string"
+            },
+            "related_slot": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "relation": {
+              "type": "string"
+            },
+            "where": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/JudgmentExprSpec"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null
+            }
+          },
+          "required": [
+            "kind",
+            "relation",
+            "current_slot",
+            "related_slot"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "current_slot": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "kind": {
+              "const": "sum_related",
+              "type": "string"
+            },
+            "related_slot": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "relation": {
+              "type": "string"
+            },
+            "value": {
+              "$ref": "#/$defs/RelatedValueRefSpec"
+            },
+            "where": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/JudgmentExprSpec"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null
+            }
+          },
+          "required": [
+            "kind",
+            "relation",
+            "current_slot",
+            "related_slot",
+            "value"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "condition": {
+              "$ref": "#/$defs/JudgmentExprSpec"
+            },
+            "else_expr": {
+              "$ref": "#/$defs/ScalarExprSpec"
+            },
+            "kind": {
+              "const": "if",
+              "type": "string"
+            },
+            "then_expr": {
+              "$ref": "#/$defs/ScalarExprSpec"
+            }
+          },
+          "required": [
+            "kind",
+            "condition",
+            "then_expr",
+            "else_expr"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "Reduction over an entity's own period axis (lifetime execution only).\n`n` is present only for the `sum_top_n` reduction. Expression-level,\nadditive to the serialized surface — no artifact-format-version bump.",
+          "properties": {
+            "kind": {
+              "const": "over_periods",
+              "type": "string"
+            },
+            "n": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/ScalarExprSpec"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "over": {
+              "$ref": "#/$defs/OverPeriodsKindSpec"
+            },
+            "value": {
+              "$ref": "#/$defs/ScalarExprSpec"
+            }
+          },
+          "required": [
+            "kind",
+            "over",
+            "value"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "ScalarValueSpec": {
+      "oneOf": [
+        {
+          "properties": {
+            "kind": {
+              "const": "bool",
+              "type": "string"
+            },
+            "value": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "kind",
+            "value"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "kind": {
+              "const": "integer",
+              "type": "string"
+            },
+            "value": {
+              "format": "int64",
+              "type": "integer"
+            }
+          },
+          "required": [
+            "kind",
+            "value"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "kind": {
+              "const": "decimal",
+              "type": "string"
+            },
+            "value": {
+              "description": "Decimal value as a quoted string (arbitrary precision) or a JSON integer; floats are rejected.",
+              "type": [
+                "string",
+                "integer"
+              ]
+            }
+          },
+          "required": [
+            "kind",
+            "value"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "kind": {
+              "const": "text",
+              "type": "string"
+            },
+            "value": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "value"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "kind": {
+              "const": "date",
+              "type": "string"
+            },
+            "value": {
+              "format": "date",
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "value"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "SourceVerification": {
+      "additionalProperties": true,
+      "description": "Grounding of a module in legal source text. `corpus_citation_path`\naddresses the provision in the Axiom corpus; `source_sha256` pins the\nSHA-256 hex digest of the exact provision text the module was encoded\nfrom, so tooling can detect mechanically when the published source has\nchanged out from under the encoding. Additional subfields (for example\n`corpus_citation_paths`) are preserved verbatim.",
+      "properties": {
+        "corpus_citation_path": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "source_sha256": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "UnitSpec": {
+      "oneOf": [
+        {
+          "properties": {
+            "kind": {
+              "const": "currency",
+              "type": "string"
+            },
+            "minor_units": {
+              "format": "uint8",
+              "maximum": 255,
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "kind",
+            "minor_units"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "kind": {
+              "const": "count",
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "kind": {
+              "const": "ratio",
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "kind": {
+              "const": "duration",
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "kind": {
+              "const": "custom",
+              "type": "string"
+            },
+            "label": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "label"
+          ],
+          "type": "object"
+        }
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "ValidationRecord": {
+      "description": "One oracle-validation result for the module: which oracle, whether the\nencoding currently matches it, and when it last ran.",
+      "properties": {
+        "last_run": {
+          "format": "date",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "oracle": {
+          "type": "string"
+        },
+        "status": {
+          "$ref": "#/$defs/ValidationStatus"
+        }
+      },
+      "required": [
+        "oracle",
+        "status"
+      ],
+      "type": "object"
+    },
+    "ValidationStatus": {
+      "description": "Outcome of an oracle validation run. Any other status string is\nrejected at parse time.",
+      "enum": [
+        "matches",
+        "mismatches",
+        "pending"
+      ],
+      "type": "string"
+    }
+  },
+  "$id": "https://schemas.axiom-foundation.org/rules-engine/compiled-artifact.v2.schema.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "description": "A compiled RuleSpec program: the ProgramSpec IR plus evaluation order and fast-path metadata, stamped with an artifact format version. Produced by `axiom-rules-engine compile`.",
+  "properties": {
+    "artifact_format_version": {
+      "const": 2,
+      "format": "uint32",
+      "minimum": 0,
+      "type": "integer"
+    },
+    "engine_version": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "metadata": {
+      "$ref": "#/$defs/CompiledProgramMetadata"
+    },
+    "program": {
+      "$ref": "#/$defs/ProgramSpec"
+    }
+  },
+  "required": [
+    "artifact_format_version",
+    "program",
+    "metadata"
+  ],
+  "title": "Axiom compiled program artifact",
+  "type": "object"
+}

--- a/src/bulk.rs
+++ b/src/bulk.rs
@@ -1184,7 +1184,7 @@ fn lookup_parameter_bulk(
     let version = parameter
         .versions
         .iter()
-        .filter(|version| version.effective_from <= period.start)
+        .filter(|version| version.applies_at(period.start))
         .max_by_key(|version| version.effective_from)
         .ok_or_else(|| EvalError::MissingParameterValue {
             parameter: parameter.name.clone(),

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -54,7 +54,7 @@ pub enum CompileError {
     )]
     AmbiguousRuleSpecYaml { path: String },
     #[error(
-        "compiled artefact `{path}` has artifact_format_version {found}, but this engine supports up to {supported}; recompile the program with this engine or upgrade the engine"
+        "compiled artefact `{path}` has artifact_format_version {found}, but this engine requires exact version {supported}; recompile the program with this engine"
     )]
     UnsupportedArtifactFormatVersion {
         path: String,
@@ -64,14 +64,15 @@ pub enum CompileError {
 }
 
 /// Format version stamped into every artifact this engine compiles.
-/// Artifacts with a missing field (version 0) predate stamping and are
-/// accepted; artifacts newer than this are rejected at load.
-pub const ARTIFACT_FORMAT_VERSION: u32 = 1;
+/// Artifact v2 is the sole accepted contract. It adds executable
+/// `effective_to` bounds to parameter and derived versions. Missing, older,
+/// and newer versions are rejected at load so no engine can silently ignore
+/// or guess at temporal semantics from another artifact generation.
+pub const ARTIFACT_FORMAT_VERSION: u32 = 2;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub struct CompiledProgramArtifact {
-    #[serde(default)]
     pub artifact_format_version: u32,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub engine_version: Option<String>,
@@ -100,6 +101,7 @@ impl CompiledProgramArtifact {
         // at compile time, so a malformed artifact never ships. Execution paths
         // re-check the same invariant via `to_program`.
         program.validate_rounding()?;
+        program.validate_effective_ranges()?;
         let evaluation_order = evaluation_order(&program)?;
         let fast_path = fast_path_metadata(&program);
         Ok(Self {
@@ -114,13 +116,14 @@ impl CompiledProgramArtifact {
     }
 
     fn check_format_version(self, path: &str) -> Result<Self, CompileError> {
-        if self.artifact_format_version > ARTIFACT_FORMAT_VERSION {
+        if self.artifact_format_version != ARTIFACT_FORMAT_VERSION {
             return Err(CompileError::UnsupportedArtifactFormatVersion {
                 path: path.to_string(),
                 found: self.artifact_format_version,
                 supported: ARTIFACT_FORMAT_VERSION,
             });
         }
+        self.program.validate_effective_ranges()?;
         Ok(self)
     }
 

--- a/src/dense.rs
+++ b/src/dense.rs
@@ -3252,7 +3252,7 @@ fn lookup_parameter_dense<N: DenseNum>(
     let version = parameter
         .versions
         .iter()
-        .filter(|version| version.effective_from <= period.start)
+        .filter(|version| version.applies_at(period.start))
         .max_by_key(|version| version.effective_from)
         .ok_or_else(|| EvalError::MissingParameterValue {
             parameter: parameter.name.clone(),

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -699,7 +699,7 @@ impl<'a> Engine<'a> {
         let version = parameter
             .versions
             .iter()
-            .filter(|version| version.effective_from <= period.start)
+            .filter(|version| version.applies_at(period.start))
             .max_by_key(|version| version.effective_from)
             .ok_or_else(|| EvalError::MissingParameterValue {
                 parameter: name.to_string(),

--- a/src/formula.rs
+++ b/src/formula.rs
@@ -484,6 +484,7 @@ pub enum UnaryOpKind {
 #[derive(Clone, Debug)]
 pub struct TemporalValue {
     pub start: NaiveDate,
+    pub end: Option<NaiveDate>,
     pub expr: Expr,
 }
 
@@ -752,15 +753,19 @@ impl Parser {
             let start_tok = self.consume(TokType::Date)?;
             let start = NaiveDate::parse_from_str(&start_tok.value, "%Y-%m-%d")
                 .map_err(|e| FormulaError::parse(start_tok.line, start_tok.col, e.to_string()))?;
-            if self.at(&[TokType::To]) {
+            let end = if self.at(&[TokType::To]) {
                 self.consume(TokType::To)?;
                 let t = self.consume(TokType::Date)?;
-                NaiveDate::parse_from_str(&t.value, "%Y-%m-%d")
-                    .map_err(|e| FormulaError::parse(t.line, t.col, e.to_string()))?;
-            }
+                Some(
+                    NaiveDate::parse_from_str(&t.value, "%Y-%m-%d")
+                        .map_err(|e| FormulaError::parse(t.line, t.col, e.to_string()))?,
+                )
+            } else {
+                None
+            };
             self.consume(TokType::Colon)?;
             let expr = self.parse_expr()?;
-            decl.values.push(TemporalValue { start, expr });
+            decl.values.push(TemporalValue { start, end, expr });
         }
         Ok(decl)
     }
@@ -1146,6 +1151,7 @@ pub fn lower_module(module: &Module) -> Result<ProgramSpec, FormulaError> {
             values.insert(0, literal_to_scalar_value(&t.expr)?);
             versions.push(ParameterVersionSpec {
                 effective_from: t.start,
+                effective_to: t.end,
                 values,
             });
         }
@@ -1196,12 +1202,13 @@ pub fn lower_module(module: &Module) -> Result<ProgramSpec, FormulaError> {
                 }
             };
         let semantics = lower_semantics(&last.expr, &dtype)?;
-        let versions = if v.values.len() > 1 {
+        let versions = if v.values.len() > 1 || last.end.is_some() {
             v.values
                 .iter()
                 .map(|value| {
                     Ok(DerivedVersionSpec {
                         effective_from: value.start,
+                        effective_to: value.end,
                         semantics: lower_semantics(&value.expr, &dtype)?,
                     })
                 })

--- a/src/model.rs
+++ b/src/model.rs
@@ -377,7 +377,14 @@ pub enum DerivedSemantics {
 #[derive(Clone, Debug)]
 pub struct DerivedVersion {
     pub effective_from: NaiveDate,
+    pub effective_to: Option<NaiveDate>,
     pub semantics: DerivedSemantics,
+}
+
+impl DerivedVersion {
+    pub fn applies_at(&self, date: NaiveDate) -> bool {
+        self.effective_from <= date && self.effective_to.is_none_or(|end| date <= end)
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -406,7 +413,7 @@ impl Derived {
         }
         self.versions
             .iter()
-            .filter(|version| version.effective_from <= period.start)
+            .filter(|version| version.applies_at(period.start))
             .max_by_key(|version| version.effective_from)
             .map(|version| &version.semantics)
     }
@@ -433,7 +440,14 @@ pub struct RelationDerivation {
 #[derive(Clone, Debug)]
 pub struct ParameterVersion {
     pub effective_from: NaiveDate,
+    pub effective_to: Option<NaiveDate>,
     pub values: BTreeMap<i64, ScalarValue>,
+}
+
+impl ParameterVersion {
+    pub fn applies_at(&self, date: NaiveDate) -> bool {
+        self.effective_from <= date && self.effective_to.is_none_or(|end| date <= end)
+    }
 }
 
 #[derive(Clone, Debug)]

--- a/src/rulespec.rs
+++ b/src/rulespec.rs
@@ -1320,6 +1320,7 @@ impl RuleDefinition {
                     })?;
             versions.push(ParameterVersionSpec {
                 effective_from,
+                effective_to: version.effective_to,
                 values: version.values.clone(),
             });
         }

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -1,7 +1,7 @@
 //! Authoritative JSON Schemas for the serialized RuleSpec surface.
 //!
-//! Three schemas are published, one per format the engine and its
-//! consumers exchange:
+//! Current schemas are published for each format the engine and its consumers
+//! exchange, with superseded compiled-artifact schemas retained as archives:
 //!
 //! - `rulespec-module.v1` — the RuleSpec module/authoring format
 //!   (`format: rulespec/v1`): the document [`crate::rulespec::RulesDocument`]
@@ -10,19 +10,22 @@
 //!   versions.
 //! - `rulespec-test.v1` — the companion `*.test.yaml` format: the case list
 //!   the jurisdiction-repo and `axiom-encode` harnesses run against a module.
-//! - `compiled-artifact.v1` — [`crate::compile::CompiledProgramArtifact`],
-//!   the compiled program (embedding the `ProgramSpec` IR) that ships to
-//!   consumers.
+//! - `compiled-artifact.v2` — [`crate::compile::CompiledProgramArtifact`], the
+//!   current compiled program (embedding the `ProgramSpec` IR) that ships to
+//!   consumers. `compiled-artifact.v1` remains published unchanged so stored
+//!   v1 artifacts have a stable historical schema, but this engine does not
+//!   execute them.
 //!
 //! Fidelity is the whole point: a file that serde deserializes MUST validate
 //! against its schema, and a file that validates MUST deserialize. That goal
 //! forces two authoring strategies:
 //!
-//! - The **artifact** schema is derived from the Rust types with `schemars`
+//! - The current **artifact** schema is derived from the Rust types with `schemars`
 //!   (`#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]` on the
 //!   `*Spec` types). Those types are ordinary internally-tagged enums and
 //!   structs `schemars` mirrors exactly, so derivation is the source of
-//!   truth and cannot drift from the deserializer.
+//!   truth and cannot drift from the deserializer. Superseded artifact schemas
+//!   are frozen checked-in archives rather than regenerated from current types.
 //! - The **module** and **test** schemas are written by hand. Several fields
 //!   in the module format have hand-written `Deserialize` behavior a derive
 //!   cannot mirror — `RuleKind` accepts *any* string (deferring unknown
@@ -65,6 +68,10 @@ pub fn all_schemas() -> Vec<NamedSchema> {
         },
         NamedSchema {
             file_name: "compiled-artifact.v1.schema.json",
+            schema: archived_compiled_artifact_v1_schema(),
+        },
+        NamedSchema {
+            file_name: "compiled-artifact.v2.schema.json",
             schema: compiled_artifact_schema(),
         },
     ]
@@ -99,8 +106,18 @@ pub fn write_all_to_dir(dir: &std::path::Path) -> std::io::Result<Vec<std::path:
 // Compiled artifact — derived from the Rust types via schemars.
 // ---------------------------------------------------------------------------
 
-/// JSON Schema for [`crate::compile::CompiledProgramArtifact`], generated from
-/// the `schemars` derive so it tracks the serde types automatically.
+/// Archived v1 schema. It is loaded from the checked-in bytes instead of being
+/// regenerated from current Rust types because v1 predates executable
+/// `effective_to` fields and must remain immutable.
+#[cfg(feature = "schema")]
+fn archived_compiled_artifact_v1_schema() -> Value {
+    serde_json::from_str(include_str!("../schemas/compiled-artifact.v1.schema.json"))
+        .expect("archived compiled-artifact.v1 schema is valid JSON")
+}
+
+/// JSON Schema for the current [`crate::compile::CompiledProgramArtifact`],
+/// generated from the `schemars` derive so it tracks the serde types
+/// automatically.
 ///
 /// Known, deliberate divergences from raw serde acceptance (documented in the
 /// PR and in `docs/schema-alignment.md`):
@@ -116,9 +133,15 @@ pub fn write_all_to_dir(dir: &std::path::Path) -> std::io::Result<Vec<std::path:
 pub fn compiled_artifact_schema() -> Value {
     let mut schema = serde_json::to_value(schema_for!(crate::compile::CompiledProgramArtifact))
         .expect("artifact schema serializes");
+    schema["properties"]["artifact_format_version"] = json!({
+        "type": "integer",
+        "format": "uint32",
+        "minimum": 0,
+        "const": crate::compile::ARTIFACT_FORMAT_VERSION
+    });
     stamp_meta(
         &mut schema,
-        "compiled-artifact.v1",
+        "compiled-artifact.v2",
         "Axiom compiled program artifact",
         "A compiled RuleSpec program: the ProgramSpec IR plus evaluation \
          order and fast-path metadata, stamped with an artifact format \

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -40,6 +40,14 @@ pub enum SpecError {
         mode: String,
         unit: String,
     },
+    #[error(
+        "rule `{rule}` has an effective_to date {effective_to} before effective_from {effective_from}"
+    )]
+    InvalidEffectiveRange {
+        rule: String,
+        effective_from: NaiveDate,
+        effective_to: NaiveDate,
+    },
 }
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
@@ -89,6 +97,31 @@ impl ProgramSpec {
         };
         for derived in &self.derived {
             derived.resolve_rounding(&program)?;
+        }
+        Ok(())
+    }
+
+    /// Reject a version whose inclusive upper bound precedes its lower bound.
+    /// Called at both compile and artifact-load boundaries so malformed dated
+    /// rules fail before any execution path can see them.
+    pub fn validate_effective_ranges(&self) -> Result<(), SpecError> {
+        for parameter in &self.parameters {
+            validate_effective_ranges(
+                &parameter.name,
+                parameter
+                    .versions
+                    .iter()
+                    .map(|version| (version.effective_from, version.effective_to)),
+            )?;
+        }
+        for derived in &self.derived {
+            validate_effective_ranges(
+                &derived.name,
+                derived
+                    .versions
+                    .iter()
+                    .map(|version| (version.effective_from, version.effective_to)),
+            )?;
         }
         Ok(())
     }
@@ -295,6 +328,12 @@ pub struct IndexedParameterSpec {
 
 impl IndexedParameterSpec {
     fn to_model(&self) -> Result<IndexedParameter, SpecError> {
+        validate_effective_ranges(
+            &self.name,
+            self.versions
+                .iter()
+                .map(|version| (version.effective_from, version.effective_to)),
+        )?;
         Ok(IndexedParameter {
             id: self.id.clone(),
             name: self.name.clone(),
@@ -313,6 +352,8 @@ impl IndexedParameterSpec {
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub struct ParameterVersionSpec {
     pub effective_from: NaiveDate,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub effective_to: Option<NaiveDate>,
     pub values: BTreeMap<i64, ScalarValueSpec>,
 }
 
@@ -324,6 +365,7 @@ impl ParameterVersionSpec {
         }
         Ok(ParameterVersion {
             effective_from: self.effective_from,
+            effective_to: self.effective_to,
             values,
         })
     }
@@ -361,6 +403,12 @@ pub struct DerivedSpec {
 
 impl DerivedSpec {
     fn to_model(&self) -> Result<Derived, SpecError> {
+        validate_effective_ranges(
+            &self.name,
+            self.versions
+                .iter()
+                .map(|version| (version.effective_from, version.effective_to)),
+        )?;
         Ok(Derived {
             id: self.id.clone(),
             name: self.name.clone(),
@@ -408,6 +456,24 @@ impl DerivedSpec {
     }
 }
 
+fn validate_effective_ranges(
+    rule: &str,
+    versions: impl IntoIterator<Item = (NaiveDate, Option<NaiveDate>)>,
+) -> Result<(), SpecError> {
+    for (effective_from, effective_to) in versions {
+        if let Some(effective_to) = effective_to
+            && effective_to < effective_from
+        {
+            return Err(SpecError::InvalidEffectiveRange {
+                rule: rule.to_string(),
+                effective_from,
+                effective_to,
+            });
+        }
+    }
+    Ok(())
+}
+
 /// The RuleSpec `rounding:` vocabulary, mirroring [`crate::model::RoundingMode`].
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
@@ -443,6 +509,8 @@ impl RoundingModeSpec {
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub struct DerivedVersionSpec {
     pub effective_from: NaiveDate,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub effective_to: Option<NaiveDate>,
     #[serde(flatten)]
     pub semantics: DerivedSemanticsSpec,
 }
@@ -451,6 +519,7 @@ impl DerivedVersionSpec {
     fn to_model(&self) -> Result<DerivedVersion, SpecError> {
         Ok(DerivedVersion {
             effective_from: self.effective_from,
+            effective_to: self.effective_to,
             semantics: self.semantics.to_model()?,
         })
     }

--- a/tests/artifact_version.rs
+++ b/tests/artifact_version.rs
@@ -9,6 +9,7 @@ rules:
     unit: USD
     versions:
       - effective_from: 2026-01-01
+        effective_to: 2026-12-31
         formula: "10"
   - name: adjusted_amount
     kind: derived
@@ -18,6 +19,7 @@ rules:
     unit: USD
     versions:
       - effective_from: 2026-01-01
+        effective_to: 2026-12-31
         formula: amount + base_amount
 "#;
 
@@ -25,6 +27,7 @@ rules:
 fn compile_stamps_format_and_engine_versions() {
     let artifact = CompiledProgramArtifact::from_rulespec_str(SIMPLE_RULESPEC)
         .expect("RuleSpec module compiles from YAML");
+    assert_eq!(ARTIFACT_FORMAT_VERSION, 2);
     assert_eq!(artifact.artifact_format_version, ARTIFACT_FORMAT_VERSION);
     assert_eq!(
         artifact.engine_version.as_deref(),
@@ -42,19 +45,51 @@ fn compile_stamps_format_and_engine_versions() {
 }
 
 #[test]
-fn legacy_artifact_without_version_fields_still_loads() {
+fn v2_engine_rejects_a_v1_artifact() {
+    let artifact = CompiledProgramArtifact::from_rulespec_str(SIMPLE_RULESPEC)
+        .expect("RuleSpec module compiles to v2");
+    let mut value = serde_json::to_value(&artifact).expect("artifact serialises");
+    value["artifact_format_version"] = serde_json::json!(1);
+    let v1_json = serde_json::to_string(&value).expect("v1 JSON serialises");
+
+    let error = CompiledProgramArtifact::from_json_str(&v1_json)
+        .expect_err("the v2 engine must reject a v1 artifact");
+    assert!(matches!(
+        error,
+        CompileError::UnsupportedArtifactFormatVersion {
+            found: 1,
+            supported: 2,
+            ..
+        }
+    ));
+}
+
+#[test]
+fn missing_and_prelaunch_artifact_versions_are_rejected() {
     let artifact = CompiledProgramArtifact::from_rulespec_str(SIMPLE_RULESPEC)
         .expect("RuleSpec module compiles from YAML");
     let mut value = serde_json::to_value(&artifact).expect("artifact serialises");
-    let object = value.as_object_mut().expect("artifact is a JSON object");
-    object.remove("artifact_format_version");
-    object.remove("engine_version");
-    let legacy_json = serde_json::to_string(&value).expect("legacy JSON serialises");
+    value
+        .as_object_mut()
+        .expect("artifact is a JSON object")
+        .remove("artifact_format_version");
+    let missing_json = serde_json::to_string(&value).expect("missing-version JSON serialises");
+    assert!(
+        CompiledProgramArtifact::from_json_str(&missing_json).is_err(),
+        "unstamped artifacts must fail closed"
+    );
 
-    let reloaded = CompiledProgramArtifact::from_json_str(&legacy_json)
-        .expect("legacy artifact without version fields loads");
-    assert_eq!(reloaded.artifact_format_version, 0);
-    assert_eq!(reloaded.engine_version, None);
+    value
+        .as_object_mut()
+        .expect("artifact is a JSON object")
+        .insert("artifact_format_version".to_string(), serde_json::json!(0));
+    let v0_json = serde_json::to_string(&value).expect("v0 JSON serialises");
+    let error = CompiledProgramArtifact::from_json_str(&v0_json)
+        .expect_err("prelaunch v0 artifact must fail");
+    assert!(matches!(
+        error,
+        CompileError::UnsupportedArtifactFormatVersion { found: 0, .. }
+    ));
 }
 
 #[test]
@@ -99,4 +134,18 @@ fn artifact_file_round_trip_preserves_versions() {
     assert_eq!(reloaded.artifact_format_version, ARTIFACT_FORMAT_VERSION);
 
     std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn artifact_loader_rejects_an_inverted_effective_range() {
+    let artifact = CompiledProgramArtifact::from_rulespec_str(SIMPLE_RULESPEC)
+        .expect("bounded RuleSpec compiles");
+    let mut value = serde_json::to_value(&artifact).expect("artifact serialises");
+    value["program"]["parameters"][0]["versions"][0]["effective_to"] =
+        serde_json::json!("2025-12-31");
+    let json = serde_json::to_string(&value).expect("mutated artifact serialises");
+
+    let error = CompiledProgramArtifact::from_json_str(&json)
+        .expect_err("inverted artifact range must fail before execution");
+    assert!(matches!(error, CompileError::Spec(_)));
 }

--- a/tests/dense.rs
+++ b/tests/dense.rs
@@ -3369,6 +3369,63 @@ fn dense_broadcasts_scalar_entity_formula_parameters() {
 }
 
 #[test]
+fn dense_parameter_lookup_honors_effective_to() {
+    let rulespec = r#"
+format: rulespec/v1
+rules:
+  - name: bounded_rate
+    kind: parameter
+    dtype: Rate
+    versions:
+      - effective_from: 2026-01-01
+        effective_to: 2026-12-31
+        formula: "0.5"
+  - name: tapered_amount
+    kind: derived
+    entity: Person
+    dtype: Money
+    period: Month
+    unit: GBP
+    versions:
+      - effective_from: 2020-01-01
+        formula: income * bounded_rate
+"#;
+    let artifact = CompiledProgramArtifact::from_rulespec_str(rulespec)
+        .expect("bounded parameter RuleSpec compiles");
+    let dense = DenseCompiledProgram::from_artifact(&artifact, Some("Person"))
+        .expect("dense compilation succeeds");
+    let batch = || DenseBatchSpec {
+        row_count: 1,
+        inputs: HashMap::from([(
+            "income".to_string(),
+            DenseColumn::Decimal(vec![decimal("100")]),
+        )]),
+        relations: HashMap::new(),
+    };
+
+    dense
+        .execute(
+            &axiom_rules_engine::model::Period::month(2026, 12),
+            batch(),
+            &["tapered_amount".to_string()],
+        )
+        .expect("effective_to remains live through its date");
+
+    let error = dense
+        .execute(
+            &axiom_rules_engine::model::Period::month(2027, 1),
+            batch(),
+            &["tapered_amount".to_string()],
+        )
+        .expect_err("expired parameter is unavailable to dense execution");
+    assert!(matches!(
+        error,
+        axiom_rules_engine::engine::EvalError::MissingParameterValue { parameter, .. }
+            if parameter == "bounded_rate"
+    ));
+}
+
+#[test]
 fn dense_compiles_scalar_only_module_with_scalar_root() {
     // A module containing only scalar formula parameters falls back to the
     // Scalar pseudo-entity as its root and executes as a broadcast.

--- a/tests/execution.rs
+++ b/tests/execution.rs
@@ -3,10 +3,11 @@ use std::process::{Command, Stdio};
 use std::str::FromStr;
 
 use axiom_rules_engine::api::{
-    CompiledExecutionRequest, ExecutionMode, ExecutionQuery, ExecutionRequest, ExecutionResponse,
-    OutputValue, execute_compiled_request, execute_request,
+    ApiError, CompiledExecutionRequest, ExecutionMode, ExecutionQuery, ExecutionRequest,
+    ExecutionResponse, OutputValue, execute_compiled_request, execute_request,
 };
 use axiom_rules_engine::compile::CompiledProgramArtifact;
+use axiom_rules_engine::engine::EvalError;
 use axiom_rules_engine::spec::{
     ComparisonOpSpec, DTypeSpec, DatasetSpec, DerivedSemanticsSpec, DerivedSpec,
     DerivedVersionSpec, InputRecordSpec, IntervalSpec, JudgmentOutcomeSpec, PeriodKindSpec,
@@ -286,11 +287,13 @@ fn derived_formula_versions_select_by_query_period() {
                 DerivedVersionSpec {
                     effective_from: chrono::NaiveDate::from_ymd_opt(2024, 1, 1)
                         .expect("valid date"),
+                    effective_to: None,
                     semantics: false_semantics,
                 },
                 DerivedVersionSpec {
                     effective_from: chrono::NaiveDate::from_ymd_opt(2026, 1, 1)
                         .expect("valid date"),
+                    effective_to: None,
                     semantics: true_semantics,
                 },
             ],
@@ -353,6 +356,155 @@ fn derived_formula_versions_select_by_query_period() {
         ),
         JudgmentOutcomeSpec::Holds
     );
+}
+
+#[test]
+fn parameter_versions_expire_and_leave_gaps_in_all_execution_modes() {
+    let rulespec = r#"
+format: rulespec/v1
+rules:
+  - name: bounded_rate
+    kind: parameter
+    dtype: Integer
+    versions:
+      - effective_from: 2025-01-01
+        effective_to: 2025-12-31
+        formula: "1"
+      - effective_from: 2027-01-01
+        effective_to: 2027-12-31
+        formula: "3"
+  - name: amount_using_bounded_rate
+    kind: derived
+    entity: TaxUnit
+    dtype: Integer
+    period: Day
+    versions:
+      - effective_from: 2020-01-01
+        formula: bounded_rate
+"#;
+    let program = axiom_rules_engine::rulespec::lower_rulespec_str(rulespec)
+        .expect("bounded parameter RuleSpec lowers");
+
+    for mode in [ExecutionMode::Explain, ExecutionMode::Fast] {
+        assert_eq!(
+            integer_result(
+                &program,
+                mode.clone(),
+                2025,
+                12,
+                31,
+                "amount_using_bounded_rate"
+            )
+            .expect("effective_to is inclusive"),
+            1
+        );
+        assert!(matches!(
+            integer_result(&program, mode.clone(), 2026, 1, 1, "amount_using_bounded_rate"),
+            Err(ApiError::Eval(EvalError::MissingParameterValue { parameter, .. }))
+                if parameter == "bounded_rate"
+        ));
+        assert_eq!(
+            integer_result(
+                &program,
+                mode.clone(),
+                2027,
+                1,
+                1,
+                "amount_using_bounded_rate"
+            )
+            .expect("later parameter version begins after the gap"),
+            3
+        );
+        assert!(matches!(
+            integer_result(&program, mode, 2028, 1, 1, "amount_using_bounded_rate"),
+            Err(ApiError::Eval(EvalError::MissingParameterValue { parameter, .. }))
+                if parameter == "bounded_rate"
+        ));
+    }
+}
+
+#[test]
+fn derived_versions_expire_and_leave_gaps_in_all_execution_modes() {
+    let rulespec = r#"
+format: rulespec/v1
+rules:
+  - name: bounded_amount
+    kind: derived
+    entity: TaxUnit
+    dtype: Integer
+    period: Day
+    versions:
+      - effective_from: 2025-01-01
+        effective_to: 2025-12-31
+        formula: "1"
+      - effective_from: 2027-01-01
+        effective_to: 2027-12-31
+        formula: "3"
+"#;
+    let program = axiom_rules_engine::rulespec::lower_rulespec_str(rulespec)
+        .expect("bounded derived RuleSpec lowers");
+
+    for mode in [ExecutionMode::Explain, ExecutionMode::Fast] {
+        assert_eq!(
+            integer_result(&program, mode.clone(), 2025, 12, 31, "bounded_amount")
+                .expect("effective_to is inclusive"),
+            1
+        );
+        assert!(matches!(
+            integer_result(&program, mode.clone(), 2026, 1, 1, "bounded_amount"),
+            Err(ApiError::Eval(EvalError::MissingDerivedFormulaVersion { derived, .. }))
+                if derived == "bounded_amount"
+        ));
+        assert_eq!(
+            integer_result(&program, mode.clone(), 2027, 1, 1, "bounded_amount")
+                .expect("later derived version begins after the gap"),
+            3
+        );
+        assert!(matches!(
+            integer_result(&program, mode, 2028, 1, 1, "bounded_amount"),
+            Err(ApiError::Eval(EvalError::MissingDerivedFormulaVersion { derived, .. }))
+                if derived == "bounded_amount"
+        ));
+    }
+}
+
+fn integer_result(
+    program: &ProgramSpec,
+    mode: ExecutionMode,
+    year: i32,
+    month: u32,
+    day: u32,
+    output: &str,
+) -> Result<i64, ApiError> {
+    let date = chrono::NaiveDate::from_ymd_opt(year, month, day).expect("valid test date");
+    let response = execute_request(ExecutionRequest {
+        mode,
+        program: program.clone(),
+        dataset: DatasetSpec::default(),
+        queries: vec![ExecutionQuery {
+            assessment_date: None,
+            entity_id: "tax-unit-1".to_string(),
+            period: PeriodSpec {
+                kind: PeriodKindSpec::Custom {
+                    name: "Day".to_string(),
+                },
+                start: date,
+                end: date,
+            },
+            outputs: vec![output.to_string()],
+        }],
+    })?;
+    let value = response.results[0]
+        .outputs
+        .get(output)
+        .expect("requested output is returned");
+    match value {
+        OutputValue::Scalar {
+            value: ScalarValueSpec::Integer { value },
+            ..
+        } => Ok(*value),
+        other => panic!("expected integer output, got {other:?}"),
+    }
 }
 
 #[test]

--- a/tests/rulespec.rs
+++ b/tests/rulespec.rs
@@ -7,7 +7,7 @@ use axiom_rules_engine::compile::{
 use axiom_rules_engine::rulespec::{RuleSpecError, ValidationStatus, lower_rulespec_str};
 use axiom_rules_engine::spec::{
     DatasetSpec, DerivedSemanticsSpec, InputRecordSpec, IntervalSpec, PeriodKindSpec, PeriodSpec,
-    ScalarExprSpec, ScalarValueSpec,
+    ScalarExprSpec, ScalarValueSpec, SpecError,
 };
 use std::fs;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -172,6 +172,7 @@ rules:
     source: USDA SNAP FY 2026 COLA maximum monthly allotment table
     versions:
       - effective_from: 2025-10-01
+        effective_to: 2026-09-30
         values:
           1: 298
           2: 546
@@ -204,6 +205,10 @@ rules:
         .find(|parameter| parameter.name == "snap_maximum_allotment_table")
         .expect("indexed parameter is present");
     assert_eq!(table.versions.len(), 1);
+    assert_eq!(
+        table.versions[0].effective_to,
+        Some("2026-09-30".parse().expect("valid effective_to"))
+    );
     assert_eq!(table.versions[0].values.len(), 2);
     assert_eq!(table.indexed_by.as_deref(), Some("household_size"));
 
@@ -1992,6 +1997,7 @@ rules:
     unit: USD
     versions:
       - effective_from: 2026-01-01
+        effective_to: 2026-12-31
         formula: qualified_retirement_contributions
       - effective_from: 2027-01-01
         formula: able_account_contributions
@@ -2004,6 +2010,10 @@ rules:
         .find(|derived| derived.name == "savers_credit_gross_contributions")
         .expect("derived output present");
     assert_eq!(derived.versions.len(), 2);
+    assert_eq!(
+        derived.versions[0].effective_to,
+        Some("2026-12-31".parse().expect("valid effective_to"))
+    );
     assert!(matches!(
         &derived.versions[0].semantics,
         DerivedSemanticsSpec::Scalar {
@@ -2015,6 +2025,59 @@ rules:
         DerivedSemanticsSpec::Scalar {
             expr: ScalarExprSpec::Input { name },
         } if name == "able_account_contributions"
+    ));
+}
+
+#[test]
+fn rulespec_retains_single_bounded_derived_as_a_runtime_version() {
+    let rulespec = r#"
+format: rulespec/v1
+rules:
+  - name: temporary_credit
+    kind: derived
+    entity: TaxUnit
+    dtype: Money
+    period: Year
+    unit: USD
+    versions:
+      - effective_from: 2026-01-01
+        effective_to: 2026-12-31
+        formula: "100"
+"#;
+
+    let program = lower_rulespec_str(rulespec).expect("bounded derived formula lowers");
+    let derived = program
+        .derived
+        .iter()
+        .find(|derived| derived.name == "temporary_credit")
+        .expect("derived output present");
+    assert_eq!(derived.versions.len(), 1);
+    assert_eq!(
+        derived.versions[0].effective_to,
+        Some("2026-12-31".parse().expect("valid effective_to"))
+    );
+}
+
+#[test]
+fn compile_rejects_an_effective_to_before_effective_from() {
+    let rulespec = r#"
+format: rulespec/v1
+rules:
+  - name: impossible_window
+    kind: parameter
+    dtype: Integer
+    versions:
+      - effective_from: 2026-01-01
+        effective_to: 2025-12-31
+        formula: "1"
+"#;
+
+    let error = CompiledProgramArtifact::from_rulespec_str(rulespec)
+        .expect_err("an inverted effective range must fail compilation");
+    assert!(matches!(
+        error,
+        CompileError::Spec(SpecError::InvalidEffectiveRange { rule, .. })
+            if rule == "impossible_window"
     ));
 }
 

--- a/tests/schema_golden.rs
+++ b/tests/schema_golden.rs
@@ -68,7 +68,7 @@ fn artifact_schema_accepts_a_real_compiled_artifact() {
 
     let schema_value = all_schemas()
         .into_iter()
-        .find(|named| named.file_name == "compiled-artifact.v1.schema.json")
+        .find(|named| named.file_name == "compiled-artifact.v2.schema.json")
         .expect("artifact schema is published")
         .schema;
     let validator = jsonschema::draft7::new(&schema_value).expect("artifact schema compiles");
@@ -93,7 +93,7 @@ fn artifact_schema_accepts_the_annotated_divergences() {
     // `source_verification.extra` field, and a judgment/comparison expression.
     // If any of these regress, this artifact stops validating.
     let artifact = serde_json::json!({
-        "artifact_format_version": 1,
+        "artifact_format_version": 2,
         "engine_version": "0.1.0",
         "program": {
             "module": {
@@ -111,7 +111,7 @@ fn artifact_schema_accepts_the_annotated_divergences() {
             "parameters": [{
                 "id": "us:statutes/7/2017/a#p",
                 "name": "p", "unit": "USD", "indexed_by": "household_size",
-                "versions": [{"effective_from": "2020-01-01", "values": {
+                "versions": [{"effective_from": "2020-01-01", "effective_to": "2020-12-31", "values": {
                     "1": {"kind": "decimal", "value": 200},
                     "2": {"kind": "decimal", "value": "250.50"},
                     "3": {"kind": "integer", "value": 3},
@@ -142,7 +142,7 @@ fn artifact_schema_accepts_the_annotated_divergences() {
 
     let schema_value = all_schemas()
         .into_iter()
-        .find(|named| named.file_name == "compiled-artifact.v1.schema.json")
+        .find(|named| named.file_name == "compiled-artifact.v2.schema.json")
         .expect("artifact schema is published")
         .schema;
     let validator = jsonschema::draft7::new(&schema_value).expect("artifact schema compiles");
@@ -167,4 +167,30 @@ fn artifact_schema_accepts_the_annotated_divergences() {
             panic!("schema advertises dtype `{dtype}` but serde rejects it: {e}")
         });
     }
+}
+
+#[test]
+fn current_artifact_schema_rejects_missing_and_v1_versions() {
+    let fixture = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/rulespec/uksi/2013/376/rules.yaml");
+    let artifact = CompiledProgramArtifact::from_rulespec_file(&fixture)
+        .expect("fixture compiles to a v2 artifact");
+    let base = serde_json::to_value(&artifact).expect("artifact serializes");
+    let schema = all_schemas()
+        .into_iter()
+        .find(|named| named.file_name == "compiled-artifact.v2.schema.json")
+        .expect("current artifact schema is published")
+        .schema;
+    let validator = jsonschema::draft7::new(&schema).expect("artifact schema compiles");
+
+    let mut missing = base.clone();
+    missing
+        .as_object_mut()
+        .expect("artifact is an object")
+        .remove("artifact_format_version");
+    let mut v1 = base;
+    v1["artifact_format_version"] = serde_json::json!(1);
+
+    assert!(!validator.is_valid(&missing));
+    assert!(!validator.is_valid(&v1));
 }

--- a/wasm/README.md
+++ b/wasm/README.md
@@ -20,7 +20,7 @@ wasm build and the CLI cannot drift apart:
 | `compile(modules_json, root_target)` | `{canonical_target: yaml_text}` map + root target | `CompiledProgramArtifact` JSON (same format the CLI's `compile` writes) |
 | `execute(artifact_json, request_json)` | artifact JSON + `CompiledExecutionRequest` JSON (`mode`, `dataset`, `queries`) | `ExecutionResponse` JSON (same format the CLI's `execute` prints) |
 | `engine_version()` | — | core crate version string, for provenance display |
-| `artifact_format_version()` | — | newest artifact format this engine writes/accepts |
+| `artifact_format_version()` | — | exact artifact format this engine writes/accepts |
 
 Canonical targets are the `<jurisdiction>:<path>` form
 (`us:policies/usda/snap/fy-2026-cola/maximum-allotments`). Relative imports

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -72,23 +72,12 @@ pub fn compile(modules_json: &str, root_target: &str) -> Result<String, JsError>
 /// `ExecutionResponse` as JSON, byte-compatible with the CLI's `execute`
 /// subcommand output.
 ///
-/// Artifacts newer than this engine's supported format version are rejected,
-/// mirroring the core's load-time check.
+/// Missing, older, or newer artifact versions are rejected, mirroring the
+/// core's exact artifact contract.
 #[wasm_bindgen]
 pub fn execute(artifact_json: &str, request_json: &str) -> Result<String, JsError> {
-    let artifact: CompiledProgramArtifact = serde_json::from_str(artifact_json).map_err(|error| {
-        JsError::new(&format!(
-            "artifact_json is not a CompiledProgramArtifact: {error}"
-        ))
-    })?;
-    if artifact.artifact_format_version > ARTIFACT_FORMAT_VERSION {
-        return Err(JsError::new(&format!(
-            "compiled artefact has artifact_format_version {found}, but this engine supports up \
-             to {supported}; recompile the program with this engine or upgrade the engine",
-            found = artifact.artifact_format_version,
-            supported = ARTIFACT_FORMAT_VERSION,
-        )));
-    }
+    let artifact = CompiledProgramArtifact::from_json_str(artifact_json)
+        .map_err(|error| JsError::new(&error.to_string()))?;
     let request: CompiledExecutionRequest = serde_json::from_str(request_json).map_err(|error| {
         JsError::new(&format!(
             "request_json is not a CompiledExecutionRequest: {error}"
@@ -107,8 +96,7 @@ pub fn engine_version() -> String {
     axiom_rules_engine::ENGINE_VERSION.to_string()
 }
 
-/// The artifact format version this engine writes and the newest it accepts
-/// (re-exported from the core), for provenance display in UIs.
+/// The exact artifact format version this engine writes and accepts.
 #[wasm_bindgen]
 pub fn artifact_format_version() -> u32 {
     ARTIFACT_FORMAT_VERSION

--- a/wasm/test/smoke.mjs
+++ b/wasm/test/smoke.mjs
@@ -142,5 +142,11 @@ assert.throws(
   /CompiledExecutionRequest/,
   "malformed request JSON is reported",
 );
+const v1Artifact = JSON.stringify({ ...artifact, artifact_format_version: 1 });
+assert.throws(
+  () => engine.execute(v1Artifact, JSON.stringify(request)),
+  /requires exact version/,
+  "v1 artifacts are rejected by the v2 engine",
+);
 
 console.log("smoke test passed");


### PR DESCRIPTION
## Summary
- backport inclusive RuleSpec `effective_to` through lowering, executable IR, and runtime selection on top of exact v0.1 commit `e19f1b7`
- reject inverted effective ranges and fail closed across expired/gap periods
- bump compiled artifacts on this maintenance line to exact format v2, preserving archived v1 schema byte-for-byte
- update Python and WASM compatibility contracts/tests

## Compatibility scope
This deliberately preserves the v0.1 CLI and source-loading behavior used by the current rulespec-us validation toolchain: legacy environment root discovery, root-level `programs/`, and existing RuleSpec metadata/schema remain unchanged. The newer strict-root/schema migration on engine main is not part of this backport.

## Validation
- full Rust all-target/all-feature suite passed serially
- Python: 28 passed, 14 extension-dependent skips
- python-ext compile check: passed
- native WASM crate check: passed
- schema golden/conformance, formatting, and diff checks: passed
- archived v1 schema is byte-identical to e19
- independent review is in progress; PR remains draft

A first parallel Rust run hit a pre-existing shared timestamp-tempdir collision in two tests; both tests and the complete suite passed serially.