### PR TITLE
Support typed upstream source checks

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -733,3 +733,21 @@ the hook's semantics when both sides are present in the merged program.
   hooks with `source_relation.type: sets` and `source_relation.value`.
 - Lowering rejects cross-kind bindings and incompatible derived hooks instead
   of silently copying formulas across unlike concepts.
+
+## 2026-07-21 — Upstream source audits survive strict engine boundaries
+
+**Decision.** `module.source_verification` permits an optional exact
+`upstream_source_check` mapping with required string `status`, string-list
+`checked_paths`, and string `rationale`. The engine validates and preserves the
+record but does not interpret its source-authority policy.
+
+**Why.** Encoder-validated modules may use official guidance for a current
+parameter after checking higher-authority law. That audit must travel with the
+singular corpus citation through compilation without weakening strict unknown-
+field rejection.
+
+**Consequences.** RuleSpec, compiled-artifact, Python, and wasm boundaries
+accept and preserve the typed optional record. Unknown or malformed nested
+fields remain errors. The additive inert metadata does not require an artifact
+version bump; axiom-encode continues to own allowed statuses, path authority,
+and rationale-quality policy.

--- a/docs/rulespec.md
+++ b/docs/rulespec.md
@@ -434,8 +434,9 @@ is auditable.
 The `module:` block can carry inert metadata that grounds the module in source
 text and records how the encoding was produced and checked. The block itself
 is optional. When `source_verification` is present it is an exact mapping with
-one required singular `corpus_citation_path` and an optional `source_sha256`;
-unknown fields and the removed plural spelling are rejected recursively.
+one required singular `corpus_citation_path`, an optional `source_sha256`, and
+an optional typed `upstream_source_check`; unknown fields and the removed
+plural spelling are rejected recursively.
 The loader and artifact boundary validate this metadata, but it never changes
 formula semantics or execution results. The lowered `ProgramSpec` keeps the
 (merged) root module's metadata on `program.module`, and compiled artifacts pass
@@ -445,8 +446,13 @@ without re-parsing the YAML.
 ```yaml
 module:
   source_verification:
-    corpus_citation_path: us/statute/7/2017/a
+    corpus_citation_path: us/guidance/agency/annual-parameter
     source_sha256: 9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08
+    upstream_source_check:
+      status: official_parameter_source
+      checked_paths:
+        - us/statute/7/2017/a
+      rationale: The cited guidance supplies the annually determined parameter.
   encoding_provenance:
     encoder: axiom-encode/0.2.645
     model: claude-fable-5
@@ -468,7 +474,14 @@ module:
   mechanical "this module is stale" signal; `axiom-encode
   check-source-staleness` does exactly that. The value must be 64
   hexadecimal characters — anything else is rejected at load with an error
-  naming the module file. No other `source_verification` subfields are allowed.
+  naming the module file.
+- Optional `source_verification.upstream_source_check` preserves an encoder-
+  validated higher-authority audit with required `status` (string),
+  `checked_paths` (list of strings), and `rationale` (string). The nested
+  mapping is exact, so misspelled or additional keys are rejected. The engine
+  validates structure only; axiom-encode owns allowed statuses, authority
+  classification, and rationale-quality policy.
+- No other `source_verification` subfields are allowed.
 - `encoding_provenance` records the encoding tool (`encoder`, for example
   `axiom-encode/0.2.645`), `model`, `run_id`, and human `reviewed_by` — all
   optional strings. Unknown subfields are rejected so typos cannot pass for

--- a/python/axiom_rules_engine/concepts.py
+++ b/python/axiom_rules_engine/concepts.py
@@ -542,7 +542,11 @@ def _validate_atomic_document(
     if verification is not None:
         if not isinstance(verification, dict):
             raise ValueError(f"source_verification must be an exact mapping: {path}")
-        if set(verification) - {"corpus_citation_path", "source_sha256"}:
+        if set(verification) - {
+            "corpus_citation_path",
+            "source_sha256",
+            "upstream_source_check",
+        }:
             raise ValueError(f"source_verification contains unknown fields: {path}")
         citation = verification.get("corpus_citation_path")
         if not isinstance(citation, str) or CORPUS_CITATION_PATH_RE.fullmatch(citation) is None:
@@ -555,6 +559,30 @@ def _validate_atomic_document(
             or re.fullmatch(r"[0-9A-Fa-f]{64}", digest) is None
         ):
             raise ValueError(f"source_sha256 must be 64 hexadecimal characters: {path}")
+        upstream_check = verification.get("upstream_source_check")
+        if upstream_check is not None:
+            if not isinstance(upstream_check, dict) or set(upstream_check) != {
+                "status",
+                "checked_paths",
+                "rationale",
+            }:
+                raise ValueError(
+                    "upstream_source_check must contain exactly status, "
+                    f"checked_paths, and rationale: {path}"
+                )
+            if not isinstance(upstream_check["status"], str):
+                raise ValueError(f"upstream_source_check status must be a string: {path}")
+            checked_paths = upstream_check["checked_paths"]
+            if not isinstance(checked_paths, list) or not all(
+                isinstance(checked_path, str) for checked_path in checked_paths
+            ):
+                raise ValueError(
+                    f"upstream_source_check checked_paths must be a list of strings: {path}"
+                )
+            if not isinstance(upstream_check["rationale"], str):
+                raise ValueError(
+                    f"upstream_source_check rationale must be a string: {path}"
+                )
 
     _validate_recursive_citation_fields(document, path)
     _validate_rule_shapes(document.get("rules"), path)

--- a/python/tests/test_concepts.py
+++ b/python/tests/test_concepts.py
@@ -258,7 +258,15 @@ def test_concepts_reject_yml_wrong_country_and_missing_explicit_root(
         ),
         (
             "format: rulespec/v1\nmodule:\n  source_verification:\n    corpus_citation_path: us/statute/26/62\n    upstream_source_check: {}\nrules: []",
-            "unknown fields",
+            "must contain exactly status, checked_paths, and rationale",
+        ),
+        (
+            "format: rulespec/v1\nmodule:\n  source_verification:\n    corpus_citation_path: us/guidance/treasury/rate\n    upstream_source_check:\n      status: official_parameter_source\n      checked_paths: [42]\n      rationale: checked\nrules: []",
+            "checked_paths must be a list of strings",
+        ),
+        (
+            "format: rulespec/v1\nmodule:\n  source_verification:\n    corpus_citation_path: us/guidance/treasury/rate\n    upstream_source_check:\n      status: official_parameter_source\n      checked_paths: [us/statute/26/62]\n      rationale: checked\n      note: typo\nrules: []",
+            "must contain exactly status, checked_paths, and rationale",
         ),
         (
             "format: rulespec/v1\nmodule:\n  source_verification:\n    corpus_citation_path: us/statute\nrules: []",
@@ -326,6 +334,28 @@ rules: []
     )
     concepts = discover_concepts([root.resolve()])
     assert concepts[0].concept_id == "uk-kingston-upon-thames:policies/ctr/2026"
+
+
+def test_concepts_accept_typed_upstream_source_check(tmp_path: Path) -> None:
+    root = canonical_root(tmp_path)
+    write_rulespec(
+        root,
+        "us/policies/treasury/rate.yaml",
+        """
+format: rulespec/v1
+module:
+  source_verification:
+    corpus_citation_path: us/guidance/treasury/rate
+    upstream_source_check:
+      status: official_parameter_source
+      checked_paths:
+        - us/statute/26/62
+      rationale: The official guidance supplies the current annual parameter.
+rules: []
+""",
+    )
+    concepts = discover_concepts([root])
+    assert concepts[0].concept_id == "us:policies/treasury/rate"
 
 
 def test_concepts_reject_case_aliased_root_on_case_insensitive_filesystems(

--- a/python/tests/test_dense_surface.py
+++ b/python/tests/test_dense_surface.py
@@ -24,6 +24,13 @@ module:
   summary: |-
     Dense-surface test fixture: a two-bracket flat tax with a boolean
     exemption predicate, exercising metadata, Decimal and f64 execution.
+  source_verification:
+    corpus_citation_path: us/guidance/tests/dense-flat-tax
+    upstream_source_check:
+      status: official_parameter_source
+      checked_paths:
+        - us/statute/tests/dense-flat-tax
+      rationale: The synthetic guidance supplies the current test parameters.
 units:
   - name: EUR
     kind: currency

--- a/schemas/compiled-artifact.v2.schema.json
+++ b/schemas/compiled-artifact.v2.schema.json
@@ -1762,7 +1762,7 @@
           }
         }
       ],
-      "description": "Grounding of a module in legal source text. `corpus_citation_path`\naddresses the provision in the Axiom corpus; `source_sha256` pins the\nSHA-256 hex digest of the exact provision text the module was encoded\nfrom, so tooling can detect mechanically when the published source has\nchanged out from under the encoding. The mapping is exact: the singular\ncitation path is required and unknown/plural fields are rejected.",
+      "description": "Grounding of a module in legal source text. `corpus_citation_path`\naddresses the provision in the Axiom corpus; `source_sha256` pins the\nSHA-256 hex digest of the exact provision text the module was encoded\nfrom, so tooling can detect mechanically when the published source has\nchanged out from under the encoding. `upstream_source_check` records the\nhigher-authority sources checked before using guidance or another\nimplementation source. The mapping is exact: the singular citation path\nis required and unknown/plural fields are rejected.",
       "properties": {
         "corpus_citation_path": {
           "pattern": "^[a-z]{2,3}(?:-[a-z0-9]+)*/[a-z][a-z0-9-]*(?:/[A-Za-z0-9](?:[A-Za-z0-9 .:\\-–]*[A-Za-z0-9.:\\-–])?)+$",
@@ -1773,6 +1773,16 @@
           "type": [
             "string",
             "null"
+          ]
+        },
+        "upstream_source_check": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/UpstreamSourceCheck"
+            },
+            {
+              "type": "null"
+            }
           ]
         }
       },
@@ -1916,6 +1926,39 @@
       },
       "required": [
         "name"
+      ],
+      "type": "object"
+    },
+    "UpstreamSourceCheck": {
+      "additionalProperties": false,
+      "allOf": [
+        {
+          "not": {
+            "required": [
+              "corpus_citation_paths"
+            ]
+          }
+        }
+      ],
+      "description": "Structural record of a higher-authority source audit. The encoder owns\nsemantic policy for accepted statuses, path authority, and rationale\nquality; the engine preserves the exact typed record in compiled artifacts.",
+      "properties": {
+        "checked_paths": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "rationale": {
+          "type": "string"
+        },
+        "status": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "status",
+        "checked_paths",
+        "rationale"
       ],
       "type": "object"
     },

--- a/schemas/rulespec-module.v1.schema.json
+++ b/schemas/rulespec-module.v1.schema.json
@@ -106,7 +106,10 @@
                 "checked_paths",
                 "rationale"
               ],
-              "type": "object"
+              "type": [
+                "object",
+                "null"
+              ]
             }
           },
           "required": [

--- a/schemas/rulespec-module.v1.schema.json
+++ b/schemas/rulespec-module.v1.schema.json
@@ -84,6 +84,29 @@
               "description": "SHA-256 hex digest of the exact provision text. Validated at load — must be 64 hex chars.",
               "pattern": "^[0-9a-fA-F]{64}$",
               "type": "string"
+            },
+            "upstream_source_check": {
+              "additionalProperties": false,
+              "properties": {
+                "checked_paths": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "rationale": {
+                  "type": "string"
+                },
+                "status": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "status",
+                "checked_paths",
+                "rationale"
+              ],
+              "type": "object"
             }
           },
           "required": [

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -411,12 +411,15 @@ fn validate_raw_provenance_value(
                 };
                 if !verification.contains_key("corpus_citation_path")
                     || verification.keys().any(|key| {
-                        !matches!(key.as_str(), "corpus_citation_path" | "source_sha256")
+                        !matches!(
+                            key.as_str(),
+                            "corpus_citation_path" | "source_sha256" | "upstream_source_check"
+                        )
                     })
                 {
                     return Err(invalid_artifact_contract(
                         path,
-                        "source_verification requires one singular corpus_citation_path and optional source_sha256 only",
+                        "source_verification requires one singular corpus_citation_path and permits only optional source_sha256 and upstream_source_check metadata",
                     ));
                 }
             }

--- a/src/rulespec.rs
+++ b/src/rulespec.rs
@@ -298,8 +298,10 @@ impl ModuleMetadata {
 /// addresses the provision in the Axiom corpus; `source_sha256` pins the
 /// SHA-256 hex digest of the exact provision text the module was encoded
 /// from, so tooling can detect mechanically when the published source has
-/// changed out from under the encoding. The mapping is exact: the singular
-/// citation path is required and unknown/plural fields are rejected.
+/// changed out from under the encoding. `upstream_source_check` records the
+/// higher-authority sources checked before using guidance or another
+/// implementation source. The mapping is exact: the singular citation path
+/// is required and unknown/plural fields are rejected.
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[serde(deny_unknown_fields)]
@@ -307,6 +309,23 @@ pub struct SourceVerification {
     pub corpus_citation_path: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub source_sha256: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub upstream_source_check: Option<UpstreamSourceCheck>,
+}
+
+/// Structural record of a higher-authority source audit. The encoder owns
+/// semantic policy for accepted statuses, path authority, and rationale
+/// quality; the engine preserves the exact typed record in compiled artifacts.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[serde(deny_unknown_fields)]
+pub struct UpstreamSourceCheck {
+    #[serde(deserialize_with = "deserialize_strict_string")]
+    pub status: String,
+    #[serde(deserialize_with = "deserialize_strict_string_list")]
+    pub checked_paths: Vec<String>,
+    #[serde(deserialize_with = "deserialize_strict_string")]
+    pub rationale: String,
 }
 
 /// Who and what produced the encoding: tool (`encoder`, for example
@@ -3416,6 +3435,34 @@ where
             "expected scalar string-like value, got {other:?}"
         ))),
     }
+}
+
+fn deserialize_strict_string<'de, D>(deserializer: D) -> Result<String, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    match serde_yaml::Value::deserialize(deserializer)? {
+        serde_yaml::Value::String(value) => Ok(value),
+        other => Err(serde::de::Error::custom(format!(
+            "expected string, got {other:?}"
+        ))),
+    }
+}
+
+fn deserialize_strict_string_list<'de, D>(deserializer: D) -> Result<Vec<String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let values = Vec::<serde_yaml::Value>::deserialize(deserializer)?;
+    values
+        .into_iter()
+        .map(|value| match value {
+            serde_yaml::Value::String(value) => Ok(value),
+            other => Err(serde::de::Error::custom(format!(
+                "expected string in list, got {other:?}"
+            ))),
+        })
+        .collect()
 }
 
 fn deserialize_parameter_value_map<'de, D>(

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -430,7 +430,7 @@ fn source_verification_schema() -> Value {
                 "pattern": "^[0-9a-fA-F]{64}$",
                 "description": "SHA-256 hex digest of the exact provision text. Validated at load — must be 64 hex chars."
             },
-            "upstream_source_check": upstream_source_check_schema()
+            "upstream_source_check": nullable_object(upstream_source_check_schema())
         }
     })
 }

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -129,7 +129,8 @@ fn archived_compiled_artifact_v1_schema() -> Value {
 /// - `usize` slot fields serialize as JSON numbers; schemars describes them as
 ///   non-negative integers, which is correct.
 /// - `SourceVerification` is an exact mapping with one required singular
-///   corpus citation path and an optional source digest.
+///   corpus citation path, an optional source digest, and an optional typed
+///   higher-authority source check.
 #[cfg(feature = "schema")]
 pub fn compiled_artifact_schema() -> Value {
     let mut schema = serde_json::to_value(schema_for!(crate::compile::CompiledProgramArtifact))
@@ -411,7 +412,8 @@ fn module_metadata_schema() -> Value {
 }
 
 /// `module.source_verification` — [`crate::rulespec::SourceVerification`].
-/// Exact mapping: one required singular corpus path, plus an optional digest.
+/// Exact mapping: one required singular corpus path, plus an optional digest
+/// and typed higher-authority source check.
 fn source_verification_schema() -> Value {
     json!({
         "type": "object",
@@ -427,7 +429,27 @@ fn source_verification_schema() -> Value {
                 "type": "string",
                 "pattern": "^[0-9a-fA-F]{64}$",
                 "description": "SHA-256 hex digest of the exact provision text. Validated at load — must be 64 hex chars."
-            }
+            },
+            "upstream_source_check": upstream_source_check_schema()
+        }
+    })
+}
+
+/// `module.source_verification.upstream_source_check` —
+/// [`crate::rulespec::UpstreamSourceCheck`]. Structural fidelity is enforced
+/// here; status and authority semantics remain encoder policy.
+fn upstream_source_check_schema() -> Value {
+    json!({
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["status", "checked_paths", "rationale"],
+        "properties": {
+            "status": { "type": "string" },
+            "checked_paths": {
+                "type": "array",
+                "items": { "type": "string" }
+            },
+            "rationale": { "type": "string" }
         }
     })
 }

--- a/tests/rulespec.rs
+++ b/tests/rulespec.rs
@@ -2555,8 +2555,13 @@ format: rulespec/v1
 module:
   title: SNAP allotment
   source_verification:
-    corpus_citation_path: us/statute/7/2017/a
+    corpus_citation_path: us/guidance/agency/annual-parameter
     source_sha256: 9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08
+    upstream_source_check:
+      status: official_parameter_source
+      checked_paths:
+        - us/statute/7/2017/a
+      rationale: The cited guidance supplies the annually determined parameter.
   encoding_provenance:
     encoder: axiom-encode/0.2.645
     model: claude-fable-5
@@ -2594,10 +2599,23 @@ rules:
         .source_verification
         .as_ref()
         .expect("source verification block survives");
-    assert_eq!(verification.corpus_citation_path, "us/statute/7/2017/a");
+    assert_eq!(
+        verification.corpus_citation_path,
+        "us/guidance/agency/annual-parameter"
+    );
     assert_eq!(
         verification.source_sha256.as_deref(),
         Some("9f86d081884c7d659a2feaa0c55ad015a3bf4f1b2b0b822cd15d6c15b0f00a08")
+    );
+    let upstream_check = verification
+        .upstream_source_check
+        .as_ref()
+        .expect("upstream source check survives");
+    assert_eq!(upstream_check.status, "official_parameter_source");
+    assert_eq!(upstream_check.checked_paths, ["us/statute/7/2017/a"]);
+    assert_eq!(
+        upstream_check.rationale,
+        "The cited guidance supplies the annually determined parameter."
     );
     let provenance = module
         .encoding_provenance
@@ -2726,6 +2744,40 @@ fn rulespec_rejects_plural_missing_and_noncanonical_corpus_paths_recursively() {
         assert!(
             lower_rulespec_str(source).is_err(),
             "{label} must fail the canonical singular citation contract"
+        );
+    }
+}
+
+#[test]
+fn rulespec_rejects_malformed_upstream_source_checks() {
+    for (label, check) in [
+        (
+            "missing rationale",
+            "status: official_parameter_source\n      checked_paths: [us/statute/7/2017/a]",
+        ),
+        (
+            "non-string checked path",
+            "status: official_parameter_source\n      checked_paths: [42]\n      rationale: checked",
+        ),
+        (
+            "non-string status",
+            "status: 42\n      checked_paths: [us/statute/7/2017/a]\n      rationale: checked",
+        ),
+        (
+            "non-string rationale",
+            "status: official_parameter_source\n      checked_paths: [us/statute/7/2017/a]\n      rationale: 42",
+        ),
+        (
+            "unknown nested field",
+            "status: official_parameter_source\n      checked_paths: [us/statute/7/2017/a]\n      rationale: checked\n      note: typo",
+        ),
+    ] {
+        let source = format!(
+            "format: rulespec/v1\nmodule:\n  source_verification:\n    corpus_citation_path: us/guidance/treasury/rate\n    upstream_source_check:\n      {check}\nrules: []\n"
+        );
+        assert!(
+            lower_rulespec_str(&source).is_err(),
+            "{label} must fail the exact upstream source check contract"
         );
     }
 }

--- a/tests/schema_fidelity.rs
+++ b/tests/schema_fidelity.rs
@@ -185,7 +185,7 @@ fn bad_source_sha256_is_rejected_by_pattern() {
         "a non-64-hex source_sha256 must fail the schema pattern"
     );
     let good = format!(
-        "format: rulespec/v1\nmodule:\n  source_verification:\n    corpus_citation_path: us/statute/7/2017/a\n    source_sha256: '{}'\nrules: []\n",
+        "format: rulespec/v1\nmodule:\n  source_verification:\n    corpus_citation_path: us/guidance/treasury/rate\n    source_sha256: '{}'\n    upstream_source_check:\n      status: official_parameter_source\n      checked_paths: [us/statute/7/2017/a]\n      rationale: Guidance supplies the current annual parameter.\nrules: []\n",
         "a".repeat(64)
     );
     let good_value: Value = serde_yaml::from_str(&good).expect("valid yaml");
@@ -194,6 +194,7 @@ fn bad_source_sha256_is_rejected_by_pattern() {
     for invalid in [
         "format: rulespec/v1\nmodule:\n  source_verification:\n    source_sha256: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\nrules: []\n",
         "format: rulespec/v1\nmodule:\n  source_verification:\n    corpus_citation_paths: [us/statute/7/2017/a]\nrules: []\n",
+        "format: rulespec/v1\nmodule:\n  source_verification:\n    corpus_citation_path: us/guidance/treasury/rate\n    upstream_source_check:\n      status: official_parameter_source\n      checked_paths: [us/statute/7/2017/a]\n      rationale: checked\n      note: unknown\nrules: []\n",
     ] {
         let value: Value = serde_yaml::from_str(invalid).expect("valid yaml");
         assert!(!v.is_valid(&value), "invalid source verification must fail");

--- a/tests/schema_fidelity.rs
+++ b/tests/schema_fidelity.rs
@@ -115,6 +115,11 @@ fn schema_accepts_what_serde_accepts() {
         "validation-null",
         "format: rulespec/v1\nmodule:\n  validation:\nrules: []\n",
     );
+    assert_agrees(
+        &v,
+        "upstream-source-check-null",
+        "format: rulespec/v1\nmodule:\n  source_verification:\n    corpus_citation_path: us/guidance/treasury/rate\n    upstream_source_check:\nrules: []\n",
+    );
     // String-like coercion: a numeric unit.
     assert_agrees(
         &v,

--- a/tests/schema_golden.rs
+++ b/tests/schema_golden.rs
@@ -100,7 +100,12 @@ fn artifact_schema_accepts_the_annotated_divergences() {
             "module": {
                 "source_verification": {
                     "corpus_citation_path": "us/statute/7/2017/a",
-                    "source_sha256": "a".repeat(64)
+                    "source_sha256": "a".repeat(64),
+                    "upstream_source_check": {
+                        "status": "official_parameter_source",
+                        "checked_paths": ["us/statute/7/2017/a"],
+                        "rationale": "The official guidance supplies the current parameter."
+                    }
                 },
                 "encoding_provenance": {"encoder": "axiom-encode/0.2"},
                 "validation": [{"oracle": "taxsim", "status": "matches", "last_run": "2026-06-01"}]
@@ -194,6 +199,22 @@ fn artifact_schema_rejects_wrong_version_and_invalid_provenance() {
         serde_json::json!({"corpus_citation_path": "us/statute"}),
         serde_json::json!({"corpus_citation_path": "us/statute/26/62", "source_sha256": "bad"}),
         serde_json::json!({"corpus_citation_paths": ["us/statute/26/62"]}),
+        serde_json::json!({
+            "corpus_citation_path": "us/guidance/treasury/rate",
+            "upstream_source_check": {
+                "status": "official_parameter_source",
+                "checked_paths": ["us/statute/26/62"],
+                "rationale": "checked",
+                "note": "unknown"
+            }
+        }),
+        serde_json::json!({
+            "corpus_citation_path": "us/guidance/treasury/rate",
+            "upstream_source_check": {
+                "status": "official_parameter_source",
+                "checked_paths": ["us/statute/26/62"]
+            }
+        }),
     ] {
         let mut value = base.clone();
         value["program"]["module"] = serde_json::json!({"source_verification": verification});

--- a/wasm/test/smoke.mjs
+++ b/wasm/test/smoke.mjs
@@ -46,6 +46,14 @@ const STATE_MODULE = `
 format: rulespec/v1
 imports:
   - ${FEDERAL_TARGET}
+module:
+  source_verification:
+    corpus_citation_path: us-co/guidance/cdhs/snap/fy-2026-benefit
+    upstream_source_check:
+      status: official_parameter_source
+      checked_paths:
+        - us/statute/7/2017/a
+      rationale: The state guidance supplies the current implementation parameter.
 rules:
   - name: snap_household_food_contribution_rate
     kind: parameter
@@ -85,6 +93,14 @@ assert.ok(
   artifact.program.derived.some((derived) => derived.id === OUTPUT_ID),
   `compiled program exposes ${OUTPUT_ID}`,
 );
+assert.deepEqual(artifact.program.module.source_verification, {
+  corpus_citation_path: "us-co/guidance/cdhs/snap/fy-2026-benefit",
+  upstream_source_check: {
+    status: "official_parameter_source",
+    checked_paths: ["us/statute/7/2017/a"],
+    rationale: "The state guidance supplies the current implementation parameter.",
+  },
+});
 
 // execute: CompiledExecutionRequest JSON -> ExecutionResponse JSON, exactly
 // the CLI's request/response shapes.


### PR DESCRIPTION
## Summary

- allow optional exact `module.source_verification.upstream_source_check` metadata with required string `status`, string-list `checked_paths`, and string `rationale`
- preserve strict rejection of plural/unknown source-verification fields and reject malformed nested records
- carry the typed metadata through compiled artifact v2, Python/PyO3, wasm, and published schemas without changing evaluation semantics or bumping the artifact version

## Michigan reproduction

The historical Michigan 2026 rate-determination module was reproduced with one singular Treasury-notice `corpus_citation_path` plus its statute/guidance `upstream_source_check`.

- pinned release engine `ffd8213` already validates, compiles, and passes its fixture
- pre-change strict `main` rejected `upstream_source_check` as unknown
- this branch compiles the exact module and preserves the full typed record in the v2 artifact

This leaves the pinned campaign engine untouched while preventing the next strict engine pin from dropping validated Treasury-notice proofs.

## Validation

- `cargo fmt --all -- --check`
- `cargo test`
- `cargo test --features schema`
- `cargo check --manifest-path python-ext/Cargo.toml`
- `cargo check --target wasm32-unknown-unknown --no-default-features`
- Python 3.14 native extension build/import and `68 passed`
- wasm-pack nodejs + web builds and Node smoke test
- exact Michigan strict-main compile and artifact metadata inspection

## Review cycle

Independent review of `37d0007` found one low-severity RuleSpec-schema nullability mismatch. Fixed in `2f3b00d`, regenerated the schema, added a schema/serde fidelity regression, and reran focused checks. Independent re-review of exact HEAD `2f3b00df69d9b41fcb798ba1308d61dd68a230ee` found no remaining actionable findings.