### PR TITLE
Publish the wasm engine to npm: @axiom-foundation/rules-engine-wasm

### DIFF
--- a/.github/workflows/wasm-npm.yml
+++ b/.github/workflows/wasm-npm.yml
@@ -1,0 +1,69 @@
+name: wasm npm package
+
+# Builds @axiom-foundation/rules-engine-wasm (both wasm-pack targets, one
+# package). PRs touching the wasm crate get a build + pack dry-run; pushing a
+# `wasm-npm-v*` tag publishes to npm with provenance.
+#
+# Publishing needs the NPM_TOKEN repo secret (an npm automation token for the
+# @axiom-foundation org).
+
+on:
+  pull_request:
+    paths:
+      - "wasm/**"
+      - ".github/workflows/wasm-npm.yml"
+  push:
+    tags:
+      - "wasm-npm-v*"
+
+permissions:
+  contents: read
+  id-token: write # npm provenance
+
+jobs:
+  build:
+    name: build · pack${{ startsWith(github.ref, 'refs/tags/wasm-npm-v') && ' · publish' || '' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6.0.2
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Cache cargo registry and build
+        uses: Swatinem/rust-cache@v2.9.1
+
+      - name: Install wasm-pack
+        run: cargo install wasm-pack --locked
+
+      - name: Set up Node (with npm registry for provenance)
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Derive version from tag
+        id: version
+        run: |
+          if [[ "$GITHUB_REF" == refs/tags/wasm-npm-v* ]]; then
+            echo "version=${GITHUB_REF#refs/tags/wasm-npm-v}" >> "$GITHUB_OUTPUT"
+          else
+            echo "version=" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Assemble the package
+        run: node wasm/npm/build-npm.mjs ${{ steps.version.outputs.version }}
+
+      - name: Pack (dry run)
+        run: npm pack --dry-run ./wasm/npm-dist
+
+      - name: Smoke the assembled package
+        run: node wasm/npm/smoke-dist.mjs
+
+      - name: Publish
+        if: startsWith(github.ref, 'refs/tags/wasm-npm-v')
+        run: npm publish ./wasm/npm-dist --access public --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,8 @@ paper/_build/
 
 # setuptools build output from pip installs of python/
 python/build/
+
+# wasm npm packaging outputs
+wasm/pkg-npm-web/
+wasm/pkg-npm-node/
+wasm/npm-dist/

--- a/wasm/npm/README.md
+++ b/wasm/npm/README.md
@@ -1,0 +1,64 @@
+# @axiom-foundation/rules-engine-wasm
+
+The [Axiom rules engine](https://github.com/TheAxiomFoundation/axiom-rules-engine)
+compiled to WebAssembly: compile and execute RuleSpec law encodings — statutes,
+regulations, and policy as versioned, citable programs — in the browser or in
+Node. No server, no network: household facts never leave the process.
+
+Both wasm-pack targets ship in this package:
+
+- **`.` (default, ESM/browsers/bundlers)** — the `web` build; call the default
+  export to instantiate before use.
+- **`./node` (CommonJS)** — the `nodejs` build; loads the binary from disk,
+  ready on require.
+
+## Browser / bundler
+
+```js
+import init, { compile, execute, engine_version } from "@axiom-foundation/rules-engine-wasm";
+
+await init(); // fetches and instantiates the .wasm (bundlers resolve the asset)
+
+// A RuleSpec program is a map of canonical targets to YAML module text.
+const artifactJson = compile(JSON.stringify(modules), rootTarget);
+
+// …or execute a precompiled artifact you downloaded and hash-verified.
+const response = JSON.parse(execute(artifactJson, JSON.stringify(request)));
+```
+
+## Node
+
+```js
+const engine = require("@axiom-foundation/rules-engine-wasm/node");
+const response = JSON.parse(engine.execute(artifactJson, JSON.stringify(request)));
+```
+
+## The JSON boundary
+
+`compile(modules_json, root_target) -> artifact_json` takes
+`{"<canonical target>": "<RuleSpec YAML>", …}` and returns a compiled program
+artifact carrying `engine_version`, `artifact_format_version`, and every
+rule's durable legal id.
+
+`execute(artifact_json, request_json) -> response_json` takes a
+`CompiledExecutionRequest` — a dataset of typed input records and relation
+tuples plus queries — and returns outputs with an explain-mode trace whose
+every value cites the statute, regulation, or answer it came from.
+
+`engine_version()` and `artifact_format_version()` report what this build
+compiles and accepts.
+
+## Reference consumers
+
+- [axiom-playground](https://github.com/TheAxiomFoundation/axiom-playground) —
+  full composed programs (Colorado SNAP, federal income tax, …) executing
+  in-tab, with descriptors, screening presumptions, and a citation-trace UI.
+  Its `src/lib/` shows request building and trace reconstruction against this
+  boundary.
+- [axiom-reg-demo](https://github.com/TheAxiomFoundation/axiom-reg-demo) — a
+  UK Companies Act determination in the browser.
+
+## Provenance
+
+Published from CI with npm provenance attestations; the workflow, the crate,
+and the engine source are one repository. Apache-2.0.

--- a/wasm/npm/build-npm.mjs
+++ b/wasm/npm/build-npm.mjs
@@ -1,0 +1,104 @@
+#!/usr/bin/env node
+/**
+ * Assembles the publishable npm package for the wasm engine:
+ * `@axiom-foundation/rules-engine-wasm`, both wasm-pack targets in one
+ * package — `web` (browsers/bundlers, ESM with a default init) and `node`
+ * (CommonJS, loads the binary from disk). Consumers:
+ *
+ *   import init, { compile, execute } from "@axiom-foundation/rules-engine-wasm";
+ *   const engine = require("@axiom-foundation/rules-engine-wasm/node");
+ *
+ * Usage (from wasm/):  node npm/build-npm.mjs [version]
+ * Output:              wasm/npm-dist/  (publish with: npm publish npm-dist/)
+ *
+ * No dependencies; needs wasm-pack and a Rust toolchain on PATH.
+ */
+
+import { execFileSync } from "node:child_process";
+import { cpSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const wasmDir = join(dirname(fileURLToPath(import.meta.url)), "..");
+const dist = join(wasmDir, "npm-dist");
+
+const cargoToml = readFileSync(join(wasmDir, "Cargo.toml"), "utf8");
+const crateVersion = /\nversion = "([^"]+)"/.exec(cargoToml)?.[1];
+const version = process.argv[2] ?? crateVersion;
+if (!version) throw new Error("No version: pass one or set it in Cargo.toml");
+
+for (const [target, outDir] of [
+  ["web", "pkg-npm-web"],
+  ["nodejs", "pkg-npm-node"],
+]) {
+  console.log(`wasm-pack build --target ${target}…`);
+  execFileSync(
+    "wasm-pack",
+    ["build", "--release", "--target", target, "--out-dir", outDir, "--no-pack"],
+    { cwd: wasmDir, stdio: "inherit" },
+  );
+}
+
+rmSync(dist, { recursive: true, force: true });
+mkdirSync(join(dist, "web"), { recursive: true });
+mkdirSync(join(dist, "node"), { recursive: true });
+
+const KEEP = /\.(js|d\.ts|wasm)$/;
+for (const [src, dest] of [
+  ["pkg-npm-web", "web"],
+  ["pkg-npm-node", "node"],
+]) {
+  cpSync(join(wasmDir, src), join(dist, dest), {
+    recursive: true,
+    filter: (path) => !path.includes(".") || KEEP.test(path) || path.endsWith(src),
+  });
+}
+cpSync(join(wasmDir, "LICENSE"), join(dist, "LICENSE"));
+cpSync(join(wasmDir, "npm", "README.md"), join(dist, "README.md"));
+
+const glue = "axiom_rules_engine_wasm";
+writeFileSync(
+  join(dist, "package.json"),
+  JSON.stringify(
+    {
+      name: "@axiom-foundation/rules-engine-wasm",
+      version,
+      description:
+        "The Axiom rules engine compiled to WebAssembly: compile and execute RuleSpec law encodings in the browser or Node, no server involved.",
+      license: "Apache-2.0",
+      repository: {
+        type: "git",
+        url: "git+https://github.com/TheAxiomFoundation/axiom-rules-engine.git",
+        directory: "wasm",
+      },
+      homepage: "https://github.com/TheAxiomFoundation/axiom-rules-engine/tree/main/wasm",
+      keywords: ["rulespec", "rules-engine", "wasm", "law", "benefits", "tax"],
+      main: `./node/${glue}.js`,
+      module: `./web/${glue}.js`,
+      types: `./web/${glue}.d.ts`,
+      exports: {
+        ".": {
+          types: `./web/${glue}.d.ts`,
+          node: `./node/${glue}.js`,
+          default: `./web/${glue}.js`,
+        },
+        "./node": {
+          types: `./node/${glue}.d.ts`,
+          default: `./node/${glue}.js`,
+        },
+        "./web/*": "./web/*",
+      },
+      files: ["web", "node", "README.md", "LICENSE"],
+      sideEffects: false,
+    },
+    null,
+    2,
+  ),
+);
+
+// Scoped module-type markers: the web build is ESM, the node build is
+// CommonJS — a root "type" would misdeclare one of them.
+writeFileSync(join(dist, "web", "package.json"), JSON.stringify({ type: "module" }, null, 2));
+writeFileSync(join(dist, "node", "package.json"), JSON.stringify({ type: "commonjs" }, null, 2));
+
+console.log(`assembled ${dist} as @axiom-foundation/rules-engine-wasm@${version}`);

--- a/wasm/npm/smoke-dist.mjs
+++ b/wasm/npm/smoke-dist.mjs
@@ -1,0 +1,115 @@
+// Smoke test for the ASSEMBLED npm package (wasm/npm-dist): the node target
+// must compile and execute the same federal+state pair test/smoke.mjs runs,
+// and the web target's files must be present for bundler consumers.
+// Run after build-npm.mjs:  node wasm/npm/smoke-dist.mjs
+
+import assert from "node:assert/strict";
+import { readFileSync, existsSync } from "node:fs";
+import { createRequire } from "node:module";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const dist = join(dirname(fileURLToPath(import.meta.url)), "..", "npm-dist");
+const require = createRequire(import.meta.url);
+const engine = require(join(dist, "node", "axiom_rules_engine_wasm.js"));
+
+const FEDERAL_TARGET = "us:policies/usda/snap/fy-2026-cola/maximum-allotments";
+const STATE_TARGET = "us-co:policies/cdhs/snap/fy-2026-benefit";
+const OUTPUT_ID = `${STATE_TARGET}#snap_regular_month_allotment`;
+
+const modules = {
+  [FEDERAL_TARGET]: `
+format: rulespec/v1
+rules:
+  - name: snap_maximum_allotment_table
+    kind: parameter
+    dtype: Money
+    unit: USD
+    indexed_by: household_size
+    versions:
+      - effective_from: 2025-10-01
+        values:
+          1: 298
+          2: 546
+  - name: snap_maximum_allotment
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    versions:
+      - effective_from: 2025-10-01
+        formula: snap_maximum_allotment_table[household_size]
+`,
+  [STATE_TARGET]: `
+format: rulespec/v1
+imports:
+  - ${FEDERAL_TARGET}
+rules:
+  - name: snap_household_food_contribution_rate
+    kind: parameter
+    dtype: Rate
+    versions:
+      - effective_from: 2025-10-01
+        formula: "0.30"
+  - name: snap_regular_month_allotment
+    kind: derived
+    entity: Household
+    dtype: Money
+    period: Month
+    unit: USD
+    versions:
+      - effective_from: 2025-10-01
+        formula: floor(snap_maximum_allotment - (net_income * snap_household_food_contribution_rate))
+`,
+};
+
+const artifactJson = engine.compile(JSON.stringify(modules), STATE_TARGET);
+const interval = { start: "2026-01-01", end: "2026-01-31" };
+const request = {
+  mode: "explain",
+  dataset: {
+    inputs: [
+      {
+        name: `${FEDERAL_TARGET}#input.household_size`,
+        entity: "Household",
+        entity_id: "household-1",
+        interval,
+        value: { kind: "integer", value: 1 },
+      },
+      {
+        name: `${STATE_TARGET}#input.net_income`,
+        entity: "Household",
+        entity_id: "household-1",
+        interval,
+        value: { kind: "decimal", value: "100" },
+      },
+    ],
+    relations: [],
+  },
+  queries: [
+    { entity_id: "household-1", period: { period_kind: "month", ...interval }, outputs: [OUTPUT_ID] },
+  ],
+};
+const response = JSON.parse(engine.execute(artifactJson, JSON.stringify(request)));
+const output = response.results[0].outputs[OUTPUT_ID];
+assert.equal(output.value.value, "268");
+
+// The web target ships alongside, assets intact, and the manifest exports both.
+for (const file of [
+  "web/axiom_rules_engine_wasm.js",
+  "web/axiom_rules_engine_wasm_bg.wasm",
+  "web/axiom_rules_engine_wasm.d.ts",
+  "README.md",
+  "LICENSE",
+]) {
+  assert.ok(existsSync(join(dist, file)), `missing ${file}`);
+}
+const manifest = JSON.parse(readFileSync(join(dist, "package.json"), "utf8"));
+assert.equal(manifest.name, "@axiom-foundation/rules-engine-wasm");
+assert.ok(manifest.exports["."], "missing root export");
+assert.ok(manifest.exports["./node"], "missing ./node export");
+
+console.log(
+  `npm-dist smoke: 268 ✓ — ${manifest.name}@${manifest.version}, web+node targets present`,
+);


### PR DESCRIPTION
## What

The build-on-top path without cloning or vendoring: `npm install @axiom-foundation/rules-engine-wasm` gives any product the compiler + evaluator, browser or Node, offline. Closes the "npm WASM package: publish at launch or keep vendoring?" open question from the launch plan — with the hosted API and MCP out of launch scope, this is the primary programmatic entry point.

- **One package, both targets**: `.` → web build (ESM, `await init()`), `./node` → nodejs build (CJS). Scoped `type` markers per directory — a root `"type": "module"` misdeclares the CJS build (the smoke test caught this before it shipped).
- `wasm/npm/build-npm.mjs` — dependency-free assembler (two release wasm-pack builds → `wasm/npm-dist`), version from tag or crate.
- `wasm/npm/smoke-dist.mjs` — runs the canonical federal+state SNAP pair through the **assembled** node target (asserts 268), verifies web assets + export map.
- `.github/workflows/wasm-npm.yml` — PRs touching `wasm/**`: build + `npm pack --dry-run` + smoke. Tag `wasm-npm-v*`: publish with **npm provenance** (`id-token: write`).

## Verified locally

Built, smoked (268 ✓), and dry-run packed: 13 files, web+node targets, README/LICENSE included.

## To publish v0.1.0 (after merge)

1. Add the `NPM_TOKEN` repo secret (npm automation token for the @axiom-foundation org)
2. `git tag wasm-npm-v0.1.0 && git push origin wasm-npm-v0.1.0`

Follow-up (separate): the versioning-gap work — git tag ↔ npm version anchoring is handled here by deriving the version from the tag itself.

Reference consumer: TheAxiomFoundation/axiom-playground (PR #2) vendors these same builds today and can switch to the package once published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)