### PR TITLE
Docs: separate the released v0.1.1 CLI contract from main's

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -4,8 +4,8 @@ Branch: `docs/released-binary-cli-contract` (from `origin/main`).
 
 ## State
 
-The released-binary install path is corrected and ready for verification. The
-README and jurisdiction documentation still need their contract labels.
+The released v0.1.1 and current-`main` CLI contracts are separated throughout
+the command guidance found by the documentation audit. Verification remains.
 
 ## Done
 
@@ -27,11 +27,12 @@ README and jurisdiction documentation still need their contract labels.
   and `compile-composed` with repeatable `--rulespec-root`.
 - Separated the v0.1.1 and current-`main` CLI contracts in `README.md`, keeping
   the source-built `compile` and `compile-composed` documentation.
+- Labeled the release and current-`main` import-resolution contracts in
+  `docs/jurisdiction-repos.md`; the explicit root example now uses `cargo run`.
+- Labeled the current-`main` root and `compile-composed` requirements in
+  `docs/rulespec.md`, and distinguished the released v0.1.1 contract.
 
 ## Next
 
-- Label the source-built contract in `docs/jurisdiction-repos.md`.
-- Inspect and, if needed, label the current-`main` examples in
-  `docs/rulespec.md`.
 - Verify line numbers, links, wording, and the final documentation-only diff.
 - Record the final report in the requested output file.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,46 +1,259 @@
-# Progress — released binary CLI documentation
+# PROGRESS — cross-period reduction (issue #67)
 
-Branch: `docs/released-binary-cli-contract` (from `origin/main`).
+Branch: `cross-period-reduction` (worktree axiom-engine-67, from origin/main).
 
 ## State
+Design finalized after full read of dense.rs, formula.rs, spec.rs, model.rs,
+engine.rs, bulk.rs, api.rs, rulespec.rs, python-ext/src/lib.rs, python/dense.py,
+CI workflow, and tests/dense.rs. Starting implementation.
 
-Complete. The released v0.1.1 and current-`main` CLI contracts are separated
-throughout the command guidance found by the documentation audit, and the
-documentation-only verification gate passes.
+## Design (from brief, settled) + resolved mechanics
+
+### New expression node (threaded end-to-end)
+- model `ScalarExpr::OverPeriods { kind: OverPeriodsKind, value: Box<ScalarExpr>, n: Option<Box<ScalarExpr>> }`
+  where `OverPeriodsKind ∈ { Sum, Max, Count, SumTopN }`.
+- spec `ScalarExprSpec::OverPeriods { kind, value, n }` (serde-tagged, round-trips; additive → no artifact version bump).
+- dense `CompiledScalarExpr::OverPeriods { kind, value: Box<..>, n: Option<Box<..>> }`.
+- formula.rs `lower_to_scalar` parses the four builtin `Call`s:
+  - `sum_over_periods(x)` → OverPeriods{Sum, x, None}
+  - `max_over_periods(x)` → OverPeriods{Max, x, None}
+  - `count_over_periods(x)` → OverPeriods{Count, x, None}  (x still lowered so alignment/period count is well-defined; count ignores values)
+  - `sum_top_n_over_periods(x, n)` → OverPeriods{SumTopN, x, Some(n)}
+  arg-count errors mirror existing builtins.
+
+### Per-period-context rejection (lifetime-only)
+- Per-period dense executor `eval_scalar_expr`: OverPeriods → EvalError::OverPeriodsOutsideLifetime.
+- dense `compile_related_scalar` / `compile_current_scalar_expr`: reject (can't nest a cross-period
+  reduction inside a related/where expr) via DenseCompileError::Unsupported.
+- Sparse `engine.rs` eval_scalar_expr + bulk.rs (both columnar and related scalar paths) + api.rs
+  dep-collector + model.rs input-slot collector: handle new variant (sparse/bulk error clearly;
+  collectors recurse into value/n so inputs referenced inside a reduction are still discovered).
+
+### Lifetime execution surface (dense.rs)
+- `execute_lifetime(periods: &[Period], batches: Vec<DenseBatchSpec>, outputs) -> DenseExecutionResult` (Decimal)
+- `execute_lifetime_f64(...)` (f64), parallel to execute/execute_f64.
+- Validation:
+  - periods.len() == batches.len(), non-empty.
+  - every batch binds identically (bind_batch each) and all have the SAME row_count (v1 positional
+    alignment; error clearly on mismatch — new EvalError::LifetimeRowCountMismatch).
+  - each requested output's compiled formula must contain ≥1 OverPeriods node; else
+    EvalError::LifetimeOutputWithoutReduction (brief: lifetime exec only supports reduction outputs).
+- Evaluation model (LifetimeExecutor):
+  - Build one per-period bound batch + a way to make a per-period DenseExecutor<N>.
+  - Outer formula evaluated ONCE (row-wise), recursively:
+    * OverPeriods{kind,value,n}: evaluate `value` per period with that period's DenseExecutor
+      → P columns of length R; transpose to per-row Vec<N> of length P; reduce row-wise:
+        Sum = Σ; Max = max (error if P==0 — guaranteed ≥1 by non-empty periods); Count = P (ignores value);
+        SumTopN = sort desc, take top n, zero-pad when P<n (missing periods contribute 0 — mirrors 415(b)).
+        n: evaluate `n` at reference period (last), per-row; truncate toward zero to i64; error if < 1
+        (EvalError::TypeMismatch with a clear message). n is per-row but typically constant.
+    * Literal / Add / Sub / Mul / Div / Max / Min / Ceil / Floor / If(condition over reductions): recurse row-wise.
+    * ParameterLookup / Derived(scalar): evaluate at reference period (last period) — parameters like a
+      bend point are indexed to the eligibility/last year; Derived recurses through lifetime evaluator so a
+      derived that itself reduces works.
+    * Period-ambiguous leaves OUTSIDE any reduction (bare Input, InputOrElse, PeriodStart/End, CountRelated,
+      SumRelated): error EvalError::LifetimeAmbiguousLeaf — tell the caller these must appear inside an
+      over-periods reduction. (Faithful to "reused per-period evaluation"; keeps semantics unambiguous.)
+  - Reference period = last period supplied (documented). Rationale: over-periods reductions are the
+    lifetime axis; scalars combined with the reduction (bend points, divisor) are resolved at the
+    determination period, which is the most recent supplied period.
+
+### PyO3
+- `execute_lifetime_f64(periods, batches, outputs=None)` on CompiledDenseProgramHandle, parallel to
+  execute_f64. `periods`: list of (period_kind, start, end); `batches`: list of the same input/relation
+  dict shape build_batch already accepts. Python wrapper method `execute_lifetime_f64` in dense.py.
+
+### No RuleSpec schema changes (expression-level only). Additive serde on ScalarExprSpec.
 
 ## Done
+- Full exploration; PROGRESS.md seeded.
+- model.rs: OverPeriodsKind (+ as_call_name) + ScalarExpr::OverPeriods + input-slot collector arm.
+- spec.rs: ScalarExprSpec::OverPeriods + OverPeriodsKindSpec + to_model.
+- formula.rs: parse sum/max/count/sum_top_n_over_periods in lower_to_scalar; promote_ints descends into value.
+- engine.rs: EvalError variants (OverPeriodsOutsideLifetime, Lifetime*, OverPeriodsTopNInvalid) + sparse reject arm.
+- bulk.rs (both paths) + api.rs collector: new arms.
+- compile.rs: fast-blocker (adds blocker), dependency collector, relation-member collector arms.
+- rulespec.rs: 4 traversal arms (alias rewrite, relation-name collect, relation-ref rewrite, imported-derived check).
+- dense.rs: CompiledScalarExpr::OverPeriods + compile arm + per-period reject + related/current reject +
+  DenseNum::to_i64_trunc + LifetimeExecutor + execute_lifetime[_f64] + derived_reduces_over_periods gate.
+- schemas/compiled-artifact.v1.schema.json regenerated (additive over_periods variant; no format-version bump).
+- GREEN: cargo build, fmt, cargo test (default + schema feature), cargo check python-ext.
+- clippy: baseline origin/main already emits 36 lib warnings; my additions introduce ZERO new warnings
+  (every warning location is in pre-existing code). Not touching the 36 pre-existing ones (scope).
 
-- Confirmed the starting worktree was clean and contained no user changes.
-- Confirmed `docs/install.md` names release `v0.1.0` on lines 13 and 25, then
-  gives an unlabeled `compile-composed --rulespec-root` example on lines 40–43.
-- Confirmed `README.md` gives the source-built `compile --rulespec-root`
-  contract on lines 60–63 without explicitly distinguishing it from the
-  released binary linked immediately above.
-- Confirmed `docs/jurisdiction-repos.md` gives
-  `compile --rulespec-root` on lines 52–55 without identifying it as the
-  source-built `main` contract.
-- Confirmed the requested scope is documentation only.
-- Updated `docs/install.md` to download and attest release `v0.1.1`.
-- Documented the known macOS `shasum --check` trailing-blank-line warning and
-  the successful `OK` result.
-- Added the verified v0.1.1 `compile` and `run-compiled` sequence, with no root
-  flag, and separately retained the source-built `main` examples for `compile`
-  and `compile-composed` with repeatable `--rulespec-root`.
-- Separated the v0.1.1 and current-`main` CLI contracts in `README.md`, keeping
-  the source-built `compile` and `compile-composed` documentation.
-- Labeled the release and current-`main` import-resolution contracts in
-  `docs/jurisdiction-repos.md`; the explicit root example now uses `cargo run`.
-- Labeled the current-`main` root and `compile-composed` requirements in
-  `docs/rulespec.md`, and distinguished the released v0.1.1 contract.
-- Verified the current-`main` contract with
-  `cargo run --locked --offline --quiet -- compile --help`.
-- Verified the v0.1.1 tags, worked example, and checksum warning against the
-  executed results supplied for issues #121 and #122.
-- Verified that the diff contains only Markdown files, has no whitespace
-  errors, has balanced code fences, and resolves every local link.
-- Completed independent contract and scope reviews with no defects found.
+- python-ext/src/lib.rs: execute_lifetime_f64 PyO3 method + shared execution_to_pydict +
+  split_lifetime_batch; python/dense.py: execute_lifetime_f64 wrapper.
+- tests/lifetime.rs: 22 Rust tests — AIME acceptance (Decimal + f64, =2833), each builtin, top-n
+  (ties, n>period_count zero-pad, n as param expr, non-integer n truncation, negatives), multi-row
+  alignment, outer-formula-with-parameter, all validation/error paths, per-period rejection, Decimal exactness.
+- python/tests/test_dense_lifetime.py: 4 tests — AIME acceptance (=2833), two-worker row alignment,
+  period/batch-count and row-count mismatch errors. Built wheel via maturin (py3.14 venv), 36/36 python tests pass.
 
-## Next
+## Acceptance test AIME value
+AIME = 2833. Synthetic 40-year worker, indexed earnings year k = 12_000 + 1_000*(k-1) (12_000..51_000).
+Top 35 of 40 drops the lowest 5; sum(top 35) = 35*(17_000+51_000)/2 = 1_190_000;
+floor(1_190_000 / 420) = floor(2833.33..) = 2833.
 
-- None. The local commits are ready for review. Do not push or open a pull
-  request.
+## Independent review + fixes (applied)
+An independent read-only review found NO correctness bugs (verified AIME math, Max empty-slice safety,
+SumTopN zero-pad/ties/negatives, rejection completeness, transitive gate + cycle protection, serde
+round-trip, PyO3 layer). Three polish items applied:
+- LifetimeAmbiguousLeaf now carries a String (removed the Box::leak &'static str helper).
+- count_over_periods short-circuits before building the per-period matrix (a period count must not fail
+  because the inner body is unevaluable).
+- Directly-nested reductions (e.g. sum_over_periods(max_over_periods(x)), or a reduction in the `n` arg)
+  are now rejected at DENSE COMPILE TIME (DenseCompileError::NestedOverPeriods) with a precise message,
+  instead of surfacing an opaque per-period runtime error. Reduction-via-Derived still errors safely at
+  runtime (documented; transitive check needs the whole program, not one expr).
+Added 2 Rust tests for the nested-reduction rejection (24 lifetime tests total).
+
+## Final gate (all GREEN)
+- cargo fmt --check clean; cargo build; cargo test (default) all pass; cargo test --features schema all pass;
+  cargo check python-ext; cargo check wasm32-unknown-unknown --no-default-features.
+- clippy: 36 lib warnings, identical to origin/main baseline — ZERO introduced by this change; no warnings
+  in tests/lifetime.rs or python-ext.
+- 24 Rust lifetime tests + 36 Python tests pass against the maturin-built extension.
+
+## DRAFT PR
+https://github.com/TheAxiomFoundation/axiom-rules-engine/pull/68
+(draft, base main, head cross-period-reduction, title "Cross-period reductions: lifetime execution surface (#67)").
+Do NOT merge.
+
+## Concerns
+- Reference-period choice for non-reduction scalars (parameters/derived) inside the outer formula:
+  chose LAST supplied period. Documented; flag for review. For the AIME acceptance formula the outer
+  formula only combines the reduction with a literal (420), so this choice is not exercised there.
+- (Superseded for INPUTS by the amendment below.) Lifetime execution previously rejected ALL
+  period-ambiguous bare leaves outside reductions. Bare inputs are now bound when provably invariant;
+  the reference-period-for-parameters convention above is unchanged.
+
+## Amendment — runtime-verified period-invariant binding for inputs (this session)
+
+### Why
+42 USC 415(b)'s benefit-computation-year count is a derived scalar built from per-person-constant
+inputs (year the worker attains 21 / 62) and must feed `sum_top_n_over_periods` as its `n`. Under the
+original design that `n` — a bare input reached through a derived chain, sitting OUTSIDE every reduction
+— hit the blanket `LifetimeAmbiguousLeaf` rejection, so real 415(b) logic could not run end to end.
+Empirically confirmed failing (scratchpad/check_derived_n_lifetime.py errored on `year_attained_62`).
+
+### What changed (dense.rs lifetime paths only; no schema change; per-period execute/execute_f64 unchanged)
+- `LifetimeExecutor::eval_scalar` `Input` / `InputOrElse` arms no longer error. They call the new
+  `eval_period_invariant_input(expr, name)`, which evaluates the SAME bare-input node under every
+  period's `DenseExecutor` (one column per period, positionally aligned) and checks PER ROW that the
+  value is identical across ALL supplied periods.
+  - All rows invariant → bind period 0's column (dtype preserved); the caller consumes it exactly like
+    any other column, so a value in scalar OR in the `n` position, reached directly OR through a derived
+    chain (Sub/Max/… compose row-wise), all work.
+  - Any row varies → new `EvalError::LifetimePeriodVaryingInput`, naming the input and the first two
+    differing period labels (`start..end`) and values. Truly period-varying inputs still fail loudly.
+- New free helpers in dense.rs: `first_differing_row` (exact per-row equality; numeric variants compared
+  by Decimal-promoted value so `1985` == `1985.0`; non-numeric mismatch or non-finite → treated as
+  differing = safe error), `period_label`, `dense_value_label`.
+- New `EvalError::LifetimePeriodVaryingInput` variant in engine.rs. `LifetimeAmbiguousLeaf` still used
+  for the genuinely period-specific leaves (PeriodStart/End, Date*, Count/SumRelated).
+- Parameters keep their existing last-supplied-period behavior; the amendment touches inputs only.
+
+### Tests
+- tests/lifetime.rs (+4, 28 total): (a) per-person-constant input binds outside a reduction;
+  (b) per-row-varying but per-period-constant input binds per row (rows 100 vs 500);
+  (c) period-VARYING input errors, message names the input; (d) the derived-n-from-constant-inputs
+  chain end to end (two workers, n = 36 and 31; earnings_total [3_456_000, 1_922_000]; aime [8000, 5166]).
+- python/tests/test_dense_lifetime.py (+2): two-worker derived-n case (mirrors the scratchpad script) and
+  a period-varying-input error case naming the input.
+
+### Acceptance-script arithmetic note (IMPORTANT — flagged for review)
+scratchpad/check_derived_n_lifetime.py as delivered expected `aime[1] = 5167` for worker B, with a
+comment `floor(5167.20)`. That is wrong: worker B has total 1_922_000, n = 31, so
+`aime = floor(1_922_000 / (12*31 = 372)) = floor(5166.666…) = 5166`. 5167 is the round-HALF-UP value,
+not the `floor` the module (and 42 USC 415(b)(2)(A) / 20 CFR 404.211(d), which round DOWN) use — and no
+integer months divisor can even produce 5167 for this total (floor jumps 5180 at d=371 to 5166 at d=372,
+skipping 5167). Independently re-derived. The engine is statutorily correct at 5166; the fixture's one
+expected constant was corrected 5167 → 5166 (worker A's 8000 is unaffected: floor and round agree there).
+The binding mechanism the script exercises — two workers with DIFFERENT derived n binding correctly — is
+proven by `earnings_total = [3_456_000, 1_922_000]`, which matches exactly.
+
+### Final gate (all GREEN, this amendment)
+- cargo fmt --check clean; cargo build; cargo test (default) 0 failed; cargo test --features schema
+  0 failed (schema golden-file guard passes — no artifact-schema change); cargo check python-ext;
+  cargo check wasm32-unknown-unknown --no-default-features.
+- clippy --all-targets: actual lint findings BYTE-IDENTICAL to the pre-amendment branch tip (37 finding
+  lines; 35 lib + 35 lib-test as before) — ZERO new warnings; none reference the new code.
+- 28 Rust lifetime tests + 38 Python tests pass against the maturin-rebuilt extension; the corrected
+  scratchpad acceptance script passes (earnings_total [3456000, 1922000], aime [8000, 5166]).
+
+## Review response — six fixes (this session, PR #68 review)
+
+Six confirmed review findings addressed; semantics decided by the feature-brief
+author. Referential transparency, ordering validation, and count-nonzero were
+already implemented from the prior session; this session completed the strict n
+contract, the exhaustive reduction parse, and the DECISIONS.md entry, corrected
+the stale comments, and pinned every case as a test.
+
+1. **Referential transparency (dense.rs).** A derived referenced OUTSIDE a
+   reduction is evaluated by inlining its body in the lifetime context (the
+   `Derived` arm recurses through the lifetime executor): parameters resolve at
+   the reference period, and a bare input inside that body goes through the
+   per-row period-invariance guard. A parameter-bearing derived reused both
+   inside a reduction and bare outside it therefore denotes exactly its
+   definition in both positions. The review's 600-case
+   (`sum_over_periods(credit) + credit`, `credit = rate + earnings`, `earnings`
+   period-varying) now errors loudly via `LifetimePeriodVaryingInput` naming
+   `earnings`, instead of silently returning 600. Test:
+   `derived_reused_inside_and_outside_reduction_errors_on_period_varying_input`.
+
+2. **Strictly-ascending periods (dense.rs + engine.rs).** `execute_lifetime[_f64]`
+   validate that supplied periods strictly ascend by start date and error with
+   `LifetimePeriodsNotAscending` (naming the offending adjacent pair) rather than
+   silently resolving parameters / n at a positionally-last-but-chronologically-
+   earlier year. Reference period = the (now guaranteed chronologically-last)
+   final period. Tests: `errors_when_periods_are_not_strictly_ascending`
+   (Rust), `test_descending_periods_raise` (Python).
+
+3. **count_over_periods counts nonzero (dense.rs + model.rs).** `count_over_periods`
+   now evaluates its argument per period and counts, per row, the periods whose
+   value is nonzero (`Bool` counts `true`; text/date rejected). It is no longer a
+   bare supplied-period count. The stale "evaluated but ignored" doc on
+   `OverPeriodsKind::Count` (model.rs) was corrected. Tests:
+   `count_over_periods_counts_nonzero_periods_per_row`,
+   `count_over_periods_all_zero_is_zero` (Rust), and a Python analogue.
+
+4. **Strict n contract for sum_top_n (dense.rs + engine.rs + model.rs).**
+   `DenseNum::try_to_i64_trunc(self) -> Option<i64>` replaces the saturating
+   `to_i64_trunc` in both dtype impls. `eval_top_n_counts` now: evaluates n under
+   EVERY period's executor and rejects a period-VARYING n (parameter- and
+   input-sourced held to the identical contract) with
+   `OverPeriodsTopNPeriodVarying`; truncates the reference column toward zero to
+   an exact i64 (a non-finite / out-of-range value -> `None` -> hard error); and
+   enforces `1 <= n <= period_count`, erroring `OverPeriodsTopNOutOfRange` on
+   under- and over-length n. No clamp to i64::MAX, no silent reference-period
+   pin, no zero-pad past the period count. Tests:
+   `sum_top_n_n_exceeds_period_count_errors_in_decimal_path`,
+   `...in_f64_path`, `sum_top_n_period_varying_parameter_n_errors`, updated
+   `errors_when_sum_top_n_n_is_less_than_one` and the former zero-pad test
+   (now `sum_top_n_errors_when_n_exceeds_the_period_count`); Python analogues.
+
+5. **Exhaustive reduction parse (formula.rs).** The one-argument over-periods
+   arm chooses its kind by an exhaustive match with an explicit error arm (no
+   wildcard falling through to `Count`), and any other `*_over_periods` name is
+   rejected with a reduction-specific parse error rather than the generic
+   "unknown function". Tests: `unknown_over_periods_reduction_fails_to_parse`
+   (Rust + Python).
+
+6. **DECISIONS.md.** One new most-recent-first entry (2026-07-05) covering the
+   lifetime execution surface: the `OverPeriods` node + four builtins, reference
+   period = chronologically-last supplied period, strictly-ascending validation,
+   period-invariant input binding + inlined-body derived semantics,
+   count-nonzero, and the strict n contract.
+
+### Final gate (all GREEN, this session)
+- `cargo fmt` applied; `cargo fmt --check` clean; `cargo build`; `cargo test`
+  (default) 0 failed; `cargo test --features schema` 0 failed;
+  `cargo check --manifest-path python-ext/Cargo.toml`;
+  `cargo check --target wasm32-unknown-unknown --no-default-features`.
+- clippy: `--lib` and `--all-targets` finding multisets BYTE-IDENTICAL to branch
+  tip 984a4e0 (per-file counts diff empty) — ZERO new warnings; python-ext clippy
+  identical to baseline (2 pre-existing).
+- 35 Rust lifetime tests + 42 Python tests pass against the maturin-rebuilt
+  (`--release`) extension; the acceptance script
+  `scratchpad/check_derived_n_lifetime.py` prints
+  `earnings_total [3456000. 1922000.]`, `aime [8000. 5166.]` and all assertions pass.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -4,8 +4,8 @@ Branch: `docs/released-binary-cli-contract` (from `origin/main`).
 
 ## State
 
-The worktree and branch are verified. The documentation audit is complete, and
-the CLI-contract corrections are ready to edit.
+The released-binary install path is corrected and ready for verification. The
+README and jurisdiction documentation still need their contract labels.
 
 ## Done
 
@@ -19,12 +19,15 @@ the CLI-contract corrections are ready to edit.
   `compile --rulespec-root` on lines 52–55 without identifying it as the
   source-built `main` contract.
 - Confirmed the requested scope is documentation only.
+- Updated `docs/install.md` to download and attest release `v0.1.1`.
+- Documented the known macOS `shasum --check` trailing-blank-line warning and
+  the successful `OK` result.
+- Added the verified v0.1.1 `compile` and `run-compiled` sequence, with no root
+  flag, and separately retained the source-built `main` examples for `compile`
+  and `compile-composed` with repeatable `--rulespec-root`.
 
 ## Next
 
-- Update `docs/install.md` to download and attest release `v0.1.1`, explain the
-  macOS checksum warning, and separate released-binary commands from
-  source-built `main` commands.
 - Separate and label the two CLI contracts in `README.md`.
 - Label the source-built contract in `docs/jurisdiction-repos.md`.
 - Verify line numbers, links, wording, and the final documentation-only diff.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -4,8 +4,9 @@ Branch: `docs/released-binary-cli-contract` (from `origin/main`).
 
 ## State
 
-The released v0.1.1 and current-`main` CLI contracts are separated throughout
-the command guidance found by the documentation audit. Verification remains.
+Complete. The released v0.1.1 and current-`main` CLI contracts are separated
+throughout the command guidance found by the documentation audit, and the
+documentation-only verification gate passes.
 
 ## Done
 
@@ -31,8 +32,15 @@ the command guidance found by the documentation audit. Verification remains.
   `docs/jurisdiction-repos.md`; the explicit root example now uses `cargo run`.
 - Labeled the current-`main` root and `compile-composed` requirements in
   `docs/rulespec.md`, and distinguished the released v0.1.1 contract.
+- Verified the current-`main` contract with
+  `cargo run --locked --offline --quiet -- compile --help`.
+- Verified the v0.1.1 tags, worked example, and checksum warning against the
+  executed results supplied for issues #121 and #122.
+- Verified that the diff contains only Markdown files, has no whitespace
+  errors, has balanced code fences, and resolves every local link.
+- Completed independent contract and scope reviews with no defects found.
 
 ## Next
 
-- Verify line numbers, links, wording, and the final documentation-only diff.
-- Record the final report in the requested output file.
+- None. The local commits are ready for review. Do not push or open a pull
+  request.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -25,10 +25,13 @@ README and jurisdiction documentation still need their contract labels.
 - Added the verified v0.1.1 `compile` and `run-compiled` sequence, with no root
   flag, and separately retained the source-built `main` examples for `compile`
   and `compile-composed` with repeatable `--rulespec-root`.
+- Separated the v0.1.1 and current-`main` CLI contracts in `README.md`, keeping
+  the source-built `compile` and `compile-composed` documentation.
 
 ## Next
 
-- Separate and label the two CLI contracts in `README.md`.
 - Label the source-built contract in `docs/jurisdiction-repos.md`.
+- Inspect and, if needed, label the current-`main` examples in
+  `docs/rulespec.md`.
 - Verify line numbers, links, wording, and the final documentation-only diff.
 - Record the final report in the requested output file.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,259 +1,31 @@
-# PROGRESS — cross-period reduction (issue #67)
+# Progress — released binary CLI documentation
 
-Branch: `cross-period-reduction` (worktree axiom-engine-67, from origin/main).
+Branch: `docs/released-binary-cli-contract` (from `origin/main`).
 
 ## State
-Design finalized after full read of dense.rs, formula.rs, spec.rs, model.rs,
-engine.rs, bulk.rs, api.rs, rulespec.rs, python-ext/src/lib.rs, python/dense.py,
-CI workflow, and tests/dense.rs. Starting implementation.
 
-## Design (from brief, settled) + resolved mechanics
-
-### New expression node (threaded end-to-end)
-- model `ScalarExpr::OverPeriods { kind: OverPeriodsKind, value: Box<ScalarExpr>, n: Option<Box<ScalarExpr>> }`
-  where `OverPeriodsKind ∈ { Sum, Max, Count, SumTopN }`.
-- spec `ScalarExprSpec::OverPeriods { kind, value, n }` (serde-tagged, round-trips; additive → no artifact version bump).
-- dense `CompiledScalarExpr::OverPeriods { kind, value: Box<..>, n: Option<Box<..>> }`.
-- formula.rs `lower_to_scalar` parses the four builtin `Call`s:
-  - `sum_over_periods(x)` → OverPeriods{Sum, x, None}
-  - `max_over_periods(x)` → OverPeriods{Max, x, None}
-  - `count_over_periods(x)` → OverPeriods{Count, x, None}  (x still lowered so alignment/period count is well-defined; count ignores values)
-  - `sum_top_n_over_periods(x, n)` → OverPeriods{SumTopN, x, Some(n)}
-  arg-count errors mirror existing builtins.
-
-### Per-period-context rejection (lifetime-only)
-- Per-period dense executor `eval_scalar_expr`: OverPeriods → EvalError::OverPeriodsOutsideLifetime.
-- dense `compile_related_scalar` / `compile_current_scalar_expr`: reject (can't nest a cross-period
-  reduction inside a related/where expr) via DenseCompileError::Unsupported.
-- Sparse `engine.rs` eval_scalar_expr + bulk.rs (both columnar and related scalar paths) + api.rs
-  dep-collector + model.rs input-slot collector: handle new variant (sparse/bulk error clearly;
-  collectors recurse into value/n so inputs referenced inside a reduction are still discovered).
-
-### Lifetime execution surface (dense.rs)
-- `execute_lifetime(periods: &[Period], batches: Vec<DenseBatchSpec>, outputs) -> DenseExecutionResult` (Decimal)
-- `execute_lifetime_f64(...)` (f64), parallel to execute/execute_f64.
-- Validation:
-  - periods.len() == batches.len(), non-empty.
-  - every batch binds identically (bind_batch each) and all have the SAME row_count (v1 positional
-    alignment; error clearly on mismatch — new EvalError::LifetimeRowCountMismatch).
-  - each requested output's compiled formula must contain ≥1 OverPeriods node; else
-    EvalError::LifetimeOutputWithoutReduction (brief: lifetime exec only supports reduction outputs).
-- Evaluation model (LifetimeExecutor):
-  - Build one per-period bound batch + a way to make a per-period DenseExecutor<N>.
-  - Outer formula evaluated ONCE (row-wise), recursively:
-    * OverPeriods{kind,value,n}: evaluate `value` per period with that period's DenseExecutor
-      → P columns of length R; transpose to per-row Vec<N> of length P; reduce row-wise:
-        Sum = Σ; Max = max (error if P==0 — guaranteed ≥1 by non-empty periods); Count = P (ignores value);
-        SumTopN = sort desc, take top n, zero-pad when P<n (missing periods contribute 0 — mirrors 415(b)).
-        n: evaluate `n` at reference period (last), per-row; truncate toward zero to i64; error if < 1
-        (EvalError::TypeMismatch with a clear message). n is per-row but typically constant.
-    * Literal / Add / Sub / Mul / Div / Max / Min / Ceil / Floor / If(condition over reductions): recurse row-wise.
-    * ParameterLookup / Derived(scalar): evaluate at reference period (last period) — parameters like a
-      bend point are indexed to the eligibility/last year; Derived recurses through lifetime evaluator so a
-      derived that itself reduces works.
-    * Period-ambiguous leaves OUTSIDE any reduction (bare Input, InputOrElse, PeriodStart/End, CountRelated,
-      SumRelated): error EvalError::LifetimeAmbiguousLeaf — tell the caller these must appear inside an
-      over-periods reduction. (Faithful to "reused per-period evaluation"; keeps semantics unambiguous.)
-  - Reference period = last period supplied (documented). Rationale: over-periods reductions are the
-    lifetime axis; scalars combined with the reduction (bend points, divisor) are resolved at the
-    determination period, which is the most recent supplied period.
-
-### PyO3
-- `execute_lifetime_f64(periods, batches, outputs=None)` on CompiledDenseProgramHandle, parallel to
-  execute_f64. `periods`: list of (period_kind, start, end); `batches`: list of the same input/relation
-  dict shape build_batch already accepts. Python wrapper method `execute_lifetime_f64` in dense.py.
-
-### No RuleSpec schema changes (expression-level only). Additive serde on ScalarExprSpec.
+The worktree and branch are verified. The documentation audit is complete, and
+the CLI-contract corrections are ready to edit.
 
 ## Done
-- Full exploration; PROGRESS.md seeded.
-- model.rs: OverPeriodsKind (+ as_call_name) + ScalarExpr::OverPeriods + input-slot collector arm.
-- spec.rs: ScalarExprSpec::OverPeriods + OverPeriodsKindSpec + to_model.
-- formula.rs: parse sum/max/count/sum_top_n_over_periods in lower_to_scalar; promote_ints descends into value.
-- engine.rs: EvalError variants (OverPeriodsOutsideLifetime, Lifetime*, OverPeriodsTopNInvalid) + sparse reject arm.
-- bulk.rs (both paths) + api.rs collector: new arms.
-- compile.rs: fast-blocker (adds blocker), dependency collector, relation-member collector arms.
-- rulespec.rs: 4 traversal arms (alias rewrite, relation-name collect, relation-ref rewrite, imported-derived check).
-- dense.rs: CompiledScalarExpr::OverPeriods + compile arm + per-period reject + related/current reject +
-  DenseNum::to_i64_trunc + LifetimeExecutor + execute_lifetime[_f64] + derived_reduces_over_periods gate.
-- schemas/compiled-artifact.v1.schema.json regenerated (additive over_periods variant; no format-version bump).
-- GREEN: cargo build, fmt, cargo test (default + schema feature), cargo check python-ext.
-- clippy: baseline origin/main already emits 36 lib warnings; my additions introduce ZERO new warnings
-  (every warning location is in pre-existing code). Not touching the 36 pre-existing ones (scope).
 
-- python-ext/src/lib.rs: execute_lifetime_f64 PyO3 method + shared execution_to_pydict +
-  split_lifetime_batch; python/dense.py: execute_lifetime_f64 wrapper.
-- tests/lifetime.rs: 22 Rust tests — AIME acceptance (Decimal + f64, =2833), each builtin, top-n
-  (ties, n>period_count zero-pad, n as param expr, non-integer n truncation, negatives), multi-row
-  alignment, outer-formula-with-parameter, all validation/error paths, per-period rejection, Decimal exactness.
-- python/tests/test_dense_lifetime.py: 4 tests — AIME acceptance (=2833), two-worker row alignment,
-  period/batch-count and row-count mismatch errors. Built wheel via maturin (py3.14 venv), 36/36 python tests pass.
+- Confirmed the starting worktree was clean and contained no user changes.
+- Confirmed `docs/install.md` names release `v0.1.0` on lines 13 and 25, then
+  gives an unlabeled `compile-composed --rulespec-root` example on lines 40–43.
+- Confirmed `README.md` gives the source-built `compile --rulespec-root`
+  contract on lines 60–63 without explicitly distinguishing it from the
+  released binary linked immediately above.
+- Confirmed `docs/jurisdiction-repos.md` gives
+  `compile --rulespec-root` on lines 52–55 without identifying it as the
+  source-built `main` contract.
+- Confirmed the requested scope is documentation only.
 
-## Acceptance test AIME value
-AIME = 2833. Synthetic 40-year worker, indexed earnings year k = 12_000 + 1_000*(k-1) (12_000..51_000).
-Top 35 of 40 drops the lowest 5; sum(top 35) = 35*(17_000+51_000)/2 = 1_190_000;
-floor(1_190_000 / 420) = floor(2833.33..) = 2833.
+## Next
 
-## Independent review + fixes (applied)
-An independent read-only review found NO correctness bugs (verified AIME math, Max empty-slice safety,
-SumTopN zero-pad/ties/negatives, rejection completeness, transitive gate + cycle protection, serde
-round-trip, PyO3 layer). Three polish items applied:
-- LifetimeAmbiguousLeaf now carries a String (removed the Box::leak &'static str helper).
-- count_over_periods short-circuits before building the per-period matrix (a period count must not fail
-  because the inner body is unevaluable).
-- Directly-nested reductions (e.g. sum_over_periods(max_over_periods(x)), or a reduction in the `n` arg)
-  are now rejected at DENSE COMPILE TIME (DenseCompileError::NestedOverPeriods) with a precise message,
-  instead of surfacing an opaque per-period runtime error. Reduction-via-Derived still errors safely at
-  runtime (documented; transitive check needs the whole program, not one expr).
-Added 2 Rust tests for the nested-reduction rejection (24 lifetime tests total).
-
-## Final gate (all GREEN)
-- cargo fmt --check clean; cargo build; cargo test (default) all pass; cargo test --features schema all pass;
-  cargo check python-ext; cargo check wasm32-unknown-unknown --no-default-features.
-- clippy: 36 lib warnings, identical to origin/main baseline — ZERO introduced by this change; no warnings
-  in tests/lifetime.rs or python-ext.
-- 24 Rust lifetime tests + 36 Python tests pass against the maturin-built extension.
-
-## DRAFT PR
-https://github.com/TheAxiomFoundation/axiom-rules-engine/pull/68
-(draft, base main, head cross-period-reduction, title "Cross-period reductions: lifetime execution surface (#67)").
-Do NOT merge.
-
-## Concerns
-- Reference-period choice for non-reduction scalars (parameters/derived) inside the outer formula:
-  chose LAST supplied period. Documented; flag for review. For the AIME acceptance formula the outer
-  formula only combines the reduction with a literal (420), so this choice is not exercised there.
-- (Superseded for INPUTS by the amendment below.) Lifetime execution previously rejected ALL
-  period-ambiguous bare leaves outside reductions. Bare inputs are now bound when provably invariant;
-  the reference-period-for-parameters convention above is unchanged.
-
-## Amendment — runtime-verified period-invariant binding for inputs (this session)
-
-### Why
-42 USC 415(b)'s benefit-computation-year count is a derived scalar built from per-person-constant
-inputs (year the worker attains 21 / 62) and must feed `sum_top_n_over_periods` as its `n`. Under the
-original design that `n` — a bare input reached through a derived chain, sitting OUTSIDE every reduction
-— hit the blanket `LifetimeAmbiguousLeaf` rejection, so real 415(b) logic could not run end to end.
-Empirically confirmed failing (scratchpad/check_derived_n_lifetime.py errored on `year_attained_62`).
-
-### What changed (dense.rs lifetime paths only; no schema change; per-period execute/execute_f64 unchanged)
-- `LifetimeExecutor::eval_scalar` `Input` / `InputOrElse` arms no longer error. They call the new
-  `eval_period_invariant_input(expr, name)`, which evaluates the SAME bare-input node under every
-  period's `DenseExecutor` (one column per period, positionally aligned) and checks PER ROW that the
-  value is identical across ALL supplied periods.
-  - All rows invariant → bind period 0's column (dtype preserved); the caller consumes it exactly like
-    any other column, so a value in scalar OR in the `n` position, reached directly OR through a derived
-    chain (Sub/Max/… compose row-wise), all work.
-  - Any row varies → new `EvalError::LifetimePeriodVaryingInput`, naming the input and the first two
-    differing period labels (`start..end`) and values. Truly period-varying inputs still fail loudly.
-- New free helpers in dense.rs: `first_differing_row` (exact per-row equality; numeric variants compared
-  by Decimal-promoted value so `1985` == `1985.0`; non-numeric mismatch or non-finite → treated as
-  differing = safe error), `period_label`, `dense_value_label`.
-- New `EvalError::LifetimePeriodVaryingInput` variant in engine.rs. `LifetimeAmbiguousLeaf` still used
-  for the genuinely period-specific leaves (PeriodStart/End, Date*, Count/SumRelated).
-- Parameters keep their existing last-supplied-period behavior; the amendment touches inputs only.
-
-### Tests
-- tests/lifetime.rs (+4, 28 total): (a) per-person-constant input binds outside a reduction;
-  (b) per-row-varying but per-period-constant input binds per row (rows 100 vs 500);
-  (c) period-VARYING input errors, message names the input; (d) the derived-n-from-constant-inputs
-  chain end to end (two workers, n = 36 and 31; earnings_total [3_456_000, 1_922_000]; aime [8000, 5166]).
-- python/tests/test_dense_lifetime.py (+2): two-worker derived-n case (mirrors the scratchpad script) and
-  a period-varying-input error case naming the input.
-
-### Acceptance-script arithmetic note (IMPORTANT — flagged for review)
-scratchpad/check_derived_n_lifetime.py as delivered expected `aime[1] = 5167` for worker B, with a
-comment `floor(5167.20)`. That is wrong: worker B has total 1_922_000, n = 31, so
-`aime = floor(1_922_000 / (12*31 = 372)) = floor(5166.666…) = 5166`. 5167 is the round-HALF-UP value,
-not the `floor` the module (and 42 USC 415(b)(2)(A) / 20 CFR 404.211(d), which round DOWN) use — and no
-integer months divisor can even produce 5167 for this total (floor jumps 5180 at d=371 to 5166 at d=372,
-skipping 5167). Independently re-derived. The engine is statutorily correct at 5166; the fixture's one
-expected constant was corrected 5167 → 5166 (worker A's 8000 is unaffected: floor and round agree there).
-The binding mechanism the script exercises — two workers with DIFFERENT derived n binding correctly — is
-proven by `earnings_total = [3_456_000, 1_922_000]`, which matches exactly.
-
-### Final gate (all GREEN, this amendment)
-- cargo fmt --check clean; cargo build; cargo test (default) 0 failed; cargo test --features schema
-  0 failed (schema golden-file guard passes — no artifact-schema change); cargo check python-ext;
-  cargo check wasm32-unknown-unknown --no-default-features.
-- clippy --all-targets: actual lint findings BYTE-IDENTICAL to the pre-amendment branch tip (37 finding
-  lines; 35 lib + 35 lib-test as before) — ZERO new warnings; none reference the new code.
-- 28 Rust lifetime tests + 38 Python tests pass against the maturin-rebuilt extension; the corrected
-  scratchpad acceptance script passes (earnings_total [3456000, 1922000], aime [8000, 5166]).
-
-## Review response — six fixes (this session, PR #68 review)
-
-Six confirmed review findings addressed; semantics decided by the feature-brief
-author. Referential transparency, ordering validation, and count-nonzero were
-already implemented from the prior session; this session completed the strict n
-contract, the exhaustive reduction parse, and the DECISIONS.md entry, corrected
-the stale comments, and pinned every case as a test.
-
-1. **Referential transparency (dense.rs).** A derived referenced OUTSIDE a
-   reduction is evaluated by inlining its body in the lifetime context (the
-   `Derived` arm recurses through the lifetime executor): parameters resolve at
-   the reference period, and a bare input inside that body goes through the
-   per-row period-invariance guard. A parameter-bearing derived reused both
-   inside a reduction and bare outside it therefore denotes exactly its
-   definition in both positions. The review's 600-case
-   (`sum_over_periods(credit) + credit`, `credit = rate + earnings`, `earnings`
-   period-varying) now errors loudly via `LifetimePeriodVaryingInput` naming
-   `earnings`, instead of silently returning 600. Test:
-   `derived_reused_inside_and_outside_reduction_errors_on_period_varying_input`.
-
-2. **Strictly-ascending periods (dense.rs + engine.rs).** `execute_lifetime[_f64]`
-   validate that supplied periods strictly ascend by start date and error with
-   `LifetimePeriodsNotAscending` (naming the offending adjacent pair) rather than
-   silently resolving parameters / n at a positionally-last-but-chronologically-
-   earlier year. Reference period = the (now guaranteed chronologically-last)
-   final period. Tests: `errors_when_periods_are_not_strictly_ascending`
-   (Rust), `test_descending_periods_raise` (Python).
-
-3. **count_over_periods counts nonzero (dense.rs + model.rs).** `count_over_periods`
-   now evaluates its argument per period and counts, per row, the periods whose
-   value is nonzero (`Bool` counts `true`; text/date rejected). It is no longer a
-   bare supplied-period count. The stale "evaluated but ignored" doc on
-   `OverPeriodsKind::Count` (model.rs) was corrected. Tests:
-   `count_over_periods_counts_nonzero_periods_per_row`,
-   `count_over_periods_all_zero_is_zero` (Rust), and a Python analogue.
-
-4. **Strict n contract for sum_top_n (dense.rs + engine.rs + model.rs).**
-   `DenseNum::try_to_i64_trunc(self) -> Option<i64>` replaces the saturating
-   `to_i64_trunc` in both dtype impls. `eval_top_n_counts` now: evaluates n under
-   EVERY period's executor and rejects a period-VARYING n (parameter- and
-   input-sourced held to the identical contract) with
-   `OverPeriodsTopNPeriodVarying`; truncates the reference column toward zero to
-   an exact i64 (a non-finite / out-of-range value -> `None` -> hard error); and
-   enforces `1 <= n <= period_count`, erroring `OverPeriodsTopNOutOfRange` on
-   under- and over-length n. No clamp to i64::MAX, no silent reference-period
-   pin, no zero-pad past the period count. Tests:
-   `sum_top_n_n_exceeds_period_count_errors_in_decimal_path`,
-   `...in_f64_path`, `sum_top_n_period_varying_parameter_n_errors`, updated
-   `errors_when_sum_top_n_n_is_less_than_one` and the former zero-pad test
-   (now `sum_top_n_errors_when_n_exceeds_the_period_count`); Python analogues.
-
-5. **Exhaustive reduction parse (formula.rs).** The one-argument over-periods
-   arm chooses its kind by an exhaustive match with an explicit error arm (no
-   wildcard falling through to `Count`), and any other `*_over_periods` name is
-   rejected with a reduction-specific parse error rather than the generic
-   "unknown function". Tests: `unknown_over_periods_reduction_fails_to_parse`
-   (Rust + Python).
-
-6. **DECISIONS.md.** One new most-recent-first entry (2026-07-05) covering the
-   lifetime execution surface: the `OverPeriods` node + four builtins, reference
-   period = chronologically-last supplied period, strictly-ascending validation,
-   period-invariant input binding + inlined-body derived semantics,
-   count-nonzero, and the strict n contract.
-
-### Final gate (all GREEN, this session)
-- `cargo fmt` applied; `cargo fmt --check` clean; `cargo build`; `cargo test`
-  (default) 0 failed; `cargo test --features schema` 0 failed;
-  `cargo check --manifest-path python-ext/Cargo.toml`;
-  `cargo check --target wasm32-unknown-unknown --no-default-features`.
-- clippy: `--lib` and `--all-targets` finding multisets BYTE-IDENTICAL to branch
-  tip 984a4e0 (per-file counts diff empty) — ZERO new warnings; python-ext clippy
-  identical to baseline (2 pre-existing).
-- 35 Rust lifetime tests + 42 Python tests pass against the maturin-rebuilt
-  (`--release`) extension; the acceptance script
-  `scratchpad/check_derived_n_lifetime.py` prints
-  `earnings_total [3456000. 1922000.]`, `aime [8000. 5166.]` and all assertions pass.
+- Update `docs/install.md` to download and attest release `v0.1.1`, explain the
+  macOS checksum warning, and separate released-binary commands from
+  source-built `main` commands.
+- Separate and label the two CLI contracts in `README.md`.
+- Label the source-built contract in `docs/jurisdiction-repos.md`.
+- Verify line numbers, links, wording, and the final documentation-only diff.
+- Record the final report in the requested output file.

--- a/README.md
+++ b/README.md
@@ -54,6 +54,24 @@ remain local formula symbols only.
 
 To install and verify a published executable, see [Install a released binary](docs/install.md).
 
+### Released v0.1.1 binary
+
+Release v0.1.1 uses a different CLI contract from current `main`. Its `compile`
+command accepts `--program` and `--output` only and resolves canonical
+cross-repo imports without a root flag:
+
+```bash
+axiom-rules-engine compile \
+  --program rulespec-uk/uk-coventry/policies/coventry/council-tax-reduction.yaml \
+  --output ctr.json
+axiom-rules-engine run-compiled --artifact ctr.json < household.json
+```
+
+The v0.1.1 binary does not provide `compile-composed`.
+
+### CLI built from current main
+
+Commands invoked through `cargo run` use the current `main` contract.
 Compile a RuleSpec file:
 
 ```bash

--- a/docs/install.md
+++ b/docs/install.md
@@ -10,7 +10,7 @@ attestation. Verify both before you run the binary. The archives are
 asset="axiom-rules-engine-aarch64-apple-darwin.tar.xz"
 
 # Download the archive and its checksum.
-gh release download v0.1.0 \
+gh release download v0.1.1 \
   --repo TheAxiomFoundation/axiom-rules-engine \
   --pattern "$asset" \
   --pattern "$asset.sha256"
@@ -22,26 +22,53 @@ sha256sum --check "$asset.sha256"          # Linux
 # Verify GitHub/Sigstore build provenance.
 gh attestation verify "$asset" \
   --repo TheAxiomFoundation/axiom-rules-engine \
-  --source-ref refs/tags/v0.1.0
+  --source-ref refs/tags/v0.1.1
 
 # Only extract after both checks pass.
 tar -xJf "$asset"
 ```
 
-## Trusted rule content
+On macOS, `shasum --check` may also print
+`WARNING: 1 line is improperly formatted` because the published `.sha256` file
+has a trailing blank line
+([issue #122](https://github.com/TheAxiomFoundation/axiom-rules-engine/issues/122)).
+The check still reports the archive as `OK`.
 
-The downloaded binary alone runs a compiled artifact or a self-contained JSON
-`ExecutionRequest`. Compiling canonical `us:` imports from source additionally
-requires a rulespec checkout (or a downloaded program-artifacts release),
-passed with the **required, repeatable `--rulespec-root`** flag — one absolute
-path per canonical country repo:
+## Use the v0.1.1 CLI
+
+Release v0.1.1 provides `compile`, `run-compiled`, `emit-schemas`, and
+`--version`. Its `compile` command accepts `--program` and `--output` only. It
+resolves canonical cross-repo imports without a root flag.
 
 ```sh
-axiom-rules-engine compile-composed \
+axiom-rules-engine compile \
+  --program rulespec-uk/uk-coventry/policies/coventry/council-tax-reduction.yaml \
+  --output ctr.json
+axiom-rules-engine run-compiled --artifact ctr.json < household.json
+```
+
+Do not pass `--rulespec-root` or use `compile-composed` with the v0.1.1 binary.
+Those interfaces belong to the CLI built from current `main`.
+
+## Use the CLI built from current main
+
+Current `main` has a different CLI contract. Its `compile` and
+`compile-composed` commands require the repeatable `--rulespec-root` option, with
+one absolute path for each canonical country repository:
+
+```sh
+cargo run -- compile \
+  --program /abs/path/to/rulespec-us/us/policies/example.yaml \
+  --rulespec-root /abs/path/to/rulespec-us \
+  --output compiled.json
+
+cargo run -- compile-composed \
   --program /abs/path/to/program.yaml \
   --rulespec-root /abs/path/to/rulespec-us \
   --output compiled.json
 ```
+
+## Artifact provenance
 
 [Artifact releases](https://github.com/TheAxiomFoundation/axiom-rules-engine/releases)
 carry Sigstore attestations and the corpus releases they cite are

--- a/docs/install.md
+++ b/docs/install.md
@@ -50,6 +50,17 @@ axiom-rules-engine run-compiled --artifact ctr.json < household.json
 Do not pass `--rulespec-root` or use `compile-composed` with the v0.1.1 binary.
 Those interfaces belong to the CLI built from current `main`.
 
+> **Compile only from a canonical country monorepo checkout.** Because v0.1.1 resolves
+> canonical imports by searching the filesystem rather than from explicitly declared roots, it
+> can select an authority from a *neighbouring* checkout — silently compiling a different
+> jurisdiction's text than the one your `--program` path points into
+> ([issue #99](https://github.com/TheAxiomFoundation/axiom-rules-engine/issues/99)). Layouts
+> known to resolve correctly are an exact `rulespec-<country>` monorepo and a full
+> branch-suffixed copy of one. Layouts known to mis-resolve include standalone jurisdiction
+> checkouts, sparse worktrees, nested `_axiom` directories, and reliance on cwd or environment
+> discovery. Current `main` removes this search entirely in favour of the required
+> `--rulespec-root`, which is why that flag exists.
+
 ## Use the CLI built from current main
 
 Current `main` has a different CLI contract. Its `compile` and

--- a/docs/jurisdiction-repos.md
+++ b/docs/jurisdiction-repos.md
@@ -46,18 +46,31 @@ rules: []
 ```
 
 Import targets follow the same path identity scheme as rule IDs, without the
-optional `#rule_name` suffix. Supply the exact country checkout explicitly:
+optional `#rule_name` suffix. Release v0.1.1 and current `main` use different
+CLI contracts to resolve those targets.
+
+### Released v0.1.1 binary
+
+The v0.1.1 `compile` command accepts `--program` and `--output` only and resolves
+canonical cross-repo imports without a root flag. See the
+[release instructions](install.md) for a complete example.
+
+### CLI built from current main
+
+With a binary built from current `main`, supply the exact country checkout
+explicitly with the required, repeatable `--rulespec-root` option:
 
 ```bash
-axiom-rules-engine compile \
+cargo run -- compile \
   --program /srv/rulespec-us/us-tn/policies/example.yaml \
   --rulespec-root /srv/rulespec-us \
   --output /tmp/example.compiled.json
 ```
 
-The runtime resolves `us:` to `/srv/rulespec-us/us/` and `us-tn:` to
-`/srv/rulespec-us/us-tn/`. It never discovers or prefers standalone,
-suffixed-worktree, sibling, ancestor, cwd, or environment-provided roots.
+For this current-`main` command, the engine resolves `us:` to
+`/srv/rulespec-us/us/` and `us-tn:` to `/srv/rulespec-us/us-tn/`. It never
+discovers or prefers standalone, suffixed-worktree, sibling, ancestor, cwd, or
+environment-provided roots.
 
 Rule files are named by the legal or policy unit they encode. Companion tests use
 the same stem and are never importable module targets:

--- a/docs/rulespec.md
+++ b/docs/rulespec.md
@@ -169,12 +169,17 @@ checkout named `rulespec-<country>` with direct matching jurisdiction
 directories. For example, `us:` resolves below `rulespec-us/us/` and `us-co:`
 below `rulespec-us/us-co/`.
 
-Callers must supply at least one absolute, real, unaliased country checkout.
-The CLI uses required repeatable `--rulespec-root` arguments; Rust callers pass
-a validated `CanonicalRuleSpecRoots` to `load_rulespec_file`,
-`CompiledProgramArtifact::from_rulespec_file`, or `FsModuleSource`. There is no
-environment, cwd, ancestor, sibling-checkout, suffixed-worktree, or standalone
-jurisdiction-repository fallback.
+For current `main`, filesystem callers must supply at least one absolute, real,
+unaliased country checkout. The CLI built from `main` uses required repeatable
+`--rulespec-root` arguments; Rust callers pass a validated
+`CanonicalRuleSpecRoots` to `load_rulespec_file`,
+`CompiledProgramArtifact::from_rulespec_file`, or `FsModuleSource`. These
+current-`main` interfaces have no environment, cwd, ancestor, sibling-checkout,
+suffixed-worktree, or standalone jurisdiction-repository fallback.
+
+The released v0.1.1 CLI uses a different contract. Its `compile` command accepts
+`--program` and `--output` only and resolves canonical cross-repo imports
+without a root flag. See the [release instructions](install.md).
 
 Configured roots must remain trusted and quiescent throughout validation and
 compilation. This is a deterministic authority boundary, not a sandbox against
@@ -192,15 +197,16 @@ special paths, `.yml`/case-variant/double extensions, relative imports, and
 reserved or whitespace path components fail closed before compilation.
 
 `axiom-compose` emits an ephemeral import-bearing `rulespec/v1` composition,
-not an atomic module. Compile that output with the separate
-`compile-composed` command. Its input must be an absolute, real, unaliased
-`.yaml` outside every RuleSpec checkout with exact
+not an atomic module. The CLI built from current `main` compiles that output
+with the separate `compile-composed` command. Its input must be an absolute,
+real, unaliased `.yaml` outside every RuleSpec checkout with exact
 `module.kind: composition`; it still requires one or more explicit
 `--rulespec-root` arguments. Only fragmentless canonical atomic imports are
 allowed, and synthesized root rules remain originless. The removed top-level
-`extends` directive is rejected on both surfaces. The ordinary `compile` command
-rejects the ephemeral file, while `compile-composed` rejects atomic modules and
-declarative ProgramSpecs.
+`extends` directive is rejected on both surfaces. On current `main`, the
+ordinary `compile` command rejects the ephemeral file, while `compile-composed`
+rejects atomic modules and declarative ProgramSpecs. Release v0.1.1 does not
+provide `compile-composed`.
 
 Compiled artifacts make the input boundary explicit in
 `metadata.input_catalog`. Each runtime slot has a deterministic


### PR DESCRIPTION
Closes #121. Documentation only — no source changes.

## Why

The install docs told readers to download a released binary and then showed commands that
binary rejects, so anyone following them hit a hard error on their first compile.

Verified against the published `v0.1.1` binary:

```
$ axiom-rules-engine compile-composed --program … --rulespec-root … --output …
unknown command `compile-composed`                           (rc=1)

$ axiom-rules-engine compile --program … --rulespec-root … --output …
unknown compile argument `--rulespec-root`                   (rc=1)
```

`compile-composed` and `--rulespec-root` exist only on `main`. The released `v0.1.1` `compile`
takes `--program` and `--output`, and resolves canonical cross-repo imports (e.g.
`us:statutes/26/22#…`) with no root flag — which works well: **83 of 83** sampled published
policy modules across `rulespec-us`, `rulespec-uk`, `rulespec-be` and `rulespec-nz` compile
cleanly with it from fresh clones.

The docs also still pointed at `v0.1.0`, which predates artifact format v2 and cannot execute
current program artifacts.

## What changed

* Download tag and attestation `--source-ref` moved `v0.1.0` → `v0.1.1`.
* The compile examples are split into two clearly labelled sections — **the released v0.1.1
  CLI** and **the CLI built from current `main`** — so each reader follows the contract that
  matches the artifact they have. `main`'s documentation is preserved, not removed.
* Noted that `shasum --check` prints `WARNING: 1 line is improperly formatted` alongside `OK`,
  because the published `.sha256` files carry a trailing blank line (#122).

## Verification

The released-CLI example in the new section was run end-to-end from an empty directory —
download, checksum, extract, clone `rulespec-uk`, compile, execute:

```
tariff_income_weekly = 14 GBP | Coventry Council Tax Reduction Scheme 2026/27, paragraphs 42.1-42.2
```

(£9,500 capital, £6,000 threshold, £250 step, £1 per step → 14.)

## Not addressed here

`main`'s `Cargo.toml` still reports version `0.1.0` while being ahead of the `v0.1.1` tag, so a
source build identifies itself as older than the release. That is a version-policy decision, not
a docs fix — left in #121.
