### PR TITLE
Stop lowering from erasing commencement dates, match patterns, and unit declarations

### DIFF
--- a/src/dense.rs
+++ b/src/dense.rs
@@ -1,5 +1,6 @@
 use std::collections::{HashMap, HashSet};
 
+use chrono::NaiveDate;
 use rust_decimal::Decimal;
 use rust_decimal::prelude::{FromPrimitive, ToPrimitive};
 use thiserror::Error;
@@ -511,6 +512,11 @@ struct CompiledDerived {
     /// Applied to the whole evaluated column before it is cached, so dependents
     /// and direct outputs observe the same rounded values as the other paths.
     rounding: Option<Rounding>,
+    /// Commencement date of the single unbounded version this was compiled from,
+    /// when the source rule was versioned. Dense compiles once and executes for
+    /// many periods, so the date cannot be resolved at compile time; it is
+    /// enforced per execution instead. `None` for unversioned rules.
+    effective_from: Option<NaiveDate>,
 }
 
 #[derive(Clone, Debug)]
@@ -628,12 +634,31 @@ impl DenseCompiledProgram {
         self.execute_with::<f64>(period, batch, outputs)
     }
 
+    /// Every rule in a dense plan is reachable from the compiled roots, so a plan executed
+    /// before any of their commencement dates has no lawful answer. The generic executor
+    /// reports that per rule as `MissingDerivedFormulaVersion`; report it identically here
+    /// rather than computing a pre-commencement number (#84).
+    fn check_commencement(&self, period: &Period) -> Result<(), EvalError> {
+        for derived in &self.derived {
+            if let Some(effective_from) = derived.effective_from
+                && period.start < effective_from
+            {
+                return Err(EvalError::MissingDerivedFormulaVersion {
+                    derived: derived.name.clone(),
+                    at: period.start,
+                });
+            }
+        }
+        Ok(())
+    }
+
     fn execute_with<N: DenseNum>(
         &self,
         period: &Period,
         batch: DenseBatchSpec,
         outputs: &[String],
     ) -> Result<DenseExecutionResult, EvalError> {
+        self.check_commencement(period)?;
         let batch = self.bind_batch(batch)?;
         let mut executor: DenseExecutor<'_, N> = DenseExecutor::new(self, period, batch);
         let mut result = HashMap::new();
@@ -1067,11 +1092,21 @@ impl<'a> DenseCompiler<'a> {
             self.program.derived.get(name).ok_or_else(|| {
                 DenseCompileError::Unsupported(format!("unknown derived `{name}`"))
             })?;
-        if !derived.versions.is_empty() {
-            return Err(DenseCompileError::Unsupported(format!(
-                "versioned derived formulas in `{name}`; use generic API execution"
-            )));
-        }
+        // Since #84 stopped discarding commencement dates, every declared derived rule carries
+        // at least one version, so rejecting all versioned rules here would reject the whole
+        // corpus. The single unbounded version — the shape #84 restored — is compiled directly
+        // and its commencement enforced at execution time. Genuinely multi-version or
+        // end-bounded rules still need per-period selection the dense plan cannot express, and
+        // are still routed to the generic API.
+        let versioned_semantics = match derived.versions.as_slice() {
+            [] => None,
+            [only] if only.effective_to.is_none() => Some((&only.semantics, only.effective_from)),
+            _ => {
+                return Err(DenseCompileError::Unsupported(format!(
+                    "versioned derived formulas in `{name}`; use generic API execution"
+                )));
+            }
+        };
         if derived.entity != self.root_entity && derived.entity != SCALAR_ENTITY {
             return Err(DenseCompileError::CrossEntityDependency {
                 derived: name.to_string(),
@@ -1080,8 +1115,13 @@ impl<'a> DenseCompiler<'a> {
             });
         }
 
+        let (source_semantics, effective_from) = match versioned_semantics {
+            Some((semantics, from)) => (semantics, Some(from)),
+            None => (&derived.semantics, None),
+        };
+
         self.visiting.insert(name.to_string());
-        let compiled_semantics = match &derived.semantics {
+        let compiled_semantics = match source_semantics {
             DerivedSemantics::Scalar(expr) => {
                 CompiledSemantics::Scalar(self.compile_scalar_expr(name, expr)?)
             }
@@ -1096,6 +1136,7 @@ impl<'a> DenseCompiler<'a> {
             name: derived.name.clone(),
             semantics: compiled_semantics,
             rounding: derived.rounding,
+            effective_from,
         });
         self.derived_index.insert(name.to_string(), index);
         Ok(index)

--- a/src/formula.rs
+++ b/src/formula.rs
@@ -456,6 +456,7 @@ pub enum Expr {
     Match {
         subject: Box<Expr>,
         cases: Vec<(Expr, Expr)>,
+        default: Option<Box<Expr>>,
     },
 }
 
@@ -804,6 +805,7 @@ impl Parser {
         let subject = self.parse_or()?;
         self.consume(TokType::Colon)?;
         let mut cases = Vec::new();
+        let mut default = None;
         while matches!(
             self.peek(0).ty,
             TokType::Int
@@ -814,14 +816,27 @@ impl Parser {
                 | TokType::Ident
         ) && self.peek(1).ty == TokType::Arrow
         {
+            if default.is_some() {
+                let tok = self.peek(0);
+                return Err(FormulaError::parse(
+                    tok.line,
+                    tok.col,
+                    "a match wildcard arm must be final",
+                ));
+            }
             let pat = self.parse_primary()?;
             self.consume(TokType::Arrow)?;
             let res = self.parse_expr()?;
-            cases.push((pat, res));
+            if matches!(&pat, Expr::Var(name) if name == "_") {
+                default = Some(Box::new(res));
+            } else {
+                cases.push((pat, res));
+            }
         }
         Ok(Expr::Match {
             subject: Box::new(subject),
             cases,
+            default,
         })
     }
 
@@ -1657,20 +1672,31 @@ fn lower_to_scalar(e: &Expr, ctx: &LowerCtx) -> Result<ScalarExprSpec, FormulaEr
             then_expr: Box::new(lower_to_scalar(then_expr, ctx)?),
             else_expr: Box::new(lower_to_scalar(else_expr, ctx)?),
         },
-        Expr::Match { subject, cases } => {
-            // Lower as nested if/elif: `match s: a => x, b => y, c => z` →
-            // `if s == a: x elif s == b: y else: z`. The last case's value
-            // becomes the else branch (rather than a default 0) so all
-            // branches share the same dtype — the dense compiler enforces
-            // branch-dtype equality.
-            if cases.is_empty() {
+        Expr::Match {
+            subject,
+            cases,
+            default,
+        } => {
+            // Lower every concrete arm as a comparison. A final `_ => ...`
+            // arm is the explicit fallback. In compatibility mode a match
+            // without `_` retains the historical last result as its fallback,
+            // but its final pattern is still represented and RuleSpec lowering
+            // emits a warning (or rejects it in strict mode).
+            if cases.is_empty() && default.is_none() {
                 return Err(FormulaError::lower("empty match".to_string()));
             }
             let subj_scalar = lower_to_scalar(subject, ctx)?;
-            let (last_pat, last_res) = cases.last().unwrap();
-            let _ = last_pat; // last case is the fallthrough; pattern value unused
-            let mut expr = lower_to_scalar(last_res, ctx)?;
-            for (pat, res) in cases.iter().rev().skip(1) {
+            let mut expr = match default {
+                Some(default) => lower_to_scalar(default, ctx)?,
+                None => lower_to_scalar(
+                    &cases
+                        .last()
+                        .expect("non-empty match has a compatibility fallback")
+                        .1,
+                    ctx,
+                )?,
+            };
+            for (pat, res) in cases.iter().rev() {
                 expr = ScalarExprSpec::If {
                     condition: Box::new(JudgmentExprSpec::Comparison {
                         left: Box::new(subj_scalar.clone()),
@@ -1850,6 +1876,71 @@ fn lower_to_judgment(e: &Expr, ctx: &LowerCtx) -> Result<JudgmentExprSpec, Formu
 pub(crate) fn lower_source(source: &str) -> Result<ProgramSpec, FormulaError> {
     let module = parse_source(source)?;
     lower_module(&module)
+}
+
+/// Count `match` expressions that do not declare a final `_ => ...` arm.
+///
+/// RuleSpec uses this before lowering so compatibility mode can surface a
+/// warning while strict mode rejects the same source. Parsing is shared with
+/// normal formula lowering, so diagnostics cannot drift from the accepted
+/// expression grammar.
+pub(crate) fn non_exhaustive_match_count(formula: &str) -> Result<usize, FormulaError> {
+    let tokens = Lexer::new(formula).tokenise()?;
+    let mut parser = Parser::new(tokens);
+    let expr = parser.parse_expr()?;
+    if parser.peek(0).ty != TokType::Eof {
+        let tok = parser.peek(0);
+        return Err(FormulaError::parse(
+            tok.line,
+            tok.col,
+            "unexpected trailing token in formula",
+        ));
+    }
+    Ok(count_non_exhaustive_matches(&expr))
+}
+
+fn count_non_exhaustive_matches(expr: &Expr) -> usize {
+    match expr {
+        Expr::LitInt(_) | Expr::LitFloat(_) | Expr::LitStr(_) | Expr::LitBool(_) | Expr::Var(_) => {
+            0
+        }
+        Expr::BinOp { left, right, .. } => {
+            count_non_exhaustive_matches(left) + count_non_exhaustive_matches(right)
+        }
+        Expr::UnaryOp { operand, .. } => count_non_exhaustive_matches(operand),
+        Expr::Call { args, .. } => args.iter().map(count_non_exhaustive_matches).sum(),
+        Expr::FieldAccess { obj, .. } => count_non_exhaustive_matches(obj),
+        Expr::Index { target, index } => {
+            count_non_exhaustive_matches(target) + count_non_exhaustive_matches(index)
+        }
+        Expr::Cond {
+            condition,
+            then_expr,
+            else_expr,
+        } => {
+            count_non_exhaustive_matches(condition)
+                + count_non_exhaustive_matches(then_expr)
+                + count_non_exhaustive_matches(else_expr)
+        }
+        Expr::Match {
+            subject,
+            cases,
+            default,
+        } => {
+            usize::from(default.is_none())
+                + count_non_exhaustive_matches(subject)
+                + cases
+                    .iter()
+                    .map(|(pattern, result)| {
+                        count_non_exhaustive_matches(pattern) + count_non_exhaustive_matches(result)
+                    })
+                    .sum::<usize>()
+                + default
+                    .as_deref()
+                    .map(count_non_exhaustive_matches)
+                    .unwrap_or(0)
+        }
+    }
 }
 
 pub(crate) fn lower_judgment_formula(

--- a/src/formula.rs
+++ b/src/formula.rs
@@ -1231,20 +1231,17 @@ pub fn lower_module(module: &Module) -> Result<ProgramSpec, FormulaError> {
                 }
             };
         let semantics = lower_semantics(&last.expr, &dtype)?;
-        let versions = if v.values.len() > 1 || last.end.is_some() {
-            v.values
-                .iter()
-                .map(|value| {
-                    Ok(DerivedVersionSpec {
-                        effective_from: value.start,
-                        effective_to: value.end,
-                        semantics: lower_semantics(&value.expr, &dtype)?,
-                    })
+        let versions = v
+            .values
+            .iter()
+            .map(|value| {
+                Ok(DerivedVersionSpec {
+                    effective_from: value.start,
+                    effective_to: value.end,
+                    semantics: lower_semantics(&value.expr, &dtype)?,
                 })
-                .collect::<Result<Vec<DerivedVersionSpec>, FormulaError>>()?
-        } else {
-            Vec::new()
-        };
+            })
+            .collect::<Result<Vec<DerivedVersionSpec>, FormulaError>>()?;
         program.derived.push(DerivedSpec {
             id: None,
             name: v.path.clone(),

--- a/src/formula.rs
+++ b/src/formula.rs
@@ -1110,6 +1110,16 @@ pub fn parse_source(src: &str) -> Result<Module, FormulaError> {
 ///   lower to derived outputs attached to a synthetic `Scalar` entity so
 ///   they can be referenced from entity-scoped derived values.
 pub fn lower_module(module: &Module) -> Result<ProgramSpec, FormulaError> {
+    if let Some(variable) = module
+        .variables
+        .iter()
+        .find(|variable| variable.default.is_some())
+    {
+        return Err(FormulaError::lower(format!(
+            "variable `{}` declares unsupported `default`; write an explicit formula fallback",
+            variable.path
+        )));
+    }
     let mut program = ProgramSpec::default();
 
     // Helpful unit defaults so RuleSpec modules don't have to re-declare common

--- a/src/rulespec.rs
+++ b/src/rulespec.rs
@@ -92,6 +92,24 @@ pub enum RuleSpecError {
     MissingFormula { name: String },
     #[error("RuleSpec rule `{name}` has a formula version without effective_from")]
     MissingEffectiveFrom { name: String },
+    #[error(
+        "RuleSpec file `{path}` rule `{name}` declares more than one version effective from {effective_from}; give every version a unique effective_from"
+    )]
+    DuplicateEffectiveFrom {
+        path: String,
+        name: String,
+        effective_from: NaiveDate,
+    },
+    #[error(
+        "RuleSpec file `{path}` rule `{name}` has overlapping explicit version ranges: {first_from}..{first_to} overlaps the version starting {second_from}; end the first version before {second_from}"
+    )]
+    OverlappingVersionRanges {
+        path: String,
+        name: String,
+        first_from: NaiveDate,
+        first_to: NaiveDate,
+        second_from: NaiveDate,
+    },
     #[error("RuleSpec parameter table `{name}` has values but no indexed_by")]
     MissingIndexedBy { name: String },
     #[error(
@@ -1889,6 +1907,7 @@ impl RulesDocument {
                 }
                 Err(error) => return Err(error),
             };
+            rule.validate_version_ranges()?;
             // Rounding is an output-rule concern; reject it on any non-derived
             // kind up front (a parameter/relation with `rounding:` would
             // otherwise be silently dropped by the name-match that attaches it).
@@ -2076,6 +2095,12 @@ impl RulesDocument {
 }
 
 impl RuleDefinition {
+    fn source_path(&self) -> String {
+        self.origin_target
+            .clone()
+            .unwrap_or_else(|| "<memory>".to_string())
+    }
+
     fn canonical_rule_id(&self) -> Option<String> {
         self.origin_target
             .as_ref()
@@ -2119,6 +2144,46 @@ impl RuleDefinition {
             }];
         }
         Vec::new()
+    }
+
+    fn validate_version_ranges(&self) -> Result<(), RuleSpecError> {
+        let mut ranges = self
+            .effective_versions()
+            .into_iter()
+            .filter_map(|version| {
+                version
+                    .effective_from
+                    .map(|effective_from| (effective_from, version.effective_to))
+            })
+            .collect::<Vec<_>>();
+        ranges.sort_by_key(|(effective_from, _)| *effective_from);
+
+        for window in ranges.windows(2) {
+            let (first_from, first_to) = window[0];
+            let (second_from, _) = window[1];
+            if first_from == second_from {
+                return Err(RuleSpecError::DuplicateEffectiveFrom {
+                    path: self.source_path(),
+                    name: self.name.clone(),
+                    effective_from: first_from,
+                });
+            }
+            // An absent upper bound is intentionally superseded by the next
+            // later-starting version. Only an explicit inclusive upper bound
+            // can contradict the next version's commencement.
+            if let Some(first_to) = first_to
+                && first_to >= second_from
+            {
+                return Err(RuleSpecError::OverlappingVersionRanges {
+                    path: self.source_path(),
+                    name: self.name.clone(),
+                    first_from,
+                    first_to,
+                    second_from,
+                });
+            }
+        }
+        Ok(())
     }
 
     fn is_parameter_table(&self) -> bool {

--- a/src/rulespec.rs
+++ b/src/rulespec.rs
@@ -88,6 +88,10 @@ pub enum RuleSpecError {
         "RuleSpec rule `{name}` declares `rounding` but has kind `{kind}`; output rounding applies only to `derived` currency rules"
     )]
     RoundingOnNonDerivedRule { name: String, kind: String },
+    #[error(
+        "RuleSpec file `{path}` rule `{name}` declares unsupported `default`; rule-level defaults have no defined semantics, so remove it and express the fallback explicitly in the formula"
+    )]
+    UnsupportedDefault { path: String, name: String },
     #[error("RuleSpec rule `{name}` has no formula version")]
     MissingFormula { name: String },
     #[error("RuleSpec rule `{name}` has a formula version without effective_from")]
@@ -1917,6 +1921,7 @@ impl RulesDocument {
                 Err(error) => return Err(error),
             };
             rule.validate_version_ranges()?;
+            rule.reject_unsupported_default()?;
             // Rounding is an output-rule concern; reject it on any non-derived
             // kind up front (a parameter/relation with `rounding:` would
             // otherwise be silently dropped by the name-match that attaches it).
@@ -2212,6 +2217,16 @@ impl RuleDefinition {
         Ok(())
     }
 
+    fn reject_unsupported_default(&self) -> Result<(), RuleSpecError> {
+        if self.default.is_some() {
+            return Err(RuleSpecError::UnsupportedDefault {
+                path: self.source_path(),
+                name: self.name.clone(),
+            });
+        }
+        Ok(())
+    }
+
     fn is_parameter_table(&self) -> bool {
         self.versions
             .iter()
@@ -2499,7 +2514,6 @@ impl RuleDefinition {
         write_metadata(out, "unit", self.unit.as_deref());
         write_metadata(out, "label", self.label.as_deref());
         write_metadata(out, "description", self.description.as_deref());
-        write_metadata(out, "default", self.default.as_deref());
         write_metadata(out, "indexed_by", self.indexed_by.as_deref());
         write_metadata(out, "status", self.status.as_deref());
         let (source, source_url) = self.effective_source();

--- a/src/rulespec.rs
+++ b/src/rulespec.rs
@@ -1,4 +1,5 @@
 use std::collections::{BTreeMap, HashMap, HashSet};
+use std::fmt;
 #[cfg(feature = "fs")]
 use std::fs;
 #[cfg(feature = "fs")]
@@ -223,6 +224,85 @@ pub enum RuleSpecError {
         "RuleSpec module `{path}` declares removed plural `corpus_citation_paths`; every source/proof node must declare exactly one singular `corpus_citation_path`"
     )]
     PluralCorpusCitationPaths { path: String },
+    #[error("strict RuleSpec validation failed:\n{0}")]
+    StrictDiagnostics(RuleSpecDiagnosticReport),
+}
+
+/// Options for RuleSpec semantic lowering.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct RuleSpecLoweringOptions {
+    /// Promote compatibility diagnostics to hard errors.
+    pub strict: bool,
+}
+
+impl RuleSpecLoweringOptions {
+    pub const fn strict() -> Self {
+        Self { strict: true }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RuleSpecDiagnosticCode {
+    NonExhaustiveMatch,
+}
+
+impl RuleSpecDiagnosticCode {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::NonExhaustiveMatch => "non_exhaustive_match",
+        }
+    }
+}
+
+/// A compatibility diagnostic produced while lowering a RuleSpec module.
+///
+/// Diagnostics are warnings under the default options and errors under
+/// [`RuleSpecLoweringOptions::strict`].
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RuleSpecDiagnostic {
+    pub code: RuleSpecDiagnosticCode,
+    /// Canonical module target, or `<memory>` for an in-memory document.
+    pub path: String,
+    pub rule: String,
+    pub occurrences: usize,
+}
+
+impl fmt::Display for RuleSpecDiagnostic {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let expression = if self.occurrences == 1 {
+            "expression"
+        } else {
+            "expressions"
+        };
+        write!(
+            formatter,
+            "RuleSpec file `{}` rule `{}` has {} non-exhaustive `match` {expression}; add a final `_ => <fallback>` arm to each match",
+            self.path, self.rule, self.occurrences
+        )
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RuleSpecDiagnosticReport {
+    pub diagnostics: Vec<RuleSpecDiagnostic>,
+}
+
+impl fmt::Display for RuleSpecDiagnosticReport {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for (index, diagnostic) in self.diagnostics.iter().enumerate() {
+            if index > 0 {
+                formatter.write_str("\n")?;
+            }
+            write!(formatter, "{diagnostic}")?;
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct RuleSpecLoweringOutcome {
+    pub program: ProgramSpec,
+    pub diagnostics: Vec<RuleSpecDiagnostic>,
 }
 
 #[derive(Clone, Debug, Default, Deserialize)]
@@ -749,6 +829,15 @@ fn is_canonical_corpus_jurisdiction(value: &str) -> bool {
 }
 
 pub fn lower_rulespec_str(source: &str) -> Result<ProgramSpec, RuleSpecError> {
+    let outcome = lower_rulespec_str_with_options(source, RuleSpecLoweringOptions::default())?;
+    emit_rule_spec_diagnostics(&outcome.diagnostics);
+    Ok(outcome.program)
+}
+
+pub fn lower_rulespec_str_with_options(
+    source: &str,
+    options: RuleSpecLoweringOptions,
+) -> Result<RuleSpecLoweringOutcome, RuleSpecError> {
     if !looks_like_rulespec_yaml(source) {
         return Err(RuleSpecError::MissingDiscriminator);
     }
@@ -759,7 +848,7 @@ pub fn lower_rulespec_str(source: &str) -> Result<ProgramSpec, RuleSpecError> {
     let mut document: RulesDocument = serde_yaml::from_str(source)?;
     document.validate_atomic_module_metadata("<memory>")?;
     document.assign_origin_target(None);
-    document.to_program_spec()
+    document.to_program_spec_with_options(options)
 }
 
 #[cfg(feature = "fs")]
@@ -767,9 +856,20 @@ pub fn load_rulespec_file(
     path: impl AsRef<Path>,
     roots: &CanonicalRuleSpecRoots,
 ) -> Result<ProgramSpec, RuleSpecError> {
+    let outcome = load_rulespec_file_with_options(path, roots, RuleSpecLoweringOptions::default())?;
+    emit_rule_spec_diagnostics(&outcome.diagnostics);
+    Ok(outcome.program)
+}
+
+#[cfg(feature = "fs")]
+pub fn load_rulespec_file_with_options(
+    path: impl AsRef<Path>,
+    roots: &CanonicalRuleSpecRoots,
+    options: RuleSpecLoweringOptions,
+) -> Result<RuleSpecLoweringOutcome, RuleSpecError> {
     let target = roots.target_for_path(path.as_ref())?;
     let source = crate::source::FsModuleSource::from_validated_roots(roots.clone());
-    load_rulespec_with_source(&target, &source)
+    load_rulespec_with_source_with_options(&target, &source, options)
 }
 
 /// Load an ephemeral RuleSpec program emitted by `axiom-compose`.
@@ -783,6 +883,18 @@ pub fn load_composed_rulespec_file(
     path: impl AsRef<Path>,
     roots: &CanonicalRuleSpecRoots,
 ) -> Result<ProgramSpec, RuleSpecError> {
+    let outcome =
+        load_composed_rulespec_file_with_options(path, roots, RuleSpecLoweringOptions::default())?;
+    emit_rule_spec_diagnostics(&outcome.diagnostics);
+    Ok(outcome.program)
+}
+
+#[cfg(feature = "fs")]
+pub fn load_composed_rulespec_file_with_options(
+    path: impl AsRef<Path>,
+    roots: &CanonicalRuleSpecRoots,
+    options: RuleSpecLoweringOptions,
+) -> Result<RuleSpecLoweringOutcome, RuleSpecError> {
     let path = path.as_ref();
     validate_exact_regular_yaml(path)?;
     if roots.contains_path(path) {
@@ -812,7 +924,7 @@ pub fn load_composed_rulespec_file(
         combined = merge_rules_documents(combined, imported);
     }
     combined = merge_rules_documents(combined, document.without_imports());
-    combined.to_program_spec()
+    combined.to_program_spec_with_options(options)
 }
 
 /// Load and lower the module at `root_target` (canonical form, for example
@@ -828,10 +940,30 @@ pub fn load_rulespec_with_source(
     root_target: &str,
     source: &dyn ModuleSource,
 ) -> Result<ProgramSpec, RuleSpecError> {
+    let outcome = load_rulespec_with_source_with_options(
+        root_target,
+        source,
+        RuleSpecLoweringOptions::default(),
+    )?;
+    emit_rule_spec_diagnostics(&outcome.diagnostics);
+    Ok(outcome.program)
+}
+
+pub fn load_rulespec_with_source_with_options(
+    root_target: &str,
+    source: &dyn ModuleSource,
+    options: RuleSpecLoweringOptions,
+) -> Result<RuleSpecLoweringOutcome, RuleSpecError> {
     let root_target = validate_module_target(root_target)?;
     let mut context = SourceLoadContext::default();
     let document = load_rulespec_document_from_source(&root_target, source, &mut context)?;
-    document.to_program_spec()
+    document.to_program_spec_with_options(options)
+}
+
+fn emit_rule_spec_diagnostics(diagnostics: &[RuleSpecDiagnostic]) {
+    for diagnostic in diagnostics {
+        eprintln!("warning[{}]: {diagnostic}", diagnostic.code.as_str());
+    }
 }
 
 #[derive(Default)]
@@ -1706,6 +1838,21 @@ impl RulesDocument {
     }
 
     pub fn to_program_spec(&self) -> Result<ProgramSpec, RuleSpecError> {
+        let outcome = self.to_program_spec_with_options(RuleSpecLoweringOptions::default())?;
+        emit_rule_spec_diagnostics(&outcome.diagnostics);
+        Ok(outcome.program)
+    }
+
+    pub fn to_program_spec_with_options(
+        &self,
+        options: RuleSpecLoweringOptions,
+    ) -> Result<RuleSpecLoweringOutcome, RuleSpecError> {
+        let diagnostics = self.compatibility_diagnostics()?;
+        if options.strict && !diagnostics.is_empty() {
+            return Err(RuleSpecError::StrictDiagnostics(RuleSpecDiagnosticReport {
+                diagnostics,
+            }));
+        }
         if !self.relations.is_empty() {
             return Err(RuleSpecError::TopLevelRelationsUnsupported);
         }
@@ -1822,7 +1969,39 @@ impl RulesDocument {
         // Carried for tooling and artifact pass-through only; nothing in
         // compilation or execution reads it.
         program.module = self.module.clone();
-        Ok(program)
+        Ok(RuleSpecLoweringOutcome {
+            program,
+            diagnostics,
+        })
+    }
+
+    fn compatibility_diagnostics(&self) -> Result<Vec<RuleSpecDiagnostic>, RuleSpecError> {
+        let mut diagnostics = Vec::new();
+        for rule in &self.rules {
+            let mut occurrences = 0;
+            for version in rule.effective_versions() {
+                if let Some(formula) = version
+                    .formula
+                    .as_deref()
+                    .map(str::trim)
+                    .filter(|formula| !formula.is_empty())
+                {
+                    occurrences += crate::formula::non_exhaustive_match_count(formula)?;
+                }
+            }
+            if occurrences > 0 {
+                diagnostics.push(RuleSpecDiagnostic {
+                    code: RuleSpecDiagnosticCode::NonExhaustiveMatch,
+                    path: rule
+                        .origin_target
+                        .clone()
+                        .unwrap_or_else(|| "<memory>".to_string()),
+                    rule: rule.name.clone(),
+                    occurrences,
+                });
+            }
+        }
+        Ok(diagnostics)
     }
 
     fn apply_rule_ids(&self, program: &mut ProgramSpec) {

--- a/src/rulespec.rs
+++ b/src/rulespec.rs
@@ -233,6 +233,14 @@ pub enum RuleSpecError {
         new: usize,
     },
     #[error(
+        "RuleSpec program declares unit `{name}` with conflicting kinds `{first}` and `{second}`; keep one declaration or make repeated declarations identical"
+    )]
+    ConflictingUnitDeclarations {
+        name: String,
+        first: String,
+        second: String,
+    },
+    #[error(
         "RuleSpec module `{path}` declares source_verification.source_sha256 `{value}`, which is not a 64-character hexadecimal SHA-256 digest"
     )]
     InvalidSourceSha256 { path: String, value: String },
@@ -1874,6 +1882,7 @@ impl RulesDocument {
         if !self.relations.is_empty() {
             return Err(RuleSpecError::TopLevelRelationsUnsupported);
         }
+        self.validate_unit_declarations()?;
         let mut formula_source = String::new();
         self.write_header(&mut formula_source);
 
@@ -2021,6 +2030,23 @@ impl RulesDocument {
             }
         }
         Ok(diagnostics)
+    }
+
+    fn validate_unit_declarations(&self) -> Result<(), RuleSpecError> {
+        let mut declarations: HashMap<&str, &crate::spec::UnitKindSpec> = HashMap::new();
+        for unit in &self.units {
+            if let Some(first) = declarations.get(unit.name.as_str())
+                && !unit_kinds_equal(first, &unit.kind)
+            {
+                return Err(RuleSpecError::ConflictingUnitDeclarations {
+                    name: unit.name.clone(),
+                    first: unit_kind_label(first),
+                    second: unit_kind_label(&unit.kind),
+                });
+            }
+            declarations.entry(&unit.name).or_insert(&unit.kind);
+        }
+        Ok(())
     }
 
     fn apply_rule_ids(&self, program: &mut ProgramSpec) {
@@ -2547,6 +2573,38 @@ impl RuleDefinition {
             .clone()
             .or_else(|| self.sources.iter().find_map(|source| source.url.clone()));
         (citation, url)
+    }
+}
+
+fn unit_kinds_equal(left: &crate::spec::UnitKindSpec, right: &crate::spec::UnitKindSpec) -> bool {
+    use crate::spec::UnitKindSpec;
+
+    match (left, right) {
+        (
+            UnitKindSpec::Currency { minor_units: left },
+            UnitKindSpec::Currency { minor_units: right },
+        ) => left == right,
+        (UnitKindSpec::Count, UnitKindSpec::Count)
+        | (UnitKindSpec::Ratio, UnitKindSpec::Ratio)
+        | (UnitKindSpec::Duration, UnitKindSpec::Duration) => true,
+        (UnitKindSpec::Custom { label: left }, UnitKindSpec::Custom { label: right }) => {
+            left == right
+        }
+        _ => false,
+    }
+}
+
+fn unit_kind_label(kind: &crate::spec::UnitKindSpec) -> String {
+    use crate::spec::UnitKindSpec;
+
+    match kind {
+        UnitKindSpec::Currency { minor_units } => {
+            format!("currency(minor_units: {minor_units})")
+        }
+        UnitKindSpec::Count => "count".to_string(),
+        UnitKindSpec::Ratio => "ratio".to_string(),
+        UnitKindSpec::Duration => "duration".to_string(),
+        UnitKindSpec::Custom { label } => format!("custom(label: {label})"),
     }
 }
 

--- a/tests/dense.rs
+++ b/tests/dense.rs
@@ -3470,3 +3470,71 @@ rules:
     };
     assert_eq!(values, &vec![decimal("0.5")]);
 }
+
+/// A derived rule with a single unbounded version compiles into a dense plan (that shape is
+/// what every declared rule has since #84 stopped discarding commencement dates), but the plan
+/// must refuse to answer for a period before the rule commenced rather than computing a
+/// pre-commencement number. Dense compiles once and executes for many periods, so the date is
+/// enforced per execution.
+#[test]
+fn dense_versioned_derived_refuses_periods_before_commencement() {
+    let rulespec = r#"
+format: rulespec/v1
+rules:
+  - name: taper_fraction
+    kind: derived
+    entity: Scalar
+    dtype: Rate
+    period: Month
+    versions:
+      - effective_from: '2026-01-01'
+        formula: |-
+          1 / 2
+"#;
+    let artifact =
+        CompiledProgramArtifact::from_rulespec_str(rulespec).expect("RuleSpec module compiles");
+    let dense = DenseCompiledProgram::from_artifact(&artifact, None)
+        .expect("a single unbounded version compiles densely");
+
+    let batch = || DenseBatchSpec {
+        row_count: 1,
+        inputs: HashMap::new(),
+        relations: HashMap::new(),
+    };
+
+    // On the commencement month the plan answers normally.
+    let on_time = PeriodSpec {
+        kind: PeriodKindSpec::Month,
+        start: chrono::NaiveDate::from_ymd_opt(2026, 1, 1).expect("date"),
+        end: chrono::NaiveDate::from_ymd_opt(2026, 1, 31).expect("date"),
+    };
+    dense
+        .execute(
+            &on_time.to_model().expect("period converts"),
+            batch(),
+            &["taper_fraction".to_string()],
+        )
+        .expect("executes on its effective date");
+
+    // A month before commencement must fail the same way the generic executor does.
+    let too_early = PeriodSpec {
+        kind: PeriodKindSpec::Month,
+        start: chrono::NaiveDate::from_ymd_opt(2025, 12, 1).expect("date"),
+        end: chrono::NaiveDate::from_ymd_opt(2025, 12, 31).expect("date"),
+    };
+    let error = dense
+        .execute(
+            &too_early.to_model().expect("period converts"),
+            batch(),
+            &["taper_fraction".to_string()],
+        )
+        .expect_err("must not answer before commencement");
+    assert!(
+        matches!(
+            error,
+            axiom_rules_engine::engine::EvalError::MissingDerivedFormulaVersion { ref derived, .. }
+                if derived == "taper_fraction"
+        ),
+        "unexpected error: {error:?}"
+    );
+}

--- a/tests/execution.rs
+++ b/tests/execution.rs
@@ -508,6 +508,89 @@ rules:
     }
 }
 
+#[test]
+fn exhaustive_match_uses_wildcard_only_for_unmatched_subjects() {
+    let rulespec = r#"
+format: rulespec/v1
+rules:
+  - name: filing_credit
+    kind: derived
+    entity: TaxUnit
+    dtype: Integer
+    period: Day
+    versions:
+      - effective_from: 2026-01-01
+        formula: |
+          match filing_status:
+              "single" => 10
+              "joint" => 20
+              _ => 99
+"#;
+    let program = axiom_rules_engine::rulespec::lower_rulespec_str(rulespec)
+        .expect("exhaustive match lowers");
+    let date = chrono::NaiveDate::from_ymd_opt(2026, 1, 1).expect("valid date");
+    let period = PeriodSpec {
+        kind: PeriodKindSpec::Custom {
+            name: "Day".to_string(),
+        },
+        start: date,
+        end: date,
+    };
+
+    for mode in [ExecutionMode::Explain, ExecutionMode::Fast] {
+        let response = execute_request(ExecutionRequest {
+            mode,
+            program: program.clone(),
+            dataset: DatasetSpec {
+                inputs: [
+                    ("single-filer", "single"),
+                    ("joint-filer", "joint"),
+                    ("widowed-filer", "widowed"),
+                ]
+                .into_iter()
+                .map(|(entity_id, filing_status)| InputRecordSpec {
+                    name: "filing_status".to_string(),
+                    entity: "TaxUnit".to_string(),
+                    entity_id: entity_id.to_string(),
+                    interval: IntervalSpec {
+                        start: date,
+                        end: date,
+                    },
+                    value: ScalarValueSpec::Text {
+                        value: filing_status.to_string(),
+                    },
+                })
+                .collect(),
+                relations: Vec::new(),
+            },
+            queries: ["single-filer", "joint-filer", "widowed-filer"]
+                .into_iter()
+                .map(|entity_id| ExecutionQuery {
+                    assessment_date: None,
+                    entity_id: entity_id.to_string(),
+                    period: period.clone(),
+                    outputs: vec!["filing_credit".to_string()],
+                })
+                .collect(),
+        })
+        .expect("match executes");
+
+        let values = response
+            .results
+            .iter()
+            .map(|result| {
+                integer_output(
+                    result
+                        .outputs
+                        .get("filing_credit")
+                        .expect("filing_credit output"),
+                )
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(values, vec![10, 20, 99]);
+    }
+}
+
 fn integer_result(
     program: &ProgramSpec,
     mode: ExecutionMode,

--- a/tests/execution.rs
+++ b/tests/execution.rs
@@ -470,6 +470,44 @@ rules:
     }
 }
 
+#[test]
+fn single_unbounded_derived_version_does_not_apply_before_its_effective_date() {
+    let rulespec = r#"
+format: rulespec/v1
+rules:
+  - name: dated_belgian_amount
+    kind: derived
+    entity: TaxUnit
+    dtype: Integer
+    period: Day
+    versions:
+      - effective_from: 2022-01-01
+        formula: "17"
+"#;
+    let program = axiom_rules_engine::rulespec::lower_rulespec_str(rulespec)
+        .expect("single-version derived RuleSpec lowers");
+
+    for mode in [ExecutionMode::Explain, ExecutionMode::Fast] {
+        assert!(matches!(
+            integer_result(
+                &program,
+                mode.clone(),
+                2019,
+                1,
+                1,
+                "dated_belgian_amount"
+            ),
+            Err(ApiError::Eval(EvalError::MissingDerivedFormulaVersion { derived, .. }))
+                if derived == "dated_belgian_amount"
+        ));
+        assert_eq!(
+            integer_result(&program, mode, 2022, 1, 1, "dated_belgian_amount")
+                .expect("derived applies on its effective date"),
+            17
+        );
+    }
+}
+
 fn integer_result(
     program: &ProgramSpec,
     mode: ExecutionMode,

--- a/tests/rulespec.rs
+++ b/tests/rulespec.rs
@@ -2291,6 +2291,132 @@ rules:
 }
 
 #[test]
+fn rulespec_rejects_duplicate_version_starts_in_either_order_and_on_table_parameters() {
+    for (first, second) in [("10", "20"), ("20", "10")] {
+        let rulespec = format!(
+            r#"
+format: rulespec/v1
+rules:
+  - name: ambiguous_amount
+    kind: derived
+    entity: TaxUnit
+    dtype: Integer
+    versions:
+      - effective_from: 2026-01-01
+        formula: "{first}"
+      - effective_from: 2026-01-01
+        formula: "{second}"
+"#
+        );
+        let error = lower_rulespec_str(&rulespec)
+            .expect_err("equal-start derived versions must be rejected");
+        assert!(matches!(
+            error,
+            RuleSpecError::DuplicateEffectiveFrom {
+                name,
+                effective_from,
+                ..
+            } if name == "ambiguous_amount"
+                && effective_from
+                    == chrono::NaiveDate::from_ymd_opt(2026, 1, 1).expect("valid date")
+        ));
+    }
+
+    let table = r#"
+format: rulespec/v1
+rules:
+  - name: ambiguous_table
+    kind: parameter
+    dtype: Integer
+    indexed_by: household_size
+    versions:
+      - effective_from: 2026-01-01
+        values:
+          1: 10
+      - effective_from: 2026-01-01
+        values:
+          1: 20
+"#;
+    assert!(matches!(
+        lower_rulespec_str(table),
+        Err(RuleSpecError::DuplicateEffectiveFrom { name, .. })
+            if name == "ambiguous_table"
+    ));
+}
+
+#[test]
+fn rulespec_rejects_explicit_inclusive_version_overlap_in_either_order() {
+    let versions = [
+        r#"
+      - effective_from: 2025-01-01
+        effective_to: 2026-01-01
+        formula: "10"
+      - effective_from: 2026-01-01
+        formula: "20""#,
+        r#"
+      - effective_from: 2026-01-01
+        formula: "20"
+      - effective_from: 2025-01-01
+        effective_to: 2026-01-01
+        formula: "10""#,
+    ];
+    for versions in versions {
+        let rulespec = format!(
+            r#"
+format: rulespec/v1
+rules:
+  - name: overlapping_amount
+    kind: derived
+    entity: TaxUnit
+    dtype: Integer
+    versions:{versions}
+"#
+        );
+        let error = lower_rulespec_str(&rulespec).expect_err("inclusive overlap must be rejected");
+        assert!(matches!(
+            error,
+            RuleSpecError::OverlappingVersionRanges {
+                name,
+                first_from,
+                first_to,
+                second_from,
+                ..
+            } if name == "overlapping_amount"
+                && first_from
+                    == chrono::NaiveDate::from_ymd_opt(2025, 1, 1).expect("valid date")
+                && first_to
+                    == chrono::NaiveDate::from_ymd_opt(2026, 1, 1).expect("valid date")
+                && second_from == first_to
+        ));
+    }
+}
+
+#[test]
+fn rulespec_allows_later_versions_to_supersede_open_ended_versions() {
+    let rulespec = r#"
+format: rulespec/v1
+rules:
+  - name: superseded_amount
+    kind: derived
+    entity: TaxUnit
+    dtype: Integer
+    versions:
+      - effective_from: 2025-01-01
+        formula: "10"
+      - effective_from: 2026-01-01
+        formula: "20"
+"#;
+
+    let program = lower_rulespec_str(rulespec).expect("later start supersedes earlier version");
+    let derived = program
+        .derived
+        .iter()
+        .find(|derived| derived.name == "superseded_amount")
+        .expect("derived output present");
+    assert_eq!(derived.versions.len(), 2);
+}
+
+#[test]
 fn non_exhaustive_match_warns_by_default_and_errors_in_strict_mode() {
     let rulespec = r#"
 format: rulespec/v1

--- a/tests/rulespec.rs
+++ b/tests/rulespec.rs
@@ -5,7 +5,9 @@ use axiom_rules_engine::compile::{
     CompileError, CompiledProgramArtifact, compile_program_file_to_json,
 };
 use axiom_rules_engine::rulespec::{
-    CanonicalRuleSpecRoots, RuleSpecError, ValidationStatus, lower_rulespec_str,
+    CanonicalRuleSpecRoots, RuleSpecDiagnosticCode, RuleSpecError, RuleSpecLoweringOptions,
+    ValidationStatus, load_rulespec_file_with_options, lower_rulespec_str,
+    lower_rulespec_str_with_options,
 };
 use axiom_rules_engine::spec::{
     DatasetSpec, DerivedSemanticsSpec, InputRecordSpec, IntervalSpec, PeriodKindSpec, PeriodSpec,
@@ -2286,6 +2288,164 @@ rules:
             expr: ScalarExprSpec::Input { name },
         } if name == "able_account_contributions"
     ));
+}
+
+#[test]
+fn non_exhaustive_match_warns_by_default_and_errors_in_strict_mode() {
+    let rulespec = r#"
+format: rulespec/v1
+rules:
+  - name: filing_credit
+    kind: derived
+    entity: TaxUnit
+    dtype: Integer
+    versions:
+      - effective_from: 2026-01-01
+        formula: |
+          match filing_status:
+              "single" => 10
+              "joint" => 20
+"#;
+
+    let outcome = lower_rulespec_str_with_options(rulespec, RuleSpecLoweringOptions::default())
+        .expect("compatibility lowering succeeds");
+    assert_eq!(outcome.diagnostics.len(), 1);
+    let diagnostic = &outcome.diagnostics[0];
+    assert_eq!(diagnostic.code, RuleSpecDiagnosticCode::NonExhaustiveMatch);
+    assert_eq!(diagnostic.path, "<memory>");
+    assert_eq!(diagnostic.rule, "filing_credit");
+    assert_eq!(diagnostic.occurrences, 1);
+    assert!(
+        diagnostic
+            .to_string()
+            .contains("add a final `_ => <fallback>` arm")
+    );
+
+    // Compatibility lowering retains every concrete pattern. The final
+    // `joint` arm is an actual comparison, not an erased fallthrough.
+    let derived = outcome
+        .program
+        .derived
+        .iter()
+        .find(|derived| derived.name == "filing_credit")
+        .expect("derived output present");
+    let DerivedSemanticsSpec::Scalar { expr } = &derived.semantics else {
+        panic!("filing_credit should lower as a scalar");
+    };
+    let ScalarExprSpec::If {
+        else_expr: joint_arm,
+        ..
+    } = expr
+    else {
+        panic!("single pattern should lower to an if");
+    };
+    assert!(
+        matches!(joint_arm.as_ref(), ScalarExprSpec::If { .. }),
+        "the final concrete pattern must be preserved as a comparison"
+    );
+
+    let error = lower_rulespec_str_with_options(rulespec, RuleSpecLoweringOptions::strict())
+        .expect_err("strict lowering rejects a match without a wildcard");
+    assert!(matches!(
+        error,
+        RuleSpecError::StrictDiagnostics(report)
+            if report.diagnostics.len() == 1
+                && report.diagnostics[0].rule == "filing_credit"
+    ));
+}
+
+#[test]
+fn exhaustive_match_uses_an_explicit_wildcard_without_a_diagnostic() {
+    let rulespec = r#"
+format: rulespec/v1
+rules:
+  - name: filing_credit
+    kind: derived
+    entity: TaxUnit
+    dtype: Integer
+    versions:
+      - effective_from: 2026-01-01
+        formula: |
+          match filing_status:
+              "single" => 10
+              "joint" => 20
+              _ => 0
+"#;
+
+    let outcome = lower_rulespec_str_with_options(rulespec, RuleSpecLoweringOptions::strict())
+        .expect("a final wildcard is exhaustive");
+    assert!(outcome.diagnostics.is_empty());
+
+    let derived = outcome
+        .program
+        .derived
+        .iter()
+        .find(|derived| derived.name == "filing_credit")
+        .expect("derived output present");
+    let DerivedSemanticsSpec::Scalar { expr } = &derived.semantics else {
+        panic!("filing_credit should lower as a scalar");
+    };
+    let ScalarExprSpec::If {
+        else_expr: joint_arm,
+        ..
+    } = expr
+    else {
+        panic!("single pattern should lower to an if");
+    };
+    let ScalarExprSpec::If {
+        else_expr: wildcard,
+        ..
+    } = joint_arm.as_ref()
+    else {
+        panic!("joint pattern should lower to an if");
+    };
+    assert!(matches!(
+        wildcard.as_ref(),
+        ScalarExprSpec::Literal {
+            value: ScalarValueSpec::Integer { value: 0 }
+        }
+    ));
+}
+
+#[test]
+fn match_diagnostic_names_the_canonical_source_file() {
+    let root = unique_test_root();
+    let repository = root.join("rulespec-us");
+    let rules_file = repository.join("us/policies/tax/filing-credit.yaml");
+    fs::create_dir_all(rules_file.parent().expect("rules file has parent"))
+        .expect("create temp rules repository");
+    fs::write(
+        &rules_file,
+        r#"
+format: rulespec/v1
+rules:
+  - name: filing_credit
+    kind: derived
+    entity: TaxUnit
+    dtype: Integer
+    versions:
+      - effective_from: 2026-01-01
+        formula: |
+          match filing_status:
+              "single" => 10
+              "joint" => 20
+"#,
+    )
+    .expect("write temp RuleSpec");
+
+    let roots = CanonicalRuleSpecRoots::new([&repository]).expect("repository root is valid");
+    let outcome =
+        load_rulespec_file_with_options(&rules_file, &roots, RuleSpecLoweringOptions::default())
+            .expect("compatibility lowering succeeds");
+    assert_eq!(outcome.diagnostics.len(), 1);
+    assert_eq!(outcome.diagnostics[0].path, "us:policies/tax/filing-credit");
+    assert!(
+        outcome.diagnostics[0]
+            .to_string()
+            .contains("RuleSpec file `us:policies/tax/filing-credit`")
+    );
+
+    let _ = fs::remove_dir_all(root);
 }
 
 #[test]

--- a/tests/rulespec.rs
+++ b/tests/rulespec.rs
@@ -2476,6 +2476,35 @@ rules: []
 }
 
 #[test]
+fn rulespec_rejects_default_instead_of_discarding_it() {
+    let rulespec = r#"
+format: rulespec/v1
+rules:
+  - name: amount_with_fallback
+    kind: derived
+    entity: TaxUnit
+    dtype: Integer
+    default: 17
+    versions:
+      - effective_from: 2026-01-01
+        formula: optional_amount
+"#;
+
+    let error =
+        lower_rulespec_str(rulespec).expect_err("an unsupported default must not be discarded");
+    assert!(matches!(
+        &error,
+        RuleSpecError::UnsupportedDefault { path, name }
+            if path == "<memory>" && name == "amount_with_fallback"
+    ));
+    assert!(
+        error
+            .to_string()
+            .contains("express the fallback explicitly in the formula")
+    );
+}
+
+#[test]
 fn non_exhaustive_match_warns_by_default_and_errors_in_strict_mode() {
     let rulespec = r#"
 format: rulespec/v1

--- a/tests/rulespec.rs
+++ b/tests/rulespec.rs
@@ -2417,6 +2417,65 @@ rules:
 }
 
 #[test]
+fn rulespec_rejects_conflicting_unit_declarations_in_either_order() {
+    for (first, second) in [(2, 4), (4, 2)] {
+        let rulespec = format!(
+            r#"
+format: rulespec/v1
+units:
+  - name: EUR
+    kind: currency
+    minor_units: {first}
+  - name: EUR
+    kind: currency
+    minor_units: {second}
+rules: []
+"#
+        );
+
+        let error = lower_rulespec_str(&rulespec)
+            .expect_err("conflicting repeated unit declarations must be rejected");
+        assert!(matches!(
+            error,
+            RuleSpecError::ConflictingUnitDeclarations {
+                name,
+                first: first_kind,
+                second: second_kind,
+            } if name == "EUR"
+                && first_kind == format!("currency(minor_units: {first})")
+                && second_kind == format!("currency(minor_units: {second})")
+        ));
+    }
+}
+
+#[test]
+fn rulespec_allows_identical_repeated_unit_declarations() {
+    let rulespec = r#"
+format: rulespec/v1
+units:
+  - name: EUR
+    kind: currency
+    minor_units: 2
+  - name: EUR
+    kind: currency
+    minor_units: 2
+rules: []
+"#;
+
+    let program = lower_rulespec_str(rulespec).expect("identical declarations are idempotent");
+    let eur = program
+        .units
+        .iter()
+        .filter(|unit| unit.name == "EUR")
+        .collect::<Vec<_>>();
+    assert_eq!(eur.len(), 1);
+    assert!(matches!(
+        eur[0].kind,
+        UnitKindSpec::Currency { minor_units: 2 }
+    ));
+}
+
+#[test]
 fn non_exhaustive_match_warns_by_default_and_errors_in_strict_mode() {
     let rulespec = r#"
 format: rulespec/v1


### PR DESCRIPTION
Fixes #84. Fixes #82. Refs #124.

Lowering was allowed to erase legal distinctions. Four related fixes, plus the dense-path work
the first one turned out to require.

## #84 — commencement dates were discarded (the big one)

A derived rule with exactly one unbounded version had its `effective_from` dropped at compile
time, and the runtime treats an empty version list as timeless — so rules answered for periods
before they existed. A published Belgian rule dated `2022-01-01` returned its value for January
2019.

Fixed as default behaviour, since the current result is simply wrong. Measured over published
content, comparing this branch against `main`:

```
derived rules sampled                : 501   (uk, be, nz, gh)
timeless BEFORE                      : 501  (100.0%)
timeless AFTER                       : 0
modules compiled, main               : 46/46
modules compiled, this branch        : 46/46   ← compile success unchanged
```

**Behaviour change worth calling out in release notes:** a query for a period before a rule
commenced now returns `MissingDerivedFormulaVersion` instead of a value. That is a move from a
silent wrong answer to a loud error, but it is a move.

## The dense path had only ever worked because dates were being dropped

Fixing #84 immediately broke **62 dense and lifetime tests**: `compile_derived` rejected any
versioned rule, and after #84 every declared rule is versioned. That is a finding in itself —
**dense microsim has been evaluating rules without their commencement dates.**

Dense compiles once and executes for many periods, so a version cannot be selected at compile
time. The single unbounded version — exactly the shape #84 restores — is now compiled directly
and its commencement enforced per execution, raising the same `MissingDerivedFormulaVersion` the
generic executor does. Genuinely multi-version and end-bounded rules still need per-period
selection the dense plan cannot express, and are still routed to the generic API with the
original message.

## #82 — `match` dropped its final pattern

The lowering discarded the last pattern, so an unmatched subject silently took the final arm's
value. Now every pattern is retained, an explicit `_` wildcard arm is supported (and must be
final), and a non-exhaustive match warns by default and fails under strict mode.

## #124 — silent tie-breakers and a discarded field

Duplicate version starts, explicit overlaps, and conflicting unit declarations are rejected
rather than resolved by document order; `default:` is no longer parsed and then ignored.

## Corpus impact

Strict mode is opt-in, so nothing in the corpus breaks today:

* `#124` checks: **zero** corpus failures.
* `#82` strict: US has 14 affected source modules / 23 root entrypoints / 31 matches; UK, NZ, BE
  and GH have **zero**.
* Default-mode compile sweep on this branch: **46/46** published modules across uk/be/nz/gh.

## Tests

215 passed, 0 failed (main was 203). New coverage includes both Explain and Fast for the
commencement change, and `dense_versioned_derived_refuses_periods_before_commencement` for the
dense enforcement.
