### PR TITLE
One semantics for execution: deterministic input precedence and traces produced by the computation

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -105,6 +105,11 @@ pub enum DerivedTraceNode {
         name: String,
         #[serde(skip_serializing_if = "Option::is_none")]
         id: Option<String>,
+        /// Entity instance on which this rule was evaluated. Query-entity
+        /// instances retain the historical map key; related instances receive
+        /// an opaque suffixed key so dependency edges remain closed.
+        #[serde(default, skip_serializing_if = "String::is_empty")]
+        entity_id: String,
         dtype: DTypeSpec,
         unit: Option<String>,
         /// The rule's output value. When the rule applied currency rounding,
@@ -124,20 +129,75 @@ pub enum DerivedTraceNode {
         source: Option<String>,
         #[serde(skip_serializing_if = "Option::is_none")]
         source_url: Option<String>,
+        /// Canonical projection of the exact expression selected and executed
+        /// for this period. Unlike `source`, this is generated from executable
+        /// IR and cannot drift into a contradictory arithmetic narrative.
+        #[serde(default, skip_serializing_if = "String::is_empty")]
+        executed_expression: String,
+        /// Exact temporal parameter cells read while executing this node.
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        parameter_reads: Vec<TraceParameterRead>,
+        /// Derived edges actually traversed. Every key resolves in this trace.
         dependencies: Vec<String>,
+        /// Parent-specific edges that were present in the selected expression
+        /// but not traversed because execution short-circuited or chose another
+        /// branch.
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        not_evaluated_dependencies: Vec<NotEvaluatedDependency>,
     },
     Judgment {
         name: String,
         #[serde(skip_serializing_if = "Option::is_none")]
         id: Option<String>,
+        #[serde(default, skip_serializing_if = "String::is_empty")]
+        entity_id: String,
         unit: Option<String>,
         outcome: JudgmentOutcomeSpec,
         #[serde(skip_serializing_if = "Option::is_none")]
         source: Option<String>,
         #[serde(skip_serializing_if = "Option::is_none")]
         source_url: Option<String>,
+        #[serde(default, skip_serializing_if = "String::is_empty")]
+        executed_expression: String,
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        parameter_reads: Vec<TraceParameterRead>,
         dependencies: Vec<String>,
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        not_evaluated_dependencies: Vec<NotEvaluatedDependency>,
     },
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NotEvaluatedDependency {
+    pub dependency: String,
+    pub reason: NotEvaluatedReason,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum NotEvaluatedReason {
+    ShortCircuit,
+    BranchNotSelected,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct TraceParameterRead {
+    /// Public parameter identity (durable `id` when present, otherwise name).
+    pub parameter: String,
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    pub index: i64,
+    pub value: ScalarValueSpec,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub unit: Option<String>,
+    pub effective_from: NaiveDate,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub effective_to: Option<NaiveDate>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_url: Option<String>,
 }
 
 #[derive(Debug, Error)]
@@ -334,165 +394,352 @@ fn collect_trace(
     period: &crate::model::Period,
 ) -> BTreeMap<String, DerivedTraceNode> {
     let mut trace = BTreeMap::new();
-    for derived in program.derived.values() {
+    let mut instances = engine.evaluated_trace_instances(period, entity_id);
+    instances.sort_by(|left, right| {
+        (&left.key.derived, &left.key.entity_id).cmp(&(&right.key.derived, &right.key.entity_id))
+    });
+
+    for instance in instances {
+        let Some(derived) = program.derived.get(&instance.key.derived) else {
+            continue;
+        };
         let Some(semantics) = derived.semantics_at(period) else {
             continue;
         };
-        match semantics {
-            DerivedSemantics::Scalar(expr) => {
-                if let Some(value) = engine.cached_scalar(&derived.name, entity_id, period) {
-                    let pre_rounding_value = engine
-                        .cached_pre_rounding(&derived.name, entity_id, period)
-                        .map(ScalarValueSpec::from_model);
-                    trace.insert(
-                        program.public_derived_key(&derived.name),
-                        DerivedTraceNode::Scalar {
-                            name: derived.name.clone(),
-                            id: derived.id.clone(),
-                            dtype: DTypeSpec::from_model(&derived.dtype),
-                            unit: derived.unit.clone(),
-                            value: ScalarValueSpec::from_model(value),
-                            rounding: derived
-                                .rounding
-                                .map(|rounding| RoundingModeSpec::from_model(rounding.mode)),
-                            pre_rounding_value,
-                            source: derived.source.clone(),
-                            source_url: derived.source_url.clone(),
-                            dependencies: public_dependencies(program, scalar_dependencies(expr)),
-                        },
-                    );
+        let trace_key = trace_instance_key(program, &instance.key, entity_id);
+        let dependencies = instance
+            .execution
+            .dependencies
+            .iter()
+            .map(|dependency| trace_instance_key(program, dependency, entity_id))
+            .collect();
+        let not_evaluated_dependencies = instance
+            .execution
+            .not_evaluated_dependencies
+            .iter()
+            .map(|dependency| match dependency {
+                crate::engine::SkippedTraceDependency::Derived { key, reason } => {
+                    NotEvaluatedDependency {
+                        dependency: trace_instance_key(program, key, entity_id),
+                        reason: trace_skip_reason(*reason),
+                    }
                 }
-            }
-            DerivedSemantics::Judgment(expr) => {
-                if let Some(outcome) = engine.cached_judgment(&derived.name, entity_id, period) {
-                    trace.insert(
-                        program.public_derived_key(&derived.name),
-                        DerivedTraceNode::Judgment {
-                            name: derived.name.clone(),
-                            id: derived.id.clone(),
-                            unit: derived.unit.clone(),
-                            outcome: match outcome {
-                                JudgmentOutcome::Holds => JudgmentOutcomeSpec::Holds,
-                                JudgmentOutcome::NotHolds => JudgmentOutcomeSpec::NotHolds,
-                                JudgmentOutcome::Undetermined => JudgmentOutcomeSpec::Undetermined,
-                            },
-                            source: derived.source.clone(),
-                            source_url: derived.source_url.clone(),
-                            dependencies: public_dependencies(program, judgment_dependencies(expr)),
-                        },
-                    );
+                crate::engine::SkippedTraceDependency::Parameter { parameter, reason } => {
+                    NotEvaluatedDependency {
+                        dependency: public_parameter_key(program, parameter),
+                        reason: trace_skip_reason(*reason),
+                    }
                 }
-            }
-        }
+            })
+            .collect();
+        let parameter_reads = instance
+            .execution
+            .parameter_reads
+            .iter()
+            .map(|read| {
+                let parameter = program
+                    .parameters
+                    .get(&read.parameter)
+                    .expect("an evaluated parameter remains in the program");
+                TraceParameterRead {
+                    parameter: public_parameter_key(program, &read.parameter),
+                    name: parameter.name.clone(),
+                    id: parameter.id.clone(),
+                    index: read.index,
+                    value: ScalarValueSpec::from_model(read.value.clone()),
+                    unit: parameter.unit.clone(),
+                    effective_from: read.effective_from,
+                    effective_to: read.effective_to,
+                    source: parameter.source.clone(),
+                    source_url: parameter.source_url.clone(),
+                }
+            })
+            .collect();
+
+        let node = match (&instance.value, semantics) {
+            (
+                crate::engine::EvaluatedTraceValue::Scalar {
+                    value,
+                    pre_rounding_value,
+                },
+                DerivedSemantics::Scalar(expr),
+            ) => DerivedTraceNode::Scalar {
+                name: derived.name.clone(),
+                id: derived.id.clone(),
+                entity_id: instance.key.entity_id.clone(),
+                dtype: DTypeSpec::from_model(&derived.dtype),
+                unit: derived.unit.clone(),
+                value: ScalarValueSpec::from_model(value.clone()),
+                rounding: derived
+                    .rounding
+                    .map(|rounding| RoundingModeSpec::from_model(rounding.mode)),
+                pre_rounding_value: pre_rounding_value.clone().map(ScalarValueSpec::from_model),
+                source: derived.source.clone(),
+                source_url: derived.source_url.clone(),
+                executed_expression: format_scalar_expression(program, expr),
+                parameter_reads,
+                dependencies,
+                not_evaluated_dependencies,
+            },
+            (
+                crate::engine::EvaluatedTraceValue::Judgment(outcome),
+                DerivedSemantics::Judgment(expr),
+            ) => DerivedTraceNode::Judgment {
+                name: derived.name.clone(),
+                id: derived.id.clone(),
+                entity_id: instance.key.entity_id.clone(),
+                unit: derived.unit.clone(),
+                outcome: match outcome {
+                    JudgmentOutcome::Holds => JudgmentOutcomeSpec::Holds,
+                    JudgmentOutcome::NotHolds => JudgmentOutcomeSpec::NotHolds,
+                    JudgmentOutcome::Undetermined => JudgmentOutcomeSpec::Undetermined,
+                },
+                source: derived.source.clone(),
+                source_url: derived.source_url.clone(),
+                executed_expression: format_judgment_expression(program, expr),
+                parameter_reads,
+                dependencies,
+                not_evaluated_dependencies,
+            },
+            // A cache entry and its selected semantics are created together;
+            // a type mismatch here would indicate internal corruption.
+            _ => continue,
+        };
+        trace.insert(trace_key, node);
     }
     trace
 }
 
-fn public_dependencies(program: &crate::model::Program, dependencies: Vec<String>) -> Vec<String> {
-    dependencies
-        .into_iter()
-        .map(|dependency| program.public_derived_key(&dependency))
-        .collect()
+fn trace_skip_reason(reason: crate::engine::TraceSkipReason) -> NotEvaluatedReason {
+    match reason {
+        crate::engine::TraceSkipReason::ShortCircuit => NotEvaluatedReason::ShortCircuit,
+        crate::engine::TraceSkipReason::BranchNotSelected => NotEvaluatedReason::BranchNotSelected,
+    }
 }
 
-fn scalar_dependencies(expr: &crate::model::ScalarExpr) -> Vec<String> {
-    let mut deps: std::collections::BTreeSet<String> = Default::default();
-    collect_scalar_deps(expr, &mut deps);
-    deps.into_iter().collect()
+fn trace_instance_key(
+    program: &crate::model::Program,
+    key: &crate::engine::CacheKey,
+    query_entity_id: &str,
+) -> String {
+    let public = program.public_derived_key(&key.derived);
+    if key.entity_id == query_entity_id {
+        return public;
+    }
+    let mut encoded_entity = String::with_capacity(key.entity_id.len() * 2);
+    for byte in key.entity_id.as_bytes() {
+        use std::fmt::Write as _;
+        write!(&mut encoded_entity, "{byte:02x}").expect("writing to a String cannot fail");
+    }
+    format!("{public}@entity:{encoded_entity}")
 }
 
-fn judgment_dependencies(expr: &crate::model::JudgmentExpr) -> Vec<String> {
-    let mut deps: std::collections::BTreeSet<String> = Default::default();
-    collect_judgment_deps(expr, &mut deps);
-    deps.into_iter().collect()
+fn public_parameter_key(program: &crate::model::Program, name: &str) -> String {
+    program
+        .parameters
+        .get(name)
+        .and_then(|parameter| parameter.id.clone())
+        .unwrap_or_else(|| name.to_string())
 }
 
-fn collect_scalar_deps(
+fn format_scalar_expression(
+    program: &crate::model::Program,
     expr: &crate::model::ScalarExpr,
-    deps: &mut std::collections::BTreeSet<String>,
-) {
+) -> String {
     use crate::model::{RelatedValueRef, ScalarExpr};
     match expr {
-        ScalarExpr::Literal(_) | ScalarExpr::Input(_) | ScalarExpr::InputOrElse { .. } => {}
-        ScalarExpr::Derived(name) => {
-            deps.insert(name.clone());
+        ScalarExpr::Literal(value) => format_scalar_value(value),
+        ScalarExpr::Input(name) => format!("input({})", json_string(name)),
+        ScalarExpr::InputOrElse { name, default } => {
+            format!(
+                "input_or_else({}, {})",
+                json_string(name),
+                format_scalar_value(default)
+            )
         }
-        ScalarExpr::ParameterLookup { index, .. } => collect_scalar_deps(index, deps),
+        ScalarExpr::Derived(name) => program.public_derived_key(name),
+        ScalarExpr::ParameterLookup { parameter, index } => format!(
+            "{}[{}]",
+            public_parameter_key(program, parameter),
+            format_scalar_expression(program, index)
+        ),
         ScalarExpr::Add(items) | ScalarExpr::Max(items) | ScalarExpr::Min(items) => {
-            for item in items {
-                collect_scalar_deps(item, deps);
+            let (name, separator) = match expr {
+                ScalarExpr::Add(_) => ("", " + "),
+                ScalarExpr::Max(_) => ("max", ", "),
+                ScalarExpr::Min(_) => ("min", ", "),
+                _ => unreachable!(),
+            };
+            let body = items
+                .iter()
+                .map(|item| format_scalar_expression(program, item))
+                .collect::<Vec<_>>()
+                .join(separator);
+            if name.is_empty() {
+                format!("({body})")
+            } else {
+                format!("{name}({body})")
             }
         }
-        ScalarExpr::Sub(a, b) | ScalarExpr::Mul(a, b) | ScalarExpr::Div(a, b) => {
-            collect_scalar_deps(a, deps);
-            collect_scalar_deps(b, deps);
+        ScalarExpr::Sub(left, right)
+        | ScalarExpr::Mul(left, right)
+        | ScalarExpr::Div(left, right) => {
+            let operator = match expr {
+                ScalarExpr::Sub(_, _) => "-",
+                ScalarExpr::Mul(_, _) => "*",
+                ScalarExpr::Div(_, _) => "/",
+                _ => unreachable!(),
+            };
+            format!(
+                "({} {operator} {})",
+                format_scalar_expression(program, left),
+                format_scalar_expression(program, right)
+            )
         }
-        ScalarExpr::Ceil(value) | ScalarExpr::Floor(value) => collect_scalar_deps(value, deps),
-        ScalarExpr::PeriodStart | ScalarExpr::PeriodEnd => {}
+        ScalarExpr::Ceil(value) | ScalarExpr::Floor(value) => {
+            let function = if matches!(expr, ScalarExpr::Ceil(_)) {
+                "ceil"
+            } else {
+                "floor"
+            };
+            format!("{function}({})", format_scalar_expression(program, value))
+        }
+        ScalarExpr::PeriodStart => "period_start".to_string(),
+        ScalarExpr::PeriodEnd => "period_end".to_string(),
         ScalarExpr::DateAddDays { date, days } => {
-            collect_scalar_deps(date, deps);
-            collect_scalar_deps(days, deps);
+            format!(
+                "date_add_days({}, {})",
+                format_scalar_expression(program, date),
+                format_scalar_expression(program, days)
+            )
         }
         ScalarExpr::DaysBetween { from, to } => {
-            collect_scalar_deps(from, deps);
-            collect_scalar_deps(to, deps);
+            format!(
+                "days_between({}, {})",
+                format_scalar_expression(program, from),
+                format_scalar_expression(program, to)
+            )
         }
-        ScalarExpr::CountRelated { where_clause, .. } => {
-            if let Some(predicate) = where_clause {
-                collect_judgment_deps(predicate, deps);
-            }
-        }
+        ScalarExpr::CountRelated {
+            relation,
+            current_slot,
+            related_slot,
+            where_clause,
+        } => format!(
+            "count_related({}, {current_slot}, {related_slot}{})",
+            json_string(relation),
+            where_clause
+                .as_ref()
+                .map(|predicate| format!(
+                    ", where: {}",
+                    format_judgment_expression(program, predicate)
+                ))
+                .unwrap_or_default()
+        ),
         ScalarExpr::SumRelated {
+            relation,
+            current_slot,
+            related_slot,
             value,
             where_clause,
-            ..
-        } => {
-            if let RelatedValueRef::Derived(name) = value {
-                deps.insert(name.clone());
-            }
-            if let Some(predicate) = where_clause {
-                collect_judgment_deps(predicate, deps);
-            }
-        }
+        } => format!(
+            "sum_related({}, {current_slot}, {related_slot}, {}{})",
+            json_string(relation),
+            match value {
+                RelatedValueRef::Input(name) => format!("input({})", json_string(name)),
+                RelatedValueRef::Derived(name) => program.public_derived_key(name),
+            },
+            where_clause
+                .as_ref()
+                .map(|predicate| format!(
+                    ", where: {}",
+                    format_judgment_expression(program, predicate)
+                ))
+                .unwrap_or_default()
+        ),
         ScalarExpr::If {
             condition,
             then_expr,
             else_expr,
-        } => {
-            collect_judgment_deps(condition, deps);
-            collect_scalar_deps(then_expr, deps);
-            collect_scalar_deps(else_expr, deps);
+        } => format!(
+            "(if {} then {} else {})",
+            format_judgment_expression(program, condition),
+            format_scalar_expression(program, then_expr),
+            format_scalar_expression(program, else_expr)
+        ),
+        ScalarExpr::OverPeriods { kind, value, n } => format!(
+            "{}({}{})",
+            kind.as_call_name(),
+            format_scalar_expression(program, value),
+            n.as_ref()
+                .map(|n| format!(", {}", format_scalar_expression(program, n)))
+                .unwrap_or_default()
+        ),
+    }
+}
+
+fn format_judgment_expression(
+    program: &crate::model::Program,
+    expr: &crate::model::JudgmentExpr,
+) -> String {
+    use crate::model::{ComparisonOp, JudgmentExpr};
+    match expr {
+        JudgmentExpr::Comparison { left, op, right } => format!(
+            "({} {} {})",
+            format_scalar_expression(program, left),
+            match op {
+                ComparisonOp::Lt => "<",
+                ComparisonOp::Lte => "<=",
+                ComparisonOp::Gt => ">",
+                ComparisonOp::Gte => ">=",
+                ComparisonOp::Eq => "==",
+                ComparisonOp::Ne => "!=",
+            },
+            format_scalar_expression(program, right)
+        ),
+        JudgmentExpr::Derived(name) => program.public_derived_key(name),
+        JudgmentExpr::RelationMember {
+            relation,
+            current_slot,
+            related_slot,
+        } => format!(
+            "relation_member({}, {current_slot}, {related_slot})",
+            json_string(relation)
+        ),
+        JudgmentExpr::And(items) | JudgmentExpr::Or(items) => {
+            let separator = if matches!(expr, JudgmentExpr::And(_)) {
+                " and "
+            } else {
+                " or "
+            };
+            format!(
+                "({})",
+                items
+                    .iter()
+                    .map(|item| format_judgment_expression(program, item))
+                    .collect::<Vec<_>>()
+                    .join(separator)
+            )
         }
-        ScalarExpr::OverPeriods { value, n, .. } => {
-            collect_scalar_deps(value, deps);
-            if let Some(n) = n {
-                collect_scalar_deps(n, deps);
-            }
+        JudgmentExpr::Not(item) => {
+            format!("not ({})", format_judgment_expression(program, item))
         }
     }
 }
 
-fn collect_judgment_deps(
-    expr: &crate::model::JudgmentExpr,
-    deps: &mut std::collections::BTreeSet<String>,
-) {
-    use crate::model::JudgmentExpr;
-    match expr {
-        JudgmentExpr::Comparison { left, right, .. } => {
-            collect_scalar_deps(left, deps);
-            collect_scalar_deps(right, deps);
-        }
-        JudgmentExpr::Derived(name) => {
-            deps.insert(name.clone());
-        }
-        JudgmentExpr::RelationMember { .. } => {}
-        JudgmentExpr::And(items) | JudgmentExpr::Or(items) => {
-            for item in items {
-                collect_judgment_deps(item, deps);
-            }
-        }
-        JudgmentExpr::Not(item) => collect_judgment_deps(item, deps),
+fn format_scalar_value(value: &crate::model::ScalarValue) -> String {
+    use crate::model::ScalarValue;
+    match value {
+        ScalarValue::Bool(value) => value.to_string(),
+        ScalarValue::Integer(value) => value.to_string(),
+        ScalarValue::Decimal(value) => value.to_string(),
+        ScalarValue::Text(value) => json_string(value),
+        ScalarValue::Date(value) => format!("date({})", json_string(&value.to_string())),
     }
+}
+
+fn json_string(value: &str) -> String {
+    serde_json::to_string(value).expect("a Rust string always serialises as JSON")
 }
 
 impl ExecutionResponse {

--- a/src/api.rs
+++ b/src/api.rs
@@ -178,6 +178,7 @@ pub fn execute_request(request: ExecutionRequest) -> Result<ExecutionResponse, A
     let requested_mode = request.mode.clone();
     let program = request.program.to_program()?;
     let dataset = request.dataset.to_dataset_for_program(&program)?;
+    crate::engine::validate_input_spells(&dataset)?;
 
     match requested_mode {
         ExecutionMode::Explain => execute_explain(
@@ -191,7 +192,27 @@ pub fn execute_request(request: ExecutionRequest) -> Result<ExecutionResponse, A
             },
         ),
         ExecutionMode::Fast => {
-            match crate::bulk::try_execute(&program, &dataset, &request.queries)? {
+            // Fast accepts one shared query period. Resolve every covering
+            // input once under the same latest-start rule used by Explain
+            // before handing the dataset to the order-overwriting bulk
+            // evaluator. If periods differ, leave the full dataset intact:
+            // bulk will report Unsupported and the ordinary Explain path will
+            // select independently for each query period.
+            let resolved_dataset;
+            let fast_dataset = if let Some(first_query) = request.queries.first()
+                && request
+                    .queries
+                    .iter()
+                    .all(|query| query.period == first_query.period)
+            {
+                let period = first_query.period.to_model()?;
+                resolved_dataset = crate::engine::resolve_inputs_for_period(&dataset, &period);
+                &resolved_dataset
+            } else {
+                &dataset
+            };
+
+            match crate::bulk::try_execute(&program, fast_dataset, &request.queries)? {
                 crate::bulk::FastPathResult::Executed(response) => {
                     Ok(response.with_metadata(ExecutionMetadata {
                         requested_mode: ExecutionMode::Fast,
@@ -201,7 +222,7 @@ pub fn execute_request(request: ExecutionRequest) -> Result<ExecutionResponse, A
                 }
                 crate::bulk::FastPathResult::Unsupported { reason } => execute_explain(
                     &program,
-                    &dataset,
+                    fast_dataset,
                     request.queries,
                     ExecutionMetadata {
                         requested_mode: ExecutionMode::Fast,

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use rust_decimal::Decimal;
 use thiserror::Error;
@@ -181,10 +181,60 @@ pub(crate) fn resolve_inputs_for_period(data: &DataSet, period: &Period) -> Data
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-struct CacheKey {
-    derived: String,
-    entity_id: String,
-    period: Period,
+pub(crate) struct CacheKey {
+    pub(crate) derived: String,
+    pub(crate) entity_id: String,
+    pub(crate) period: Period,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum TraceSkipReason {
+    ShortCircuit,
+    BranchNotSelected,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum SkippedTraceDependency {
+    Derived {
+        key: CacheKey,
+        reason: TraceSkipReason,
+    },
+    Parameter {
+        parameter: String,
+        reason: TraceSkipReason,
+    },
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct ParameterTraceRead {
+    pub(crate) parameter: String,
+    pub(crate) index: i64,
+    pub(crate) value: ScalarValue,
+    pub(crate) effective_from: chrono::NaiveDate,
+    pub(crate) effective_to: Option<chrono::NaiveDate>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub(crate) struct NodeExecutionTrace {
+    pub(crate) dependencies: Vec<CacheKey>,
+    pub(crate) not_evaluated_dependencies: Vec<SkippedTraceDependency>,
+    pub(crate) parameter_reads: Vec<ParameterTraceRead>,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) enum EvaluatedTraceValue {
+    Scalar {
+        value: ScalarValue,
+        pre_rounding_value: Option<ScalarValue>,
+    },
+    Judgment(JudgmentOutcome),
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct EvaluatedTraceInstance {
+    pub(crate) key: CacheKey,
+    pub(crate) value: EvaluatedTraceValue,
+    pub(crate) execution: NodeExecutionTrace,
 }
 
 #[derive(Clone, Copy)]
@@ -217,6 +267,8 @@ pub struct Engine<'a> {
     /// the value; the trace uses it to show the rounding step for audit.
     pre_rounding_cache: HashMap<CacheKey, ScalarValue>,
     judgment_cache: HashMap<CacheKey, JudgmentOutcome>,
+    execution_trace: HashMap<CacheKey, NodeExecutionTrace>,
+    active_evaluations: Vec<CacheKey>,
 }
 
 impl<'a> Engine<'a> {
@@ -253,6 +305,8 @@ impl<'a> Engine<'a> {
             scalar_cache: HashMap::new(),
             pre_rounding_cache: HashMap::new(),
             judgment_cache: HashMap::new(),
+            execution_trace: HashMap::new(),
+            active_evaluations: Vec::new(),
         }
     }
 
@@ -279,12 +333,20 @@ impl<'a> Engine<'a> {
                 at: period.start,
             }
         })?;
-        let value = match semantics {
-            DerivedSemantics::Scalar(expr) => self.eval_scalar_expr(expr, entity_id, period)?,
+        self.execution_trace.entry(key.clone()).or_default();
+        self.active_evaluations.push(key.clone());
+        let evaluated = match semantics {
+            DerivedSemantics::Scalar(expr) => self.eval_scalar_expr(expr, entity_id, period),
             DerivedSemantics::Judgment(_) => {
-                return Err(EvalError::ExpectedScalar(derived_name.to_string()));
+                Err(EvalError::ExpectedScalar(derived_name.to_string()))
             }
         };
+        let finished = self
+            .active_evaluations
+            .pop()
+            .expect("scalar evaluation pushed an active trace key");
+        debug_assert_eq!(finished, key);
+        let value = evaluated?;
         // Apply the rule's opt-in output rounding before caching, so the
         // rounded value is what both direct queries and dependent rules
         // (`ScalarExpr::Derived`) observe. Absent `rounding` is a no-op. When
@@ -321,14 +383,69 @@ impl<'a> Engine<'a> {
                 at: period.start,
             }
         })?;
-        let value = match semantics {
-            DerivedSemantics::Judgment(expr) => self.eval_judgment_expr(expr, entity_id, period)?,
+        self.execution_trace.entry(key.clone()).or_default();
+        self.active_evaluations.push(key.clone());
+        let evaluated = match semantics {
+            DerivedSemantics::Judgment(expr) => self.eval_judgment_expr(expr, entity_id, period),
             DerivedSemantics::Scalar(_) => {
-                return Err(EvalError::ExpectedJudgment(derived_name.to_string()));
+                Err(EvalError::ExpectedJudgment(derived_name.to_string()))
             }
         };
+        let finished = self
+            .active_evaluations
+            .pop()
+            .expect("judgment evaluation pushed an active trace key");
+        debug_assert_eq!(finished, key);
+        let value = evaluated?;
         self.judgment_cache.insert(key, value);
         Ok(value)
+    }
+
+    pub(crate) fn evaluated_trace_instances(
+        &self,
+        period: &Period,
+        root_entity_id: &str,
+    ) -> Vec<EvaluatedTraceInstance> {
+        let mut instances = Vec::with_capacity(self.scalar_cache.len() + self.judgment_cache.len());
+        for (key, value) in &self.scalar_cache {
+            if key.period != *period {
+                continue;
+            }
+            instances.push(EvaluatedTraceInstance {
+                key: key.clone(),
+                value: EvaluatedTraceValue::Scalar {
+                    value: value.clone(),
+                    pre_rounding_value: self.pre_rounding_cache.get(key).cloned(),
+                },
+                execution: self.execution_trace.get(key).cloned().unwrap_or_default(),
+            });
+        }
+        for (key, outcome) in &self.judgment_cache {
+            if key.period != *period {
+                continue;
+            }
+            instances.push(EvaluatedTraceInstance {
+                key: key.clone(),
+                value: EvaluatedTraceValue::Judgment(*outcome),
+                execution: self.execution_trace.get(key).cloned().unwrap_or_default(),
+            });
+        }
+        let mut reachable = HashSet::new();
+        let mut pending: Vec<_> = instances
+            .iter()
+            .filter(|instance| instance.key.entity_id == root_entity_id)
+            .map(|instance| instance.key.clone())
+            .collect();
+        while let Some(key) = pending.pop() {
+            if !reachable.insert(key.clone()) {
+                continue;
+            }
+            if let Some(execution) = self.execution_trace.get(&key) {
+                pending.extend(execution.dependencies.iter().cloned());
+            }
+        }
+        instances.retain(|instance| reachable.contains(&instance.key));
+        instances
     }
 
     pub fn cached_scalar(
@@ -379,6 +496,96 @@ impl<'a> Engine<'a> {
             .copied()
     }
 
+    fn record_evaluated_dependency(&mut self, key: CacheKey) {
+        let Some(parent) = self.active_evaluations.last().cloned() else {
+            return;
+        };
+        let trace = self.execution_trace.entry(parent).or_default();
+        if !trace.dependencies.contains(&key) {
+            trace.dependencies.push(key);
+        }
+    }
+
+    fn record_skipped_dependency(&mut self, dependency: SkippedTraceDependency) {
+        let Some(parent) = self.active_evaluations.last().cloned() else {
+            return;
+        };
+        let trace = self.execution_trace.entry(parent).or_default();
+        if !trace.not_evaluated_dependencies.contains(&dependency) {
+            trace.not_evaluated_dependencies.push(dependency);
+        }
+    }
+
+    fn record_parameter_read(&mut self, read: ParameterTraceRead) {
+        let Some(parent) = self.active_evaluations.last().cloned() else {
+            return;
+        };
+        let trace = self.execution_trace.entry(parent).or_default();
+        if !trace.parameter_reads.contains(&read) {
+            trace.parameter_reads.push(read);
+        }
+    }
+
+    fn record_skipped_scalar_dependencies(
+        &mut self,
+        expr: &ScalarExpr,
+        entity_id: &str,
+        period: &Period,
+        reason: TraceSkipReason,
+    ) {
+        let mut derived = Vec::new();
+        let mut parameters = Vec::new();
+        collect_scalar_trace_references(expr, &mut derived, &mut parameters);
+        for name in derived {
+            self.record_skipped_dependency(SkippedTraceDependency::Derived {
+                key: CacheKey {
+                    derived: name,
+                    entity_id: entity_id.to_string(),
+                    period: period.clone(),
+                },
+                reason,
+            });
+        }
+        for parameter in parameters {
+            self.record_skipped_dependency(SkippedTraceDependency::Parameter { parameter, reason });
+        }
+    }
+
+    fn record_skipped_judgment_dependencies(
+        &mut self,
+        expr: &JudgmentExpr,
+        entity_id: &str,
+        period: &Period,
+        relation_context: Option<RelationEvalContext<'_>>,
+        reason: TraceSkipReason,
+    ) {
+        let mut derived = Vec::new();
+        let mut parameters = Vec::new();
+        collect_judgment_trace_references(expr, &mut derived, &mut parameters);
+        for name in derived {
+            let target_entity_id = self
+                .program
+                .derived
+                .get(&name)
+                .and_then(|dependency| {
+                    relation_context.and_then(|context| context.entity_id_for(&dependency.entity))
+                })
+                .unwrap_or(entity_id)
+                .to_string();
+            self.record_skipped_dependency(SkippedTraceDependency::Derived {
+                key: CacheKey {
+                    derived: name,
+                    entity_id: target_entity_id,
+                    period: period.clone(),
+                },
+                reason,
+            });
+        }
+        for parameter in parameters {
+            self.record_skipped_dependency(SkippedTraceDependency::Parameter { parameter, reason });
+        }
+    }
+
     fn get_derived(&self, name: &str) -> Result<&Derived, EvalError> {
         self.program
             .derived
@@ -411,7 +618,14 @@ impl<'a> Engine<'a> {
                     Err(other) => Err(other),
                 }
             }
-            ScalarExpr::Derived(name) => self.evaluate_scalar(name, entity_id, period),
+            ScalarExpr::Derived(name) => {
+                self.record_evaluated_dependency(CacheKey {
+                    derived: name.clone(),
+                    entity_id: entity_id.to_string(),
+                    period: period.clone(),
+                });
+                self.evaluate_scalar(name, entity_id, period)
+            }
             ScalarExpr::ParameterLookup { parameter, index } => {
                 let lookup_key = self
                     .eval_scalar_expr(index, entity_id, period)?
@@ -586,8 +800,20 @@ impl<'a> Engine<'a> {
                     .eval_judgment_expr(condition, entity_id, period)?
                     .is_holds()
                 {
+                    self.record_skipped_scalar_dependencies(
+                        else_expr,
+                        entity_id,
+                        period,
+                        TraceSkipReason::BranchNotSelected,
+                    );
                     self.eval_scalar_expr(then_expr, entity_id, period)
                 } else {
+                    self.record_skipped_scalar_dependencies(
+                        then_expr,
+                        entity_id,
+                        period,
+                        TraceSkipReason::BranchNotSelected,
+                    );
                     self.eval_scalar_expr(else_expr, entity_id, period)
                 }
             }
@@ -633,6 +859,11 @@ impl<'a> Engine<'a> {
                 let target_entity_id = relation_context
                     .and_then(|context| context.entity_id_for(&derived.entity))
                     .unwrap_or(entity_id);
+                self.record_evaluated_dependency(CacheKey {
+                    derived: name.clone(),
+                    entity_id: target_entity_id.to_string(),
+                    period: period.clone(),
+                });
                 self.evaluate_judgment(name, target_entity_id, period)
             }
             JudgmentExpr::RelationMember {
@@ -662,7 +893,7 @@ impl<'a> Engine<'a> {
             }
             JudgmentExpr::And(items) => {
                 let mut saw_undetermined = false;
-                for item in items {
+                for (index, item) in items.iter().enumerate() {
                     match self.eval_judgment_expr_inner(
                         item,
                         entity_id,
@@ -670,7 +901,18 @@ impl<'a> Engine<'a> {
                         relation_context,
                     )? {
                         JudgmentOutcome::Holds => {}
-                        JudgmentOutcome::NotHolds => return Ok(JudgmentOutcome::NotHolds),
+                        JudgmentOutcome::NotHolds => {
+                            for skipped in &items[index + 1..] {
+                                self.record_skipped_judgment_dependencies(
+                                    skipped,
+                                    entity_id,
+                                    period,
+                                    relation_context,
+                                    TraceSkipReason::ShortCircuit,
+                                );
+                            }
+                            return Ok(JudgmentOutcome::NotHolds);
+                        }
                         JudgmentOutcome::Undetermined => saw_undetermined = true,
                     }
                 }
@@ -682,14 +924,25 @@ impl<'a> Engine<'a> {
             }
             JudgmentExpr::Or(items) => {
                 let mut saw_undetermined = false;
-                for item in items {
+                for (index, item) in items.iter().enumerate() {
                     match self.eval_judgment_expr_inner(
                         item,
                         entity_id,
                         period,
                         relation_context,
                     )? {
-                        JudgmentOutcome::Holds => return Ok(JudgmentOutcome::Holds),
+                        JudgmentOutcome::Holds => {
+                            for skipped in &items[index + 1..] {
+                                self.record_skipped_judgment_dependencies(
+                                    skipped,
+                                    entity_id,
+                                    period,
+                                    relation_context,
+                                    TraceSkipReason::ShortCircuit,
+                                );
+                            }
+                            return Ok(JudgmentOutcome::Holds);
+                        }
                         JudgmentOutcome::NotHolds => {}
                         JudgmentOutcome::Undetermined => saw_undetermined = true,
                     }
@@ -718,7 +971,14 @@ impl<'a> Engine<'a> {
     ) -> Result<Decimal, EvalError> {
         let scalar = match value {
             RelatedValueRef::Input(name) => self.lookup_input(name, entity_id, period)?,
-            RelatedValueRef::Derived(name) => self.evaluate_scalar(name, entity_id, period)?,
+            RelatedValueRef::Derived(name) => {
+                self.record_evaluated_dependency(CacheKey {
+                    derived: name.clone(),
+                    entity_id: entity_id.to_string(),
+                    period: period.clone(),
+                });
+                self.evaluate_scalar(name, entity_id, period)?
+            }
         };
         scalar.as_decimal().ok_or_else(|| {
             EvalError::TypeMismatch("related aggregation requires numeric values".to_string())
@@ -773,35 +1033,44 @@ impl<'a> Engine<'a> {
     }
 
     fn lookup_parameter(
-        &self,
+        &mut self,
         name: &str,
         key: i64,
         period: &Period,
     ) -> Result<ScalarValue, EvalError> {
-        let parameter = self
-            .program
-            .parameters
-            .get(name)
-            .ok_or_else(|| EvalError::UnknownParameter(name.to_string()))?;
-        let version = parameter
-            .versions
-            .iter()
-            .filter(|version| version.applies_at(period.start))
-            .max_by_key(|version| version.effective_from)
-            .ok_or_else(|| EvalError::MissingParameterValue {
-                parameter: name.to_string(),
-                key,
-                at: period.start,
+        let (value, effective_from, effective_to) = {
+            let parameter = self
+                .program
+                .parameters
+                .get(name)
+                .ok_or_else(|| EvalError::UnknownParameter(name.to_string()))?;
+            let version = parameter
+                .versions
+                .iter()
+                .filter(|version| version.applies_at(period.start))
+                .max_by_key(|version| version.effective_from)
+                .ok_or_else(|| EvalError::MissingParameterValue {
+                    parameter: name.to_string(),
+                    key,
+                    at: period.start,
+                })?;
+            let value = version.values.get(&key).cloned().ok_or_else(|| {
+                EvalError::MissingParameterValue {
+                    parameter: name.to_string(),
+                    key,
+                    at: period.start,
+                }
             })?;
-        version
-            .values
-            .get(&key)
-            .cloned()
-            .ok_or_else(|| EvalError::MissingParameterValue {
-                parameter: name.to_string(),
-                key,
-                at: period.start,
-            })
+            (value, version.effective_from, version.effective_to)
+        };
+        self.record_parameter_read(ParameterTraceRead {
+            parameter: name.to_string(),
+            index: key,
+            value: value.clone(),
+            effective_from,
+            effective_to,
+        });
+        Ok(value)
     }
 
     fn related_entity_ids(
@@ -934,6 +1203,102 @@ impl<'a> Engine<'a> {
                     ComparisonOp::Ne => left != right,
                 })
             }
+        }
+    }
+}
+
+fn collect_scalar_trace_references(
+    expr: &ScalarExpr,
+    derived: &mut Vec<String>,
+    parameters: &mut Vec<String>,
+) {
+    match expr {
+        ScalarExpr::Literal(_)
+        | ScalarExpr::Input(_)
+        | ScalarExpr::InputOrElse { .. }
+        | ScalarExpr::PeriodStart
+        | ScalarExpr::PeriodEnd => {}
+        ScalarExpr::Derived(name) => derived.push(name.clone()),
+        ScalarExpr::ParameterLookup { parameter, index } => {
+            parameters.push(parameter.clone());
+            collect_scalar_trace_references(index, derived, parameters);
+        }
+        ScalarExpr::Add(items) | ScalarExpr::Max(items) | ScalarExpr::Min(items) => {
+            for item in items {
+                collect_scalar_trace_references(item, derived, parameters);
+            }
+        }
+        ScalarExpr::Sub(left, right)
+        | ScalarExpr::Mul(left, right)
+        | ScalarExpr::Div(left, right) => {
+            collect_scalar_trace_references(left, derived, parameters);
+            collect_scalar_trace_references(right, derived, parameters);
+        }
+        ScalarExpr::Ceil(value) | ScalarExpr::Floor(value) => {
+            collect_scalar_trace_references(value, derived, parameters);
+        }
+        ScalarExpr::DateAddDays { date, days } => {
+            collect_scalar_trace_references(date, derived, parameters);
+            collect_scalar_trace_references(days, derived, parameters);
+        }
+        ScalarExpr::DaysBetween { from, to } => {
+            collect_scalar_trace_references(from, derived, parameters);
+            collect_scalar_trace_references(to, derived, parameters);
+        }
+        ScalarExpr::CountRelated { where_clause, .. } => {
+            if let Some(predicate) = where_clause {
+                collect_judgment_trace_references(predicate, derived, parameters);
+            }
+        }
+        ScalarExpr::SumRelated {
+            value,
+            where_clause,
+            ..
+        } => {
+            if let RelatedValueRef::Derived(name) = value {
+                derived.push(name.clone());
+            }
+            if let Some(predicate) = where_clause {
+                collect_judgment_trace_references(predicate, derived, parameters);
+            }
+        }
+        ScalarExpr::If {
+            condition,
+            then_expr,
+            else_expr,
+        } => {
+            collect_judgment_trace_references(condition, derived, parameters);
+            collect_scalar_trace_references(then_expr, derived, parameters);
+            collect_scalar_trace_references(else_expr, derived, parameters);
+        }
+        ScalarExpr::OverPeriods { value, n, .. } => {
+            collect_scalar_trace_references(value, derived, parameters);
+            if let Some(n) = n {
+                collect_scalar_trace_references(n, derived, parameters);
+            }
+        }
+    }
+}
+
+fn collect_judgment_trace_references(
+    expr: &JudgmentExpr,
+    derived: &mut Vec<String>,
+    parameters: &mut Vec<String>,
+) {
+    match expr {
+        JudgmentExpr::Comparison { left, right, .. } => {
+            collect_scalar_trace_references(left, derived, parameters);
+            collect_scalar_trace_references(right, derived, parameters);
+        }
+        JudgmentExpr::Derived(name) => derived.push(name.clone()),
+        JudgmentExpr::RelationMember { .. } => {}
+        JudgmentExpr::And(items) | JudgmentExpr::Or(items) => {
+            for item in items {
+                collect_judgment_trace_references(item, derived, parameters);
+            }
+        }
+        JudgmentExpr::Not(item) => {
+            collect_judgment_trace_references(item, derived, parameters);
         }
     }
 }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -23,6 +23,14 @@ pub enum EvalError {
         period_start: chrono::NaiveDate,
         period_end: chrono::NaiveDate,
     },
+    #[error(
+        "ambiguous input `{name}` for entity `{entity_id}`: records effective from {effective_from} have conflicting values; merge or split the spells so one value applies at each start date"
+    )]
+    AmbiguousInput {
+        name: String,
+        entity_id: String,
+        effective_from: chrono::NaiveDate,
+    },
     #[error("unit `{0}` was not declared")]
     UnknownUnit(String),
     #[error("type mismatch: {0}")]
@@ -107,6 +115,69 @@ pub enum EvalError {
         second_period: String,
         second_value: String,
     },
+}
+
+/// Validate the one unresolvable tie in the input-spell precedence contract.
+///
+/// Covering records are resolved by latest `interval.start`. Two values for the
+/// same canonical fact, entity, and start date have equal precedence, so
+/// choosing either would reintroduce dataset-order semantics. Equal duplicates
+/// are harmless; conflicting values are rejected before either execution mode
+/// runs.
+pub(crate) fn validate_input_spells(data: &DataSet) -> Result<(), EvalError> {
+    let mut values_by_start: HashMap<(&str, &str, chrono::NaiveDate), &ScalarValue> =
+        HashMap::new();
+    for record in &data.inputs {
+        let key = (
+            record.name.as_str(),
+            record.entity_id.as_str(),
+            record.interval.start,
+        );
+        if let Some(existing) = values_by_start.get(&key) {
+            if *existing != &record.value {
+                return Err(EvalError::AmbiguousInput {
+                    name: record.name.clone(),
+                    entity_id: record.entity_id.clone(),
+                    effective_from: record.interval.start,
+                });
+            }
+        } else {
+            values_by_start.insert(key, &record.value);
+        }
+    }
+    Ok(())
+}
+
+/// Build the order-independent, single-period input view consumed by Fast.
+///
+/// Bulk execution handles one shared query period and otherwise falls back to
+/// Explain. Resolve every fact (including facts on related entities) once in a
+/// single O(N) pass so the bulk evaluator cannot overwrite a newer covering
+/// spell with an older record that happens to appear later in the dataset.
+pub(crate) fn resolve_inputs_for_period(data: &DataSet, period: &Period) -> DataSet {
+    let mut selected_by_fact: HashMap<(&str, &str), usize> = HashMap::new();
+    let mut inputs = Vec::new();
+
+    for record in &data.inputs {
+        if !record.interval.contains_period(period) {
+            continue;
+        }
+        let key = (record.name.as_str(), record.entity_id.as_str());
+        if let Some(&selected_index) = selected_by_fact.get(&key) {
+            let selected: &crate::model::InputRecord = &inputs[selected_index];
+            if record.interval.start > selected.interval.start {
+                inputs[selected_index] = record.clone();
+            }
+        } else {
+            selected_by_fact.insert(key, inputs.len());
+            inputs.push(record.clone());
+        }
+    }
+
+    DataSet {
+        inputs,
+        relations: data.relations.clone(),
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
@@ -671,18 +742,34 @@ impl<'a> Engine<'a> {
         entity_id: &str,
         period: &Period,
     ) -> Result<ScalarValue, EvalError> {
-        self.input_index
+        let mut covering = self
+            .input_index
             .get(&(name.to_string(), entity_id.to_string()))
             .into_iter()
             .flat_map(|records| records.iter().copied())
-            .find(|record| record.interval.contains_period(period))
-            .map(|record| record.value.clone())
-            .ok_or_else(|| EvalError::MissingInput {
-                name: name.to_string(),
-                entity_id: entity_id.to_string(),
-                period_start: period.start,
-                period_end: period.end,
-            })
+            .filter(|record| record.interval.contains_period(period));
+        let selected = covering.next().ok_or_else(|| EvalError::MissingInput {
+            name: name.to_string(),
+            entity_id: entity_id.to_string(),
+            period_start: period.start,
+            period_end: period.end,
+        })?;
+
+        // Records are sorted by descending start in `new`. Any immediately
+        // following covering records with the same start have equal
+        // precedence. Reject a conflicting tie rather than recovering dataset
+        // order as a hidden tie-breaker for direct Engine callers.
+        for tied in covering.take_while(|record| record.interval.start == selected.interval.start) {
+            if tied.value != selected.value {
+                return Err(EvalError::AmbiguousInput {
+                    name: name.to_string(),
+                    entity_id: entity_id.to_string(),
+                    effective_from: selected.interval.start,
+                });
+            }
+        }
+
+        Ok(selected.value.clone())
     }
 
     fn lookup_parameter(

--- a/tests/execution.rs
+++ b/tests/execution.rs
@@ -89,59 +89,301 @@ fn cli_round_trip_returns_json() {
 }
 
 #[test]
-fn fast_mode_matches_explain_mode_on_batch() {
-    let program = axiom_rules_engine::rulespec::lower_rulespec_str(SIMPLE_RULESPEC)
-        .expect("program fixture parses");
+fn explain_and_fast_are_differentially_equivalent_on_generated_programs() {
+    // Deterministic property-style coverage without a random dependency. Each
+    // seed varies the arithmetic program, the two overlapping input values,
+    // and their dataset order. The newer spell must win in both modes.
+    for seed in 0_u64..128 {
+        let mut state = seed.wrapping_add(0x9e37_79b9_7f4a_7c15);
+        let mut next = || {
+            state = state
+                .wrapping_mul(6_364_136_223_846_793_005)
+                .wrapping_add(1_442_695_040_888_963_407);
+            state
+        };
+        let operation = next() % 4;
+        let literal = i64::try_from(next() % 9 + 1).expect("small generated literal");
+        let newer_value = i64::try_from(next() % 2_000 + 1).expect("small generated value");
+        let older_value =
+            newer_value + i64::try_from(next() % 2_000 + 1).expect("small generated delta");
+        let newer_first = next() % 2 == 0;
+
+        let expression = match operation {
+            0 => ScalarExprSpec::Add {
+                items: vec![
+                    ScalarExprSpec::Input {
+                        name: "amount".to_string(),
+                    },
+                    decimal_literal(literal),
+                ],
+            },
+            1 => ScalarExprSpec::Sub {
+                left: Box::new(ScalarExprSpec::Input {
+                    name: "amount".to_string(),
+                }),
+                right: Box::new(decimal_literal(literal)),
+            },
+            2 => ScalarExprSpec::Mul {
+                left: Box::new(ScalarExprSpec::Input {
+                    name: "amount".to_string(),
+                }),
+                right: Box::new(decimal_literal(literal)),
+            },
+            _ => ScalarExprSpec::Div {
+                left: Box::new(ScalarExprSpec::Input {
+                    name: "amount".to_string(),
+                }),
+                right: Box::new(decimal_literal(literal)),
+            },
+        };
+        let (program, dataset, query) =
+            generated_overlap_case(expression, newer_value, older_value, newer_first);
+
+        let explain = execute_request(ExecutionRequest {
+            mode: ExecutionMode::Explain,
+            program: program.clone(),
+            dataset: dataset.clone(),
+            queries: vec![query.clone()],
+        })
+        .expect("generated Explain request succeeds");
+        let fast = execute_request(ExecutionRequest {
+            mode: ExecutionMode::Fast,
+            program,
+            dataset,
+            queries: vec![query],
+        })
+        .expect("generated Fast request succeeds");
+
+        assert_eq!(explain.metadata.actual_mode, ExecutionMode::Explain);
+        assert_eq!(
+            fast.metadata.actual_mode,
+            ExecutionMode::Fast,
+            "seed {seed} unexpectedly fell back: {:?}",
+            fast.metadata.fallback_reason
+        );
+        assert_eq!(
+            serde_json::to_value(&explain.results[0].outputs).expect("Explain outputs serialise"),
+            serde_json::to_value(&fast.results[0].outputs).expect("Fast outputs serialise"),
+            "execution modes diverged for generated seed {seed}"
+        );
+    }
+}
+
+#[test]
+fn overlapping_covering_inputs_use_latest_start_in_every_mode_and_order() {
+    let expression = ScalarExprSpec::If {
+        condition: Box::new(axiom_rules_engine::spec::JudgmentExprSpec::Comparison {
+            left: Box::new(ScalarExprSpec::Input {
+                name: "amount".to_string(),
+            }),
+            op: ComparisonOpSpec::Gt,
+            right: Box::new(decimal_literal(3_000)),
+        }),
+        then_expr: Box::new(decimal_literal(0)),
+        else_expr: Box::new(decimal_literal(650)),
+    };
+
+    for newer_first in [true, false] {
+        let (program, dataset, query) =
+            generated_overlap_case(expression.clone(), 2_000, 4_000, newer_first);
+        for mode in [ExecutionMode::Explain, ExecutionMode::Fast] {
+            let response = execute_request(ExecutionRequest {
+                mode: mode.clone(),
+                program: program.clone(),
+                dataset: dataset.clone(),
+                queries: vec![query.clone()],
+            })
+            .expect("overlapping-input request succeeds");
+
+            assert_eq!(response.metadata.actual_mode, mode);
+            assert_eq!(
+                decimal_output(
+                    response.results[0]
+                        .outputs
+                        .get("benefit")
+                        .expect("benefit output")
+                ),
+                decimal("650"),
+                "latest-start input did not win with newer_first={newer_first}"
+            );
+        }
+    }
+}
+
+#[test]
+fn equal_start_conflicting_inputs_are_ambiguous_in_every_mode_and_order() {
+    let expression = ScalarExprSpec::Input {
+        name: "amount".to_string(),
+    };
+
+    for newer_first in [true, false] {
+        let (program, mut dataset, query) =
+            generated_overlap_case(expression.clone(), 2_000, 4_000, newer_first);
+        // Give both conflicting records equal precedence while leaving their
+        // ends different. Dataset order and interval length are not authority
+        // to choose one asserted fact over another.
+        dataset.inputs[0].interval.start =
+            chrono::NaiveDate::from_ymd_opt(2025, 7, 1).expect("valid date");
+        dataset.inputs[1].interval.start =
+            chrono::NaiveDate::from_ymd_opt(2025, 7, 1).expect("valid date");
+        dataset.inputs[0].interval.end =
+            chrono::NaiveDate::from_ymd_opt(2027, 12, 31).expect("valid date");
+
+        for mode in [ExecutionMode::Explain, ExecutionMode::Fast] {
+            let error = execute_request(ExecutionRequest {
+                mode,
+                program: program.clone(),
+                dataset: dataset.clone(),
+                queries: vec![query.clone()],
+            })
+            .expect_err("equal-precedence conflicting facts must be rejected");
+
+            assert!(
+                matches!(
+                    error,
+                    ApiError::Eval(EvalError::AmbiguousInput {
+                        ref name,
+                        ref entity_id,
+                        effective_from,
+                    }) if name == "amount"
+                        && entity_id == "household-1"
+                        && effective_from
+                            == chrono::NaiveDate::from_ymd_opt(2025, 7, 1)
+                                .expect("valid date")
+                ),
+                "unexpected ambiguity error: {error}"
+            );
+        }
+    }
+}
+
+#[test]
+fn newer_non_covering_input_does_not_displace_older_covering_input() {
+    let expression = ScalarExprSpec::Input {
+        name: "amount".to_string(),
+    };
+    let (program, mut dataset, query) = generated_overlap_case(expression, 2_000, 4_000, true);
+    dataset.inputs[0].interval.start =
+        chrono::NaiveDate::from_ymd_opt(2026, 1, 15).expect("valid date");
+
+    for mode in [ExecutionMode::Explain, ExecutionMode::Fast] {
+        let response = execute_request(ExecutionRequest {
+            mode: mode.clone(),
+            program: program.clone(),
+            dataset: dataset.clone(),
+            queries: vec![query.clone()],
+        })
+        .expect("request with a non-covering newer spell succeeds");
+
+        assert_eq!(response.metadata.actual_mode, mode);
+        assert_eq!(
+            decimal_output(
+                response.results[0]
+                    .outputs
+                    .get("benefit")
+                    .expect("benefit output")
+            ),
+            decimal("4000")
+        );
+    }
+}
+
+#[test]
+fn related_inputs_use_latest_covering_start_in_every_mode_and_order() {
     let period = simple_period();
-    let queries = simple_queries(&period);
-    let dataset = simple_dataset(&period);
+    let program = ProgramSpec {
+        relations: vec![axiom_rules_engine::spec::RelationSpec {
+            name: "member_of_household".to_string(),
+            arity: 2,
+            derivation: None,
+        }],
+        derived: vec![DerivedSpec {
+            id: None,
+            name: "household_amount".to_string(),
+            entity: "Household".to_string(),
+            dtype: DTypeSpec::Decimal,
+            unit: None,
+            rounding: None,
+            source: None,
+            period: None,
+            source_url: None,
+            corpus_citation_path: None,
+            semantics: DerivedSemanticsSpec::Scalar {
+                expr: ScalarExprSpec::SumRelated {
+                    relation: "member_of_household".to_string(),
+                    current_slot: 1,
+                    related_slot: 0,
+                    value: RelatedValueRefSpec::Input {
+                        name: "amount".to_string(),
+                    },
+                    where_clause: None,
+                },
+            },
+            versions: vec![],
+        }],
+        ..ProgramSpec::default()
+    };
+    let newer = InputRecordSpec {
+        name: "amount".to_string(),
+        entity: "Person".to_string(),
+        entity_id: "person-1".to_string(),
+        interval: IntervalSpec {
+            start: chrono::NaiveDate::from_ymd_opt(2025, 7, 1).expect("valid date"),
+            end: chrono::NaiveDate::from_ymd_opt(2026, 12, 31).expect("valid date"),
+        },
+        value: decimal_value("2000"),
+    };
+    let older = InputRecordSpec {
+        name: "amount".to_string(),
+        entity: "Person".to_string(),
+        entity_id: "person-1".to_string(),
+        interval: IntervalSpec {
+            start: chrono::NaiveDate::from_ymd_opt(2025, 1, 1).expect("valid date"),
+            end: chrono::NaiveDate::from_ymd_opt(2026, 12, 31).expect("valid date"),
+        },
+        value: decimal_value("4000"),
+    };
+    let relation = RelationRecordSpec {
+        name: "member_of_household".to_string(),
+        tuple: vec!["person-1".to_string(), "household-1".to_string()],
+        interval: IntervalSpec {
+            start: period.start,
+            end: period.end,
+        },
+    };
+    let query = ExecutionQuery {
+        assessment_date: None,
+        entity_id: "household-1".to_string(),
+        period,
+        outputs: vec!["household_amount".to_string()],
+    };
 
-    let explain = execute_request(ExecutionRequest {
-        mode: ExecutionMode::Fast,
-        program: program.clone(),
-        dataset: dataset.clone(),
-        queries: queries.clone(),
-    })
-    .expect("explain request succeeds");
+    for inputs in [vec![newer.clone(), older.clone()], vec![older, newer]] {
+        let dataset = DatasetSpec {
+            inputs,
+            relations: vec![relation.clone()],
+        };
+        for mode in [ExecutionMode::Explain, ExecutionMode::Fast] {
+            let response = execute_request(ExecutionRequest {
+                mode: mode.clone(),
+                program: program.clone(),
+                dataset: dataset.clone(),
+                queries: vec![query.clone()],
+            })
+            .expect("related-input request succeeds");
 
-    let fast = execute_request(ExecutionRequest {
-        mode: ExecutionMode::Fast,
-        program,
-        dataset,
-        queries,
-    })
-    .expect("fast request succeeds");
-
-    assert_eq!(fast.metadata.requested_mode, ExecutionMode::Fast);
-    assert_eq!(fast.metadata.actual_mode, ExecutionMode::Fast);
-    assert_eq!(fast.metadata.fallback_reason, None);
-    // fast mode emits no trace; compare only primary outputs here.
-    let explain_outputs: Vec<_> = explain
-        .results
-        .iter()
-        .map(|result| {
-            (
-                result.entity_id.clone(),
-                result.period.clone(),
-                result.outputs.clone(),
-            )
-        })
-        .collect();
-    let fast_outputs: Vec<_> = fast
-        .results
-        .iter()
-        .map(|result| {
-            (
-                result.entity_id.clone(),
-                result.period.clone(),
-                result.outputs.clone(),
-            )
-        })
-        .collect();
-    assert_eq!(
-        serde_json::to_value(&explain_outputs).expect("explain outputs serialise"),
-        serde_json::to_value(&fast_outputs).expect("fast outputs serialise")
-    );
+            assert_eq!(response.metadata.actual_mode, mode);
+            assert_eq!(
+                decimal_output(
+                    response.results[0]
+                        .outputs
+                        .get("household_amount")
+                        .expect("household amount output")
+                ),
+                decimal("2000")
+            );
+        }
+    }
 }
 
 #[test]
@@ -1745,6 +1987,78 @@ fn simple_execution_request(mode: ExecutionMode, program: ProgramSpec) -> Execut
         program,
         dataset: simple_dataset(&period),
         queries: simple_queries(&period),
+    }
+}
+
+fn generated_overlap_case(
+    expression: ScalarExprSpec,
+    newer_value: i64,
+    older_value: i64,
+    newer_first: bool,
+) -> (ProgramSpec, DatasetSpec, ExecutionQuery) {
+    let period = simple_period();
+    let newer = InputRecordSpec {
+        name: "amount".to_string(),
+        entity: "Household".to_string(),
+        entity_id: "household-1".to_string(),
+        interval: IntervalSpec {
+            start: chrono::NaiveDate::from_ymd_opt(2025, 7, 1).expect("valid date"),
+            end: chrono::NaiveDate::from_ymd_opt(2026, 12, 31).expect("valid date"),
+        },
+        value: decimal_value(&newer_value.to_string()),
+    };
+    let older = InputRecordSpec {
+        name: "amount".to_string(),
+        entity: "Household".to_string(),
+        entity_id: "household-1".to_string(),
+        interval: IntervalSpec {
+            start: chrono::NaiveDate::from_ymd_opt(2025, 1, 1).expect("valid date"),
+            end: chrono::NaiveDate::from_ymd_opt(2026, 12, 31).expect("valid date"),
+        },
+        value: decimal_value(&older_value.to_string()),
+    };
+    let inputs = if newer_first {
+        vec![newer, older]
+    } else {
+        vec![older, newer]
+    };
+    let program = ProgramSpec {
+        derived: vec![DerivedSpec {
+            id: None,
+            name: "benefit".to_string(),
+            entity: "Household".to_string(),
+            dtype: DTypeSpec::Decimal,
+            unit: None,
+            rounding: None,
+            source: None,
+            period: None,
+            source_url: None,
+            corpus_citation_path: None,
+            semantics: DerivedSemanticsSpec::Scalar { expr: expression },
+            versions: vec![],
+        }],
+        ..ProgramSpec::default()
+    };
+    let query = ExecutionQuery {
+        assessment_date: None,
+        entity_id: "household-1".to_string(),
+        period,
+        outputs: vec!["benefit".to_string()],
+    };
+
+    (
+        program,
+        DatasetSpec {
+            inputs,
+            relations: vec![],
+        },
+        query,
+    )
+}
+
+fn decimal_literal(value: i64) -> ScalarExprSpec {
+    ScalarExprSpec::Literal {
+        value: decimal_value(&value.to_string()),
     }
 }
 

--- a/tests/execution.rs
+++ b/tests/execution.rs
@@ -387,6 +387,566 @@ fn related_inputs_use_latest_covering_start_in_every_mode_and_order() {
 }
 
 #[test]
+fn explain_trace_closes_short_circuited_dependency_edges() {
+    let rulespec = r#"
+format: rulespec/v1
+rules:
+  - name: gate_1
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    versions:
+      - effective_from: 2026-01-01
+        formula: gate_1_value
+  - name: gate_2
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    versions:
+      - effective_from: 2026-01-01
+        formula: gate_2_value
+  - name: gate_3
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    versions:
+      - effective_from: 2026-01-01
+        formula: gate_3_value
+  - name: gate_4
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    versions:
+      - effective_from: 2026-01-01
+        formula: gate_4_value
+  - name: gate_5
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    versions:
+      - effective_from: 2026-01-01
+        formula: gate_5_value
+  - name: gate_6
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    versions:
+      - effective_from: 2026-01-01
+        formula: gate_6_value
+  - name: gate_7
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    versions:
+      - effective_from: 2026-01-01
+        formula: gate_7_value
+  - name: snap_eligible
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    versions:
+      - effective_from: 2026-01-01
+        formula: gate_1 and gate_2 and gate_3 and gate_4 and gate_5 and gate_6 and gate_7
+"#;
+    let period = simple_period();
+    let program =
+        axiom_rules_engine::rulespec::lower_rulespec_str(rulespec).expect("RuleSpec lowers");
+    let dataset = DatasetSpec {
+        inputs: [
+            ("gate_1_value", true),
+            ("gate_2_value", true),
+            ("gate_3_value", false),
+        ]
+        .into_iter()
+        .map(|(name, value)| InputRecordSpec {
+            name: name.to_string(),
+            entity: "Household".to_string(),
+            entity_id: "household-1".to_string(),
+            interval: IntervalSpec {
+                start: period.start,
+                end: period.end,
+            },
+            value: ScalarValueSpec::Bool { value },
+        })
+        .collect(),
+        relations: vec![],
+    };
+    let response = execute_request(ExecutionRequest {
+        mode: ExecutionMode::Explain,
+        program,
+        dataset,
+        queries: vec![ExecutionQuery {
+            assessment_date: None,
+            entity_id: "household-1".to_string(),
+            period,
+            outputs: vec!["snap_eligible".to_string()],
+        }],
+    })
+    .expect("short-circuited request succeeds without skipped inputs");
+    let result = &response.results[0];
+    assert_eq!(
+        judgment_output(
+            result
+                .outputs
+                .get("snap_eligible")
+                .expect("eligibility output")
+        ),
+        JudgmentOutcomeSpec::NotHolds
+    );
+
+    let node = serde_json::to_value(
+        result
+            .trace
+            .get("snap_eligible")
+            .expect("eligibility trace node"),
+    )
+    .expect("trace node serialises");
+    let actual = node["dependencies"]
+        .as_array()
+        .expect("actual dependencies are an array");
+    assert_eq!(actual.len(), 3, "only traversed gates are actual edges");
+    for dependency in actual {
+        let dependency = dependency.as_str().expect("dependency key is text");
+        assert!(
+            result.trace.contains_key(dependency),
+            "actual dependency `{dependency}` must resolve to a trace node"
+        );
+    }
+    let skipped = node["not_evaluated_dependencies"]
+        .as_array()
+        .expect("skipped dependency edges are explicit");
+    assert_eq!(skipped.len(), 4);
+    assert!(skipped.iter().all(|dependency| {
+        dependency["reason"]
+            .as_str()
+            .is_some_and(|reason| reason == "short_circuit")
+    }));
+}
+
+#[test]
+fn trace_skip_status_is_parent_specific_even_when_child_is_cached() {
+    let rulespec = r#"
+format: rulespec/v1
+rules:
+  - name: first_gate
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    versions:
+      - effective_from: 2026-01-01
+        formula: false
+  - name: cached_but_skipped_gate
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    versions:
+      - effective_from: 2026-01-01
+        formula: true
+  - name: eligible
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    versions:
+      - effective_from: 2026-01-01
+        formula: first_gate and cached_but_skipped_gate
+"#;
+    let period = simple_period();
+    let program =
+        axiom_rules_engine::rulespec::lower_rulespec_str(rulespec).expect("RuleSpec lowers");
+    let response = execute_request(ExecutionRequest {
+        mode: ExecutionMode::Explain,
+        program,
+        dataset: DatasetSpec::default(),
+        queries: vec![ExecutionQuery {
+            assessment_date: None,
+            entity_id: "household-1".to_string(),
+            period,
+            // Warm the would-be skipped child before evaluating its parent.
+            outputs: vec![
+                "cached_but_skipped_gate".to_string(),
+                "eligible".to_string(),
+            ],
+        }],
+    })
+    .expect("request succeeds");
+    assert!(
+        response.results[0]
+            .trace
+            .contains_key("cached_but_skipped_gate"),
+        "separately requested child has an evaluated node"
+    );
+
+    let parent = serde_json::to_value(
+        response.results[0]
+            .trace
+            .get("eligible")
+            .expect("parent trace node"),
+    )
+    .expect("trace node serialises");
+    assert_eq!(
+        parent["dependencies"],
+        serde_json::json!(["first_gate"]),
+        "a warm cache must not turn an untraversed parent edge into an actual edge"
+    );
+    assert_eq!(
+        parent["not_evaluated_dependencies"][0]["dependency"],
+        "cached_but_skipped_gate"
+    );
+}
+
+#[test]
+fn trace_execution_projection_uses_selected_parameter_not_authored_source() {
+    let rulespec = r#"
+format: rulespec/v1
+rules:
+  - name: weeks_per_year
+    kind: parameter
+    dtype: Number
+    source: 52 benefit weeks
+    versions:
+      - effective_from: 2026-01-01
+        formula: 52
+  - name: weekly_value
+    kind: derived
+    entity: Person
+    dtype: Money
+    unit: GBP
+    versions:
+      - effective_from: 2026-01-01
+        formula: supplied_weekly_value
+  - name: annual_entitlement
+    kind: derived
+    entity: Person
+    dtype: Money
+    unit: GBP
+    source: Authored prose incorrectly says payment spans 365/7 calendar weeks.
+    versions:
+      - effective_from: 2026-01-01
+        formula: weekly_value * weeks_per_year
+"#;
+    let period = simple_period();
+    let program =
+        axiom_rules_engine::rulespec::lower_rulespec_str(rulespec).expect("RuleSpec lowers");
+    let response = execute_request(ExecutionRequest {
+        mode: ExecutionMode::Explain,
+        program,
+        dataset: DatasetSpec {
+            inputs: vec![InputRecordSpec {
+                name: "supplied_weekly_value".to_string(),
+                entity: "Person".to_string(),
+                entity_id: "person-1".to_string(),
+                interval: IntervalSpec {
+                    start: period.start,
+                    end: period.end,
+                },
+                value: decimal_value("8.50"),
+            }],
+            relations: vec![],
+        },
+        queries: vec![ExecutionQuery {
+            assessment_date: None,
+            entity_id: "person-1".to_string(),
+            period,
+            outputs: vec!["annual_entitlement".to_string()],
+        }],
+    })
+    .expect("annual entitlement request succeeds");
+    assert_eq!(
+        decimal_output(
+            response.results[0]
+                .outputs
+                .get("annual_entitlement")
+                .expect("annual entitlement output")
+        ),
+        decimal("442")
+    );
+
+    let node = serde_json::to_value(
+        response.results[0]
+            .trace
+            .get("annual_entitlement")
+            .expect("annual entitlement trace node"),
+    )
+    .expect("trace node serialises");
+    let executed_expression = node["executed_expression"]
+        .as_str()
+        .expect("executed expression is present");
+    assert!(executed_expression.contains("weekly_value"));
+    assert!(executed_expression.contains("weeks_per_year"));
+    assert!(
+        !executed_expression.contains("365/7"),
+        "authored prose cannot become the calculation narrative"
+    );
+    let reads = node["parameter_reads"]
+        .as_array()
+        .expect("parameter reads are present");
+    assert_eq!(reads.len(), 1);
+    assert_eq!(reads[0]["parameter"], "weeks_per_year");
+    assert_eq!(reads[0]["index"], 0);
+    assert_eq!(reads[0]["value"]["value"], serde_json::json!(52));
+}
+
+#[test]
+fn trace_records_or_and_if_skips_with_closed_actual_edges() {
+    let rulespec = r#"
+format: rulespec/v1
+rules:
+  - name: true_gate
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    versions:
+      - effective_from: 2026-01-01
+        formula: true
+  - name: skipped_gate
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    versions:
+      - effective_from: 2026-01-01
+        formula: missing_gate_input
+  - name: any_gate
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    versions:
+      - effective_from: 2026-01-01
+        formula: true_gate or skipped_gate
+  - name: selected_amount
+    kind: derived
+    entity: Household
+    dtype: Number
+    versions:
+      - effective_from: 2026-01-01
+        formula: 10
+  - name: skipped_amount
+    kind: derived
+    entity: Household
+    dtype: Number
+    versions:
+      - effective_from: 2026-01-01
+        formula: missing_amount
+  - name: conditional_amount
+    kind: derived
+    entity: Household
+    dtype: Number
+    versions:
+      - effective_from: 2026-01-01
+        formula: "if true_gate: selected_amount else: skipped_amount"
+"#;
+    let period = simple_period();
+    let program =
+        axiom_rules_engine::rulespec::lower_rulespec_str(rulespec).expect("RuleSpec lowers");
+    let response = execute_request(ExecutionRequest {
+        mode: ExecutionMode::Explain,
+        program,
+        dataset: DatasetSpec::default(),
+        queries: vec![ExecutionQuery {
+            assessment_date: None,
+            entity_id: "household-1".to_string(),
+            period,
+            outputs: vec!["any_gate".to_string(), "conditional_amount".to_string()],
+        }],
+    })
+    .expect("unselected branches do not require their missing inputs");
+    let trace = &response.results[0].trace;
+
+    let or_node =
+        serde_json::to_value(trace.get("any_gate").expect("Or trace node")).expect("serialises");
+    assert_eq!(or_node["dependencies"], serde_json::json!(["true_gate"]));
+    assert_eq!(
+        or_node["not_evaluated_dependencies"],
+        serde_json::json!([{
+            "dependency": "skipped_gate",
+            "reason": "short_circuit"
+        }])
+    );
+
+    let if_node = serde_json::to_value(
+        trace
+            .get("conditional_amount")
+            .expect("conditional trace node"),
+    )
+    .expect("serialises");
+    assert_eq!(
+        if_node["dependencies"],
+        serde_json::json!(["true_gate", "selected_amount"])
+    );
+    assert_eq!(
+        if_node["not_evaluated_dependencies"],
+        serde_json::json!([{
+            "dependency": "skipped_amount",
+            "reason": "branch_not_selected"
+        }])
+    );
+
+    for (key, node) in trace {
+        let node = serde_json::to_value(node).expect("trace node serialises");
+        for dependency in node["dependencies"]
+            .as_array()
+            .expect("dependencies are an array")
+        {
+            let dependency = dependency.as_str().expect("dependency key is text");
+            assert!(
+                trace.contains_key(dependency),
+                "trace node `{key}` has dangling dependency `{dependency}`"
+            );
+        }
+    }
+}
+
+#[test]
+fn trace_closure_includes_related_entity_instances() {
+    let period = simple_period();
+    let program = ProgramSpec {
+        relations: vec![axiom_rules_engine::spec::RelationSpec {
+            name: "member_of_household".to_string(),
+            arity: 2,
+            derivation: None,
+        }],
+        derived: vec![
+            DerivedSpec {
+                id: None,
+                name: "person_amount".to_string(),
+                entity: "Person".to_string(),
+                dtype: DTypeSpec::Decimal,
+                unit: None,
+                rounding: None,
+                source: None,
+                period: None,
+                source_url: None,
+                corpus_citation_path: None,
+                semantics: DerivedSemanticsSpec::Scalar {
+                    expr: ScalarExprSpec::Input {
+                        name: "amount".to_string(),
+                    },
+                },
+                versions: vec![],
+            },
+            DerivedSpec {
+                id: None,
+                name: "household_amount".to_string(),
+                entity: "Household".to_string(),
+                dtype: DTypeSpec::Decimal,
+                unit: None,
+                rounding: None,
+                source: None,
+                period: None,
+                source_url: None,
+                corpus_citation_path: None,
+                semantics: DerivedSemanticsSpec::Scalar {
+                    expr: ScalarExprSpec::SumRelated {
+                        relation: "member_of_household".to_string(),
+                        current_slot: 1,
+                        related_slot: 0,
+                        value: RelatedValueRefSpec::Derived {
+                            name: "person_amount".to_string(),
+                        },
+                        where_clause: None,
+                    },
+                },
+                versions: vec![],
+            },
+        ],
+        ..ProgramSpec::default()
+    };
+    let response = execute_request(ExecutionRequest {
+        mode: ExecutionMode::Explain,
+        program,
+        dataset: DatasetSpec {
+            inputs: vec![InputRecordSpec {
+                name: "amount".to_string(),
+                entity: "Person".to_string(),
+                entity_id: "person-1".to_string(),
+                interval: IntervalSpec {
+                    start: period.start,
+                    end: period.end,
+                },
+                value: decimal_value("25"),
+            }],
+            relations: vec![RelationRecordSpec {
+                name: "member_of_household".to_string(),
+                tuple: vec!["person-1".to_string(), "household-1".to_string()],
+                interval: IntervalSpec {
+                    start: period.start,
+                    end: period.end,
+                },
+            }],
+        },
+        queries: vec![ExecutionQuery {
+            assessment_date: None,
+            entity_id: "household-1".to_string(),
+            period,
+            outputs: vec!["household_amount".to_string()],
+        }],
+    })
+    .expect("related derived request succeeds");
+    let trace = &response.results[0].trace;
+    let parent = serde_json::to_value(trace.get("household_amount").expect("parent trace node"))
+        .expect("serialises");
+    let dependency = parent["dependencies"][0]
+        .as_str()
+        .expect("related instance dependency key");
+    assert!(
+        trace.contains_key(dependency),
+        "related instance edge must resolve"
+    );
+    let child = serde_json::to_value(trace.get(dependency).expect("related child trace node"))
+        .expect("serialises");
+    assert_eq!(child["name"], "person_amount");
+    assert_eq!(child["entity_id"], "person-1");
+}
+
+#[test]
+fn old_trace_json_deserializes_without_execution_projection_fields() {
+    let old_wire_shape = serde_json::json!({
+        "kind": "judgment",
+        "name": "eligible",
+        "id": null,
+        "unit": null,
+        "outcome": "holds",
+        "source": null,
+        "source_url": null,
+        "dependencies": []
+    });
+    let node: axiom_rules_engine::api::DerivedTraceNode =
+        serde_json::from_value(old_wire_shape).expect("old trace JSON remains readable");
+    assert!(matches!(
+        node,
+        axiom_rules_engine::api::DerivedTraceNode::Judgment { .. }
+    ));
+}
+
+#[test]
+fn trace_excludes_cached_nodes_from_prior_query_entities() {
+    let program = axiom_rules_engine::rulespec::lower_rulespec_str(SIMPLE_RULESPEC)
+        .expect("program fixture parses");
+    let response = execute_request(simple_execution_request(ExecutionMode::Explain, program))
+        .expect("multi-entity Explain request succeeds");
+
+    assert_eq!(response.results.len(), 2);
+    for result in &response.results {
+        assert_eq!(
+            result.trace.len(),
+            1,
+            "a query trace must not include nodes cached while evaluating another entity"
+        );
+        let node = serde_json::to_value(
+            result
+                .trace
+                .get("adjusted_amount")
+                .expect("current entity trace node"),
+        )
+        .expect("trace node serialises");
+        assert_eq!(node["entity_id"], result.entity_id);
+        assert!(
+            result.trace.keys().all(|key| !key.contains("@entity:")),
+            "unrelated cached entity instances must not leak into this query trace"
+        );
+    }
+}
+
+#[test]
 fn fast_mode_coerces_integer_and_decimal_if_branches() {
     let period = PeriodSpec {
         kind: PeriodKindSpec::Month,


### PR DESCRIPTION
Fixes #100. Fixes #127.

The project had several interpreters and a trace renderer rather than one semantics. These are
the two consequences that reached published law.

## #100 — Explain and Fast disagreed on a published benefit

The published Flemish jobbonus rule returned **€650 in Explain and €0 in Fast** for the same
entity, period and inputs — requests differing only in `mode`, both exiting 0. The trigger was
two input records for the same fact both covering the query period (2 000 and 4 000): Explain
sorted covering records, Fast overwrote them in dataset order, so they landed on opposite sides
of an eligibility threshold.

Input precedence is now **deterministic latest-start in every mode and every dataset order**,
and genuinely ambiguous data — equal-start conflicting values — is an **error** rather than a
silent pick. The engine no longer accepts an ambiguity and then disagrees with itself about it.

Verified on the published rule with the fixture that produced the divergence:

```
explain  650 EUR
fast     650 EUR
```

**The test named for Explain/Fast parity was executing Fast twice**, so it could never have
observed this. It is replaced by a real 128-case generative differential test
(`explain_and_fast_are_differentially_equivalent_on_generated_programs`) plus targeted cases for
overlapping and permuted spells, equal-start ambiguity, non-covering newer records, and related
inputs.

## #127 — traces could misdescribe the computation they accompanied

Two defects, one root cause: the trace was reconstructed alongside the computation instead of
being produced by it.

* A narrative could contradict the arithmetic — UK Healthy Start computed `£8.50 × 52 = £442`
  while the trace described `365/7` weeks and omitted the `52` parameter from its dependencies.
  Narratives are now projections of what actually executed, reading the **selected** parameter
  rather than the authored source.
* Dependency edges could name nodes absent from the trace, because `And` short-circuits. Skipped
  branches are now explicit and parent-scoped, so a consumer walking the graph can distinguish
  *not evaluated* from *missing*, and the edges close.

Also fixed: related-entity closure, and cache isolation so a node cached from a previous query
entity no longer leaks into another query's trace.

## Dense f64 — deliberately unchanged

`execute_f64` still rounds £1.005 to £1.00 where every exact path gives £1.01. It is an
explicitly approximate, opt-in mode, and `axiom-microsim` uses the exact Decimal path, so no
published number is affected. A sound exactness marker needs Python/binding changes outside this
lane. Left as-is with the reasoning recorded rather than half-fixed.

## Corpus impact

Zero strict failures across all five corpora:

| Corpus | Modules | Baseline compiled | Strict failures |
|---|---:|---:|---:|
| US | 4,487 | 4,263 | 0 |
| UK | 332 | 332 | 0 |
| NZ | 40 | 40 | 0 |
| BE | 111 | 111 | 0 |
| GH | 17 | 17 | 0 |

The 224 US baseline failures are pre-existing corpus/main incompatibilities (rulespec-us#1049,
#1050), not regressions from this branch.

## Tests

Rebased onto `main` after #130 landed and re-verified combined: **226 passed, 0 failed**. The
published-rule check and a 46/46 default-mode compile sweep across uk/be/nz/gh were re-run on
the rebased branch, not just the original one.
