### PR TITLE
Carry declared relation slot entities; validate orientation against executable usage

### DIFF
--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,107 +1,259 @@
-# PROGRESS — relation slot entities follow-up (issue #137)
+# PROGRESS — cross-period reduction (issue #67)
 
-Branch: `fix/relation-slot-entities`, extending the four existing #137 commits
-without rewriting them. Network access is prohibited.
+Branch: `cross-period-reduction` (worktree axiom-engine-67, from origin/main).
 
 ## State
+Design finalized after full read of dense.rs, formula.rs, spec.rs, model.rs,
+engine.rs, bulk.rs, api.rs, rulespec.rs, python-ext/src/lib.rs, python/dense.py,
+CI workflow, and tests/dense.rs. Starting implementation.
 
-Complete. Amendments A, B, and C, all repository gates, the final corpus and
-26/32 reruns, and independent review are complete. The completed report is in
-`out.md`; no push was performed.
+## Design (from brief, settled) + resolved mechanics
+
+### New expression node (threaded end-to-end)
+- model `ScalarExpr::OverPeriods { kind: OverPeriodsKind, value: Box<ScalarExpr>, n: Option<Box<ScalarExpr>> }`
+  where `OverPeriodsKind ∈ { Sum, Max, Count, SumTopN }`.
+- spec `ScalarExprSpec::OverPeriods { kind, value, n }` (serde-tagged, round-trips; additive → no artifact version bump).
+- dense `CompiledScalarExpr::OverPeriods { kind, value: Box<..>, n: Option<Box<..>> }`.
+- formula.rs `lower_to_scalar` parses the four builtin `Call`s:
+  - `sum_over_periods(x)` → OverPeriods{Sum, x, None}
+  - `max_over_periods(x)` → OverPeriods{Max, x, None}
+  - `count_over_periods(x)` → OverPeriods{Count, x, None}  (x still lowered so alignment/period count is well-defined; count ignores values)
+  - `sum_top_n_over_periods(x, n)` → OverPeriods{SumTopN, x, Some(n)}
+  arg-count errors mirror existing builtins.
+
+### Per-period-context rejection (lifetime-only)
+- Per-period dense executor `eval_scalar_expr`: OverPeriods → EvalError::OverPeriodsOutsideLifetime.
+- dense `compile_related_scalar` / `compile_current_scalar_expr`: reject (can't nest a cross-period
+  reduction inside a related/where expr) via DenseCompileError::Unsupported.
+- Sparse `engine.rs` eval_scalar_expr + bulk.rs (both columnar and related scalar paths) + api.rs
+  dep-collector + model.rs input-slot collector: handle new variant (sparse/bulk error clearly;
+  collectors recurse into value/n so inputs referenced inside a reduction are still discovered).
+
+### Lifetime execution surface (dense.rs)
+- `execute_lifetime(periods: &[Period], batches: Vec<DenseBatchSpec>, outputs) -> DenseExecutionResult` (Decimal)
+- `execute_lifetime_f64(...)` (f64), parallel to execute/execute_f64.
+- Validation:
+  - periods.len() == batches.len(), non-empty.
+  - every batch binds identically (bind_batch each) and all have the SAME row_count (v1 positional
+    alignment; error clearly on mismatch — new EvalError::LifetimeRowCountMismatch).
+  - each requested output's compiled formula must contain ≥1 OverPeriods node; else
+    EvalError::LifetimeOutputWithoutReduction (brief: lifetime exec only supports reduction outputs).
+- Evaluation model (LifetimeExecutor):
+  - Build one per-period bound batch + a way to make a per-period DenseExecutor<N>.
+  - Outer formula evaluated ONCE (row-wise), recursively:
+    * OverPeriods{kind,value,n}: evaluate `value` per period with that period's DenseExecutor
+      → P columns of length R; transpose to per-row Vec<N> of length P; reduce row-wise:
+        Sum = Σ; Max = max (error if P==0 — guaranteed ≥1 by non-empty periods); Count = P (ignores value);
+        SumTopN = sort desc, take top n, zero-pad when P<n (missing periods contribute 0 — mirrors 415(b)).
+        n: evaluate `n` at reference period (last), per-row; truncate toward zero to i64; error if < 1
+        (EvalError::TypeMismatch with a clear message). n is per-row but typically constant.
+    * Literal / Add / Sub / Mul / Div / Max / Min / Ceil / Floor / If(condition over reductions): recurse row-wise.
+    * ParameterLookup / Derived(scalar): evaluate at reference period (last period) — parameters like a
+      bend point are indexed to the eligibility/last year; Derived recurses through lifetime evaluator so a
+      derived that itself reduces works.
+    * Period-ambiguous leaves OUTSIDE any reduction (bare Input, InputOrElse, PeriodStart/End, CountRelated,
+      SumRelated): error EvalError::LifetimeAmbiguousLeaf — tell the caller these must appear inside an
+      over-periods reduction. (Faithful to "reused per-period evaluation"; keeps semantics unambiguous.)
+  - Reference period = last period supplied (documented). Rationale: over-periods reductions are the
+    lifetime axis; scalars combined with the reduction (bend points, divisor) are resolved at the
+    determination period, which is the most recent supplied period.
+
+### PyO3
+- `execute_lifetime_f64(periods, batches, outputs=None)` on CompiledDenseProgramHandle, parallel to
+  execute_f64. `periods`: list of (period_kind, start, end); `batches`: list of the same input/relation
+  dict shape build_batch already accepts. Python wrapper method `execute_lifetime_f64` in dense.py.
+
+### No RuleSpec schema changes (expression-level only). Additive serde on ScalarExprSpec.
 
 ## Done
+- Full exploration; PROGRESS.md seeded.
+- model.rs: OverPeriodsKind (+ as_call_name) + ScalarExpr::OverPeriods + input-slot collector arm.
+- spec.rs: ScalarExprSpec::OverPeriods + OverPeriodsKindSpec + to_model.
+- formula.rs: parse sum/max/count/sum_top_n_over_periods in lower_to_scalar; promote_ints descends into value.
+- engine.rs: EvalError variants (OverPeriodsOutsideLifetime, Lifetime*, OverPeriodsTopNInvalid) + sparse reject arm.
+- bulk.rs (both paths) + api.rs collector: new arms.
+- compile.rs: fast-blocker (adds blocker), dependency collector, relation-member collector arms.
+- rulespec.rs: 4 traversal arms (alias rewrite, relation-name collect, relation-ref rewrite, imported-derived check).
+- dense.rs: CompiledScalarExpr::OverPeriods + compile arm + per-period reject + related/current reject +
+  DenseNum::to_i64_trunc + LifetimeExecutor + execute_lifetime[_f64] + derived_reduces_over_periods gate.
+- schemas/compiled-artifact.v1.schema.json regenerated (additive over_periods variant; no format-version bump).
+- GREEN: cargo build, fmt, cargo test (default + schema feature), cargo check python-ext.
+- clippy: baseline origin/main already emits 36 lib warnings; my additions introduce ZERO new warnings
+  (every warning location is in pre-existing code). Not touching the 36 pre-existing ones (scope).
 
-- Confirmed the verified gate findings in the prior report:
-  - closure-membership errors reject five legitimate published modules;
-  - the hardcoded legacy relation alias is content-specific;
-  - declaration-based binding diagnostics point consumers toward the
-    zero-producing order for `us:statutes/26/32`.
-- Confirmed the active branch and preserved all four existing commits.
-- Added `CompileOptions::strict_relation_entities`.
-- Ratcheted relation argument validation:
-  - arity mismatch remains a hard error in every mode;
-  - shape-invalid labels warn by default, leave `slot_entities` empty, and
-    error in strict mode;
-  - well-shaped closure-unknown kinds warn by default, remain verbatim in the
-    artifact, and error in strict mode.
-- Deleted the `member_of_individuals_household` content-specific alias.
-- Routed RuleSpec diagnostics into artifact compile diagnostics without
-  serializing them, preserving canonical module paths.
-- Documented compile and binding strictness separately.
-- Red evidence: the focused test build failed because
-  `CompileOptions::strict_relation_entities` did not exist.
-- Green evidence: 82 RuleSpec tests, 12 module-source tests, and five
-  namespace-ratchet unit tests pass.
-- Added deterministic program-level relation usage analysis shared by compile
-  validation and dataset binding:
-  - aggregate owner entity constrains `current_slot`;
-  - predicate/value entity constrains `related_slot`;
-  - membership and derived-relation source uses propagate structural kinds;
-  - versioned rules inspect executable versions rather than phantom base
-    semantics;
-  - conflicting uses leave a slot unresolved instead of choosing arbitrarily.
-- Added `warning[relation_orientation_mismatch]`, strict compile promotion,
-  artifact reload recomputation, and source-fidelity preservation.
-- Binding now uses executable orientation for used relations and declaration
-  order only for unused relations.
-- Red evidence: the 26/32-shaped fixture had no compile warning, warned on the
-  working tuple, and did not warn on the empty-lookup tuple; the membership
-  fixture also had no orientation warning.
-- Green evidence: all three orientation tests pass, including strict/reload
-  behavior and derived-relation membership. Full `cargo test` passes.
-- Re-ran the staged default-mode corpus sweep:
-  - 40/46 modules compile, with the same six pre-existing failures as the
-    baseline;
-  - successful compiles emit 39 warnings across 26 invocations: 32
-    `relation_orientation_mismatch`, five
-    `unknown_relation_argument_entity`, one
-    `invalid_relation_argument_entity_shape`, and one pre-existing
-    `non_exhaustive_match`;
-  - the five closure-authority gaps compile successfully by default.
-- Completed the orientation census:
-  - the required 42-relation US cohort has 19 usage-consistent, 22
-    usage-inconsistent, and one unused declaration;
-  - the literal five-root total includes eight additional UK declarations and
-    is 21 consistent, 28 inconsistent, and one unused across 50 declarations;
-  - NZ, BE, and GH contain no declared-argument relations.
-- Re-ran the amended 26/32 dynamic fixture:
-  - compilation preserves declared slots `[TaxUnit, Person]` and emits the
-    orientation warning for executable order `[Person, TaxUnit]`;
-  - the executable-order tuple returns count 1 with no bind warning;
-  - the declaration-order tuple returns count 0 with two bind warnings, one
-    for each reversed slot.
-- Independent evidence review reproduced the corpus counts, census, worklist,
-  and 26/32 transcript without a gate-blocking finding.
-- Independent code review found that a nested aggregate's predicate/value
-  entity could contaminate its enclosing relation's orientation.
-- Added a nested `sum_related` regression covering both compile and bind
-  diagnostics. Red evidence derived `[Payment, TaxUnit]` for the outer
-  `[Person, TaxUnit]` relation and `[Payment, Payment]` for the inner
-  `[Payment, Person]` relation. Treating nested aggregate internals as a
-  separate execution context makes both executable tuple orders warning-free.
-- Focused re-review found that an untyped outer relation still suppressed the
-  nested scalar traversal. A second red regression observed no executable-use
-  diagnostic for reversed inner declaration `[Person, Payment]`. Relation
-  traversal now carries an optional current kind, retaining the independently
-  derived inner `[Payment, Person]` orientation; compile warns on the reversed
-  declaration and binding leaves the working tuple warning-free.
-- Final post-review gates:
-  - `cargo test`: 256 passed, zero failed;
-  - schema feature tests: 12 passed, zero failed;
-  - `cargo fmt --all --check`: exit 0;
-  - `cargo check --target wasm32-unknown-unknown --no-default-features`:
-    exit 0;
-  - `cargo clippy --all-targets --all-features`: exit 0;
-  - `git diff --check origin/main...HEAD`: exit 0.
-- Final post-fix corpus rerun remains 40/46 with 39 warning emissions across
-  26 successful invocations and the same six baseline failures.
-- Final fresh 26/32 rerun remains count 1 with zero bind warnings for
-  `[Person, TaxUnit]`, and count 0 with two bind warnings for
-  `[TaxUnit, Person]`.
-- Final focused independent review reports no remaining actionable finding.
-- Wrote the completed report, including all census worklists and numbers, to
-  `out.md`.
+- python-ext/src/lib.rs: execute_lifetime_f64 PyO3 method + shared execution_to_pydict +
+  split_lifetime_batch; python/dense.py: execute_lifetime_f64 wrapper.
+- tests/lifetime.rs: 22 Rust tests — AIME acceptance (Decimal + f64, =2833), each builtin, top-n
+  (ties, n>period_count zero-pad, n as param expr, non-integer n truncation, negatives), multi-row
+  alignment, outer-formula-with-parameter, all validation/error paths, per-period rejection, Decimal exactness.
+- python/tests/test_dense_lifetime.py: 4 tests — AIME acceptance (=2833), two-worker row alignment,
+  period/batch-count and row-count mismatch errors. Built wheel via maturin (py3.14 venv), 36/36 python tests pass.
 
-## Next
+## Acceptance test AIME value
+AIME = 2833. Synthetic 40-year worker, indexed earnings year k = 12_000 + 1_000*(k-1) (12_000..51_000).
+Top 35 of 40 drops the lowest 5; sum(top 35) = 35*(17_000+51_000)/2 = 1_190_000;
+floor(1_190_000 / 420) = floor(2833.33..) = 2833.
 
-No implementation work remains. Deliver `out.md`; leave the branch unpushed.
+## Independent review + fixes (applied)
+An independent read-only review found NO correctness bugs (verified AIME math, Max empty-slice safety,
+SumTopN zero-pad/ties/negatives, rejection completeness, transitive gate + cycle protection, serde
+round-trip, PyO3 layer). Three polish items applied:
+- LifetimeAmbiguousLeaf now carries a String (removed the Box::leak &'static str helper).
+- count_over_periods short-circuits before building the per-period matrix (a period count must not fail
+  because the inner body is unevaluable).
+- Directly-nested reductions (e.g. sum_over_periods(max_over_periods(x)), or a reduction in the `n` arg)
+  are now rejected at DENSE COMPILE TIME (DenseCompileError::NestedOverPeriods) with a precise message,
+  instead of surfacing an opaque per-period runtime error. Reduction-via-Derived still errors safely at
+  runtime (documented; transitive check needs the whole program, not one expr).
+Added 2 Rust tests for the nested-reduction rejection (24 lifetime tests total).
+
+## Final gate (all GREEN)
+- cargo fmt --check clean; cargo build; cargo test (default) all pass; cargo test --features schema all pass;
+  cargo check python-ext; cargo check wasm32-unknown-unknown --no-default-features.
+- clippy: 36 lib warnings, identical to origin/main baseline — ZERO introduced by this change; no warnings
+  in tests/lifetime.rs or python-ext.
+- 24 Rust lifetime tests + 36 Python tests pass against the maturin-built extension.
+
+## DRAFT PR
+https://github.com/TheAxiomFoundation/axiom-rules-engine/pull/68
+(draft, base main, head cross-period-reduction, title "Cross-period reductions: lifetime execution surface (#67)").
+Do NOT merge.
+
+## Concerns
+- Reference-period choice for non-reduction scalars (parameters/derived) inside the outer formula:
+  chose LAST supplied period. Documented; flag for review. For the AIME acceptance formula the outer
+  formula only combines the reduction with a literal (420), so this choice is not exercised there.
+- (Superseded for INPUTS by the amendment below.) Lifetime execution previously rejected ALL
+  period-ambiguous bare leaves outside reductions. Bare inputs are now bound when provably invariant;
+  the reference-period-for-parameters convention above is unchanged.
+
+## Amendment — runtime-verified period-invariant binding for inputs (this session)
+
+### Why
+42 USC 415(b)'s benefit-computation-year count is a derived scalar built from per-person-constant
+inputs (year the worker attains 21 / 62) and must feed `sum_top_n_over_periods` as its `n`. Under the
+original design that `n` — a bare input reached through a derived chain, sitting OUTSIDE every reduction
+— hit the blanket `LifetimeAmbiguousLeaf` rejection, so real 415(b) logic could not run end to end.
+Empirically confirmed failing (scratchpad/check_derived_n_lifetime.py errored on `year_attained_62`).
+
+### What changed (dense.rs lifetime paths only; no schema change; per-period execute/execute_f64 unchanged)
+- `LifetimeExecutor::eval_scalar` `Input` / `InputOrElse` arms no longer error. They call the new
+  `eval_period_invariant_input(expr, name)`, which evaluates the SAME bare-input node under every
+  period's `DenseExecutor` (one column per period, positionally aligned) and checks PER ROW that the
+  value is identical across ALL supplied periods.
+  - All rows invariant → bind period 0's column (dtype preserved); the caller consumes it exactly like
+    any other column, so a value in scalar OR in the `n` position, reached directly OR through a derived
+    chain (Sub/Max/… compose row-wise), all work.
+  - Any row varies → new `EvalError::LifetimePeriodVaryingInput`, naming the input and the first two
+    differing period labels (`start..end`) and values. Truly period-varying inputs still fail loudly.
+- New free helpers in dense.rs: `first_differing_row` (exact per-row equality; numeric variants compared
+  by Decimal-promoted value so `1985` == `1985.0`; non-numeric mismatch or non-finite → treated as
+  differing = safe error), `period_label`, `dense_value_label`.
+- New `EvalError::LifetimePeriodVaryingInput` variant in engine.rs. `LifetimeAmbiguousLeaf` still used
+  for the genuinely period-specific leaves (PeriodStart/End, Date*, Count/SumRelated).
+- Parameters keep their existing last-supplied-period behavior; the amendment touches inputs only.
+
+### Tests
+- tests/lifetime.rs (+4, 28 total): (a) per-person-constant input binds outside a reduction;
+  (b) per-row-varying but per-period-constant input binds per row (rows 100 vs 500);
+  (c) period-VARYING input errors, message names the input; (d) the derived-n-from-constant-inputs
+  chain end to end (two workers, n = 36 and 31; earnings_total [3_456_000, 1_922_000]; aime [8000, 5166]).
+- python/tests/test_dense_lifetime.py (+2): two-worker derived-n case (mirrors the scratchpad script) and
+  a period-varying-input error case naming the input.
+
+### Acceptance-script arithmetic note (IMPORTANT — flagged for review)
+scratchpad/check_derived_n_lifetime.py as delivered expected `aime[1] = 5167` for worker B, with a
+comment `floor(5167.20)`. That is wrong: worker B has total 1_922_000, n = 31, so
+`aime = floor(1_922_000 / (12*31 = 372)) = floor(5166.666…) = 5166`. 5167 is the round-HALF-UP value,
+not the `floor` the module (and 42 USC 415(b)(2)(A) / 20 CFR 404.211(d), which round DOWN) use — and no
+integer months divisor can even produce 5167 for this total (floor jumps 5180 at d=371 to 5166 at d=372,
+skipping 5167). Independently re-derived. The engine is statutorily correct at 5166; the fixture's one
+expected constant was corrected 5167 → 5166 (worker A's 8000 is unaffected: floor and round agree there).
+The binding mechanism the script exercises — two workers with DIFFERENT derived n binding correctly — is
+proven by `earnings_total = [3_456_000, 1_922_000]`, which matches exactly.
+
+### Final gate (all GREEN, this amendment)
+- cargo fmt --check clean; cargo build; cargo test (default) 0 failed; cargo test --features schema
+  0 failed (schema golden-file guard passes — no artifact-schema change); cargo check python-ext;
+  cargo check wasm32-unknown-unknown --no-default-features.
+- clippy --all-targets: actual lint findings BYTE-IDENTICAL to the pre-amendment branch tip (37 finding
+  lines; 35 lib + 35 lib-test as before) — ZERO new warnings; none reference the new code.
+- 28 Rust lifetime tests + 38 Python tests pass against the maturin-rebuilt extension; the corrected
+  scratchpad acceptance script passes (earnings_total [3456000, 1922000], aime [8000, 5166]).
+
+## Review response — six fixes (this session, PR #68 review)
+
+Six confirmed review findings addressed; semantics decided by the feature-brief
+author. Referential transparency, ordering validation, and count-nonzero were
+already implemented from the prior session; this session completed the strict n
+contract, the exhaustive reduction parse, and the DECISIONS.md entry, corrected
+the stale comments, and pinned every case as a test.
+
+1. **Referential transparency (dense.rs).** A derived referenced OUTSIDE a
+   reduction is evaluated by inlining its body in the lifetime context (the
+   `Derived` arm recurses through the lifetime executor): parameters resolve at
+   the reference period, and a bare input inside that body goes through the
+   per-row period-invariance guard. A parameter-bearing derived reused both
+   inside a reduction and bare outside it therefore denotes exactly its
+   definition in both positions. The review's 600-case
+   (`sum_over_periods(credit) + credit`, `credit = rate + earnings`, `earnings`
+   period-varying) now errors loudly via `LifetimePeriodVaryingInput` naming
+   `earnings`, instead of silently returning 600. Test:
+   `derived_reused_inside_and_outside_reduction_errors_on_period_varying_input`.
+
+2. **Strictly-ascending periods (dense.rs + engine.rs).** `execute_lifetime[_f64]`
+   validate that supplied periods strictly ascend by start date and error with
+   `LifetimePeriodsNotAscending` (naming the offending adjacent pair) rather than
+   silently resolving parameters / n at a positionally-last-but-chronologically-
+   earlier year. Reference period = the (now guaranteed chronologically-last)
+   final period. Tests: `errors_when_periods_are_not_strictly_ascending`
+   (Rust), `test_descending_periods_raise` (Python).
+
+3. **count_over_periods counts nonzero (dense.rs + model.rs).** `count_over_periods`
+   now evaluates its argument per period and counts, per row, the periods whose
+   value is nonzero (`Bool` counts `true`; text/date rejected). It is no longer a
+   bare supplied-period count. The stale "evaluated but ignored" doc on
+   `OverPeriodsKind::Count` (model.rs) was corrected. Tests:
+   `count_over_periods_counts_nonzero_periods_per_row`,
+   `count_over_periods_all_zero_is_zero` (Rust), and a Python analogue.
+
+4. **Strict n contract for sum_top_n (dense.rs + engine.rs + model.rs).**
+   `DenseNum::try_to_i64_trunc(self) -> Option<i64>` replaces the saturating
+   `to_i64_trunc` in both dtype impls. `eval_top_n_counts` now: evaluates n under
+   EVERY period's executor and rejects a period-VARYING n (parameter- and
+   input-sourced held to the identical contract) with
+   `OverPeriodsTopNPeriodVarying`; truncates the reference column toward zero to
+   an exact i64 (a non-finite / out-of-range value -> `None` -> hard error); and
+   enforces `1 <= n <= period_count`, erroring `OverPeriodsTopNOutOfRange` on
+   under- and over-length n. No clamp to i64::MAX, no silent reference-period
+   pin, no zero-pad past the period count. Tests:
+   `sum_top_n_n_exceeds_period_count_errors_in_decimal_path`,
+   `...in_f64_path`, `sum_top_n_period_varying_parameter_n_errors`, updated
+   `errors_when_sum_top_n_n_is_less_than_one` and the former zero-pad test
+   (now `sum_top_n_errors_when_n_exceeds_the_period_count`); Python analogues.
+
+5. **Exhaustive reduction parse (formula.rs).** The one-argument over-periods
+   arm chooses its kind by an exhaustive match with an explicit error arm (no
+   wildcard falling through to `Count`), and any other `*_over_periods` name is
+   rejected with a reduction-specific parse error rather than the generic
+   "unknown function". Tests: `unknown_over_periods_reduction_fails_to_parse`
+   (Rust + Python).
+
+6. **DECISIONS.md.** One new most-recent-first entry (2026-07-05) covering the
+   lifetime execution surface: the `OverPeriods` node + four builtins, reference
+   period = chronologically-last supplied period, strictly-ascending validation,
+   period-invariant input binding + inlined-body derived semantics,
+   count-nonzero, and the strict n contract.
+
+### Final gate (all GREEN, this session)
+- `cargo fmt` applied; `cargo fmt --check` clean; `cargo build`; `cargo test`
+  (default) 0 failed; `cargo test --features schema` 0 failed;
+  `cargo check --manifest-path python-ext/Cargo.toml`;
+  `cargo check --target wasm32-unknown-unknown --no-default-features`.
+- clippy: `--lib` and `--all-targets` finding multisets BYTE-IDENTICAL to branch
+  tip 984a4e0 (per-file counts diff empty) — ZERO new warnings; python-ext clippy
+  identical to baseline (2 pre-existing).
+- 35 Rust lifetime tests + 42 Python tests pass against the maturin-rebuilt
+  (`--release`) extension; the acceptance script
+  `scratchpad/check_derived_n_lifetime.py` prints
+  `earnings_total [3456000. 1922000.]`, `aime [8000. 5166.]` and all assertions pass.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -5,9 +5,9 @@ without rewriting them. Network access is prohibited.
 
 ## State
 
-Amendments A, B, and the Amendment C census are complete. The default corpus
-result is restored to 40/46, and the amended 26/32 dynamic acceptance check
-passes. Work is moving to final repository gates and independent review.
+Complete. Amendments A, B, and C, all repository gates, the final corpus and
+26/32 reruns, and independent review are complete. The completed report is in
+`out.md`; no push was performed.
 
 ## Done
 
@@ -85,8 +85,23 @@ passes. Work is moving to final repository gates and independent review.
   traversal now carries an optional current kind, retaining the independently
   derived inner `[Payment, Person]` orientation; compile warns on the reversed
   declaration and binding leaves the working tuple warning-free.
+- Final post-review gates:
+  - `cargo test`: 256 passed, zero failed;
+  - schema feature tests: 12 passed, zero failed;
+  - `cargo fmt --all --check`: exit 0;
+  - `cargo check --target wasm32-unknown-unknown --no-default-features`:
+    exit 0;
+  - `cargo clippy --all-targets --all-features`: exit 0;
+  - `git diff --check origin/main...HEAD`: exit 0.
+- Final post-fix corpus rerun remains 40/46 with 39 warning emissions across
+  26 successful invocations and the same six baseline failures.
+- Final fresh 26/32 rerun remains count 1 with zero bind warnings for
+  `[Person, TaxUnit]`, and count 0 with two bind warnings for
+  `[TaxUnit, Person]`.
+- Final focused independent review reports no remaining actionable finding.
+- Wrote the completed report, including all census worklists and numbers, to
+  `out.md`.
 
 ## Next
 
-1. Re-run all repository gates after the review fix.
-2. Finalize this progress log and write the completed report to `out.md`.
+No implementation work remains. Deliver `out.md`; leave the branch unpushed.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -1,259 +1,30 @@
-# PROGRESS — cross-period reduction (issue #67)
+# PROGRESS — relation slot entities follow-up (issue #137)
 
-Branch: `cross-period-reduction` (worktree axiom-engine-67, from origin/main).
+Branch: `fix/relation-slot-entities`, extending the four existing #137 commits
+without rewriting them. Network access is prohibited.
 
 ## State
-Design finalized after full read of dense.rs, formula.rs, spec.rs, model.rs,
-engine.rs, bulk.rs, api.rs, rulespec.rs, python-ext/src/lib.rs, python/dense.py,
-CI workflow, and tests/dense.rs. Starting implementation.
 
-## Design (from brief, settled) + resolved mechanics
-
-### New expression node (threaded end-to-end)
-- model `ScalarExpr::OverPeriods { kind: OverPeriodsKind, value: Box<ScalarExpr>, n: Option<Box<ScalarExpr>> }`
-  where `OverPeriodsKind ∈ { Sum, Max, Count, SumTopN }`.
-- spec `ScalarExprSpec::OverPeriods { kind, value, n }` (serde-tagged, round-trips; additive → no artifact version bump).
-- dense `CompiledScalarExpr::OverPeriods { kind, value: Box<..>, n: Option<Box<..>> }`.
-- formula.rs `lower_to_scalar` parses the four builtin `Call`s:
-  - `sum_over_periods(x)` → OverPeriods{Sum, x, None}
-  - `max_over_periods(x)` → OverPeriods{Max, x, None}
-  - `count_over_periods(x)` → OverPeriods{Count, x, None}  (x still lowered so alignment/period count is well-defined; count ignores values)
-  - `sum_top_n_over_periods(x, n)` → OverPeriods{SumTopN, x, Some(n)}
-  arg-count errors mirror existing builtins.
-
-### Per-period-context rejection (lifetime-only)
-- Per-period dense executor `eval_scalar_expr`: OverPeriods → EvalError::OverPeriodsOutsideLifetime.
-- dense `compile_related_scalar` / `compile_current_scalar_expr`: reject (can't nest a cross-period
-  reduction inside a related/where expr) via DenseCompileError::Unsupported.
-- Sparse `engine.rs` eval_scalar_expr + bulk.rs (both columnar and related scalar paths) + api.rs
-  dep-collector + model.rs input-slot collector: handle new variant (sparse/bulk error clearly;
-  collectors recurse into value/n so inputs referenced inside a reduction are still discovered).
-
-### Lifetime execution surface (dense.rs)
-- `execute_lifetime(periods: &[Period], batches: Vec<DenseBatchSpec>, outputs) -> DenseExecutionResult` (Decimal)
-- `execute_lifetime_f64(...)` (f64), parallel to execute/execute_f64.
-- Validation:
-  - periods.len() == batches.len(), non-empty.
-  - every batch binds identically (bind_batch each) and all have the SAME row_count (v1 positional
-    alignment; error clearly on mismatch — new EvalError::LifetimeRowCountMismatch).
-  - each requested output's compiled formula must contain ≥1 OverPeriods node; else
-    EvalError::LifetimeOutputWithoutReduction (brief: lifetime exec only supports reduction outputs).
-- Evaluation model (LifetimeExecutor):
-  - Build one per-period bound batch + a way to make a per-period DenseExecutor<N>.
-  - Outer formula evaluated ONCE (row-wise), recursively:
-    * OverPeriods{kind,value,n}: evaluate `value` per period with that period's DenseExecutor
-      → P columns of length R; transpose to per-row Vec<N> of length P; reduce row-wise:
-        Sum = Σ; Max = max (error if P==0 — guaranteed ≥1 by non-empty periods); Count = P (ignores value);
-        SumTopN = sort desc, take top n, zero-pad when P<n (missing periods contribute 0 — mirrors 415(b)).
-        n: evaluate `n` at reference period (last), per-row; truncate toward zero to i64; error if < 1
-        (EvalError::TypeMismatch with a clear message). n is per-row but typically constant.
-    * Literal / Add / Sub / Mul / Div / Max / Min / Ceil / Floor / If(condition over reductions): recurse row-wise.
-    * ParameterLookup / Derived(scalar): evaluate at reference period (last period) — parameters like a
-      bend point are indexed to the eligibility/last year; Derived recurses through lifetime evaluator so a
-      derived that itself reduces works.
-    * Period-ambiguous leaves OUTSIDE any reduction (bare Input, InputOrElse, PeriodStart/End, CountRelated,
-      SumRelated): error EvalError::LifetimeAmbiguousLeaf — tell the caller these must appear inside an
-      over-periods reduction. (Faithful to "reused per-period evaluation"; keeps semantics unambiguous.)
-  - Reference period = last period supplied (documented). Rationale: over-periods reductions are the
-    lifetime axis; scalars combined with the reduction (bend points, divisor) are resolved at the
-    determination period, which is the most recent supplied period.
-
-### PyO3
-- `execute_lifetime_f64(periods, batches, outputs=None)` on CompiledDenseProgramHandle, parallel to
-  execute_f64. `periods`: list of (period_kind, start, end); `batches`: list of the same input/relation
-  dict shape build_batch already accepts. Python wrapper method `execute_lifetime_f64` in dense.py.
-
-### No RuleSpec schema changes (expression-level only). Additive serde on ScalarExprSpec.
+Amendment work has started from `b30ea2a`. The prior report in `out.md` has
+been read, and the checkout is clean apart from that intentionally untracked
+report. The branch is four commits ahead of local `origin/main`.
 
 ## Done
-- Full exploration; PROGRESS.md seeded.
-- model.rs: OverPeriodsKind (+ as_call_name) + ScalarExpr::OverPeriods + input-slot collector arm.
-- spec.rs: ScalarExprSpec::OverPeriods + OverPeriodsKindSpec + to_model.
-- formula.rs: parse sum/max/count/sum_top_n_over_periods in lower_to_scalar; promote_ints descends into value.
-- engine.rs: EvalError variants (OverPeriodsOutsideLifetime, Lifetime*, OverPeriodsTopNInvalid) + sparse reject arm.
-- bulk.rs (both paths) + api.rs collector: new arms.
-- compile.rs: fast-blocker (adds blocker), dependency collector, relation-member collector arms.
-- rulespec.rs: 4 traversal arms (alias rewrite, relation-name collect, relation-ref rewrite, imported-derived check).
-- dense.rs: CompiledScalarExpr::OverPeriods + compile arm + per-period reject + related/current reject +
-  DenseNum::to_i64_trunc + LifetimeExecutor + execute_lifetime[_f64] + derived_reduces_over_periods gate.
-- schemas/compiled-artifact.v1.schema.json regenerated (additive over_periods variant; no format-version bump).
-- GREEN: cargo build, fmt, cargo test (default + schema feature), cargo check python-ext.
-- clippy: baseline origin/main already emits 36 lib warnings; my additions introduce ZERO new warnings
-  (every warning location is in pre-existing code). Not touching the 36 pre-existing ones (scope).
 
-- python-ext/src/lib.rs: execute_lifetime_f64 PyO3 method + shared execution_to_pydict +
-  split_lifetime_batch; python/dense.py: execute_lifetime_f64 wrapper.
-- tests/lifetime.rs: 22 Rust tests — AIME acceptance (Decimal + f64, =2833), each builtin, top-n
-  (ties, n>period_count zero-pad, n as param expr, non-integer n truncation, negatives), multi-row
-  alignment, outer-formula-with-parameter, all validation/error paths, per-period rejection, Decimal exactness.
-- python/tests/test_dense_lifetime.py: 4 tests — AIME acceptance (=2833), two-worker row alignment,
-  period/batch-count and row-count mismatch errors. Built wheel via maturin (py3.14 venv), 36/36 python tests pass.
+- Confirmed the verified gate findings in the prior report:
+  - closure-membership errors reject five legitimate published modules;
+  - the hardcoded legacy relation alias is content-specific;
+  - declaration-based binding diagnostics point consumers toward the
+    zero-producing order for `us:statutes/26/32`.
+- Confirmed the active branch and preserved all four existing commits.
 
-## Acceptance test AIME value
-AIME = 2833. Synthetic 40-year worker, indexed earnings year k = 12_000 + 1_000*(k-1) (12_000..51_000).
-Top 35 of 40 drops the lowest 5; sum(top 35) = 35*(17_000+51_000)/2 = 1_190_000;
-floor(1_190_000 / 420) = floor(2833.33..) = 2833.
+## Next
 
-## Independent review + fixes (applied)
-An independent read-only review found NO correctness bugs (verified AIME math, Max empty-slice safety,
-SumTopN zero-pad/ties/negatives, rejection completeness, transitive gate + cycle protection, serde
-round-trip, PyO3 layer). Three polish items applied:
-- LifetimeAmbiguousLeaf now carries a String (removed the Box::leak &'static str helper).
-- count_over_periods short-circuits before building the per-period matrix (a period count must not fail
-  because the inner body is unevaluable).
-- Directly-nested reductions (e.g. sum_over_periods(max_over_periods(x)), or a reduction in the `n` arg)
-  are now rejected at DENSE COMPILE TIME (DenseCompileError::NestedOverPeriods) with a precise message,
-  instead of surfacing an opaque per-period runtime error. Reduction-via-Derived still errors safely at
-  runtime (documented; transitive check needs the whole program, not one expr).
-Added 2 Rust tests for the nested-reduction rejection (24 lifetime tests total).
-
-## Final gate (all GREEN)
-- cargo fmt --check clean; cargo build; cargo test (default) all pass; cargo test --features schema all pass;
-  cargo check python-ext; cargo check wasm32-unknown-unknown --no-default-features.
-- clippy: 36 lib warnings, identical to origin/main baseline — ZERO introduced by this change; no warnings
-  in tests/lifetime.rs or python-ext.
-- 24 Rust lifetime tests + 36 Python tests pass against the maturin-built extension.
-
-## DRAFT PR
-https://github.com/TheAxiomFoundation/axiom-rules-engine/pull/68
-(draft, base main, head cross-period-reduction, title "Cross-period reductions: lifetime execution surface (#67)").
-Do NOT merge.
-
-## Concerns
-- Reference-period choice for non-reduction scalars (parameters/derived) inside the outer formula:
-  chose LAST supplied period. Documented; flag for review. For the AIME acceptance formula the outer
-  formula only combines the reduction with a literal (420), so this choice is not exercised there.
-- (Superseded for INPUTS by the amendment below.) Lifetime execution previously rejected ALL
-  period-ambiguous bare leaves outside reductions. Bare inputs are now bound when provably invariant;
-  the reference-period-for-parameters convention above is unchanged.
-
-## Amendment — runtime-verified period-invariant binding for inputs (this session)
-
-### Why
-42 USC 415(b)'s benefit-computation-year count is a derived scalar built from per-person-constant
-inputs (year the worker attains 21 / 62) and must feed `sum_top_n_over_periods` as its `n`. Under the
-original design that `n` — a bare input reached through a derived chain, sitting OUTSIDE every reduction
-— hit the blanket `LifetimeAmbiguousLeaf` rejection, so real 415(b) logic could not run end to end.
-Empirically confirmed failing (scratchpad/check_derived_n_lifetime.py errored on `year_attained_62`).
-
-### What changed (dense.rs lifetime paths only; no schema change; per-period execute/execute_f64 unchanged)
-- `LifetimeExecutor::eval_scalar` `Input` / `InputOrElse` arms no longer error. They call the new
-  `eval_period_invariant_input(expr, name)`, which evaluates the SAME bare-input node under every
-  period's `DenseExecutor` (one column per period, positionally aligned) and checks PER ROW that the
-  value is identical across ALL supplied periods.
-  - All rows invariant → bind period 0's column (dtype preserved); the caller consumes it exactly like
-    any other column, so a value in scalar OR in the `n` position, reached directly OR through a derived
-    chain (Sub/Max/… compose row-wise), all work.
-  - Any row varies → new `EvalError::LifetimePeriodVaryingInput`, naming the input and the first two
-    differing period labels (`start..end`) and values. Truly period-varying inputs still fail loudly.
-- New free helpers in dense.rs: `first_differing_row` (exact per-row equality; numeric variants compared
-  by Decimal-promoted value so `1985` == `1985.0`; non-numeric mismatch or non-finite → treated as
-  differing = safe error), `period_label`, `dense_value_label`.
-- New `EvalError::LifetimePeriodVaryingInput` variant in engine.rs. `LifetimeAmbiguousLeaf` still used
-  for the genuinely period-specific leaves (PeriodStart/End, Date*, Count/SumRelated).
-- Parameters keep their existing last-supplied-period behavior; the amendment touches inputs only.
-
-### Tests
-- tests/lifetime.rs (+4, 28 total): (a) per-person-constant input binds outside a reduction;
-  (b) per-row-varying but per-period-constant input binds per row (rows 100 vs 500);
-  (c) period-VARYING input errors, message names the input; (d) the derived-n-from-constant-inputs
-  chain end to end (two workers, n = 36 and 31; earnings_total [3_456_000, 1_922_000]; aime [8000, 5166]).
-- python/tests/test_dense_lifetime.py (+2): two-worker derived-n case (mirrors the scratchpad script) and
-  a period-varying-input error case naming the input.
-
-### Acceptance-script arithmetic note (IMPORTANT — flagged for review)
-scratchpad/check_derived_n_lifetime.py as delivered expected `aime[1] = 5167` for worker B, with a
-comment `floor(5167.20)`. That is wrong: worker B has total 1_922_000, n = 31, so
-`aime = floor(1_922_000 / (12*31 = 372)) = floor(5166.666…) = 5166`. 5167 is the round-HALF-UP value,
-not the `floor` the module (and 42 USC 415(b)(2)(A) / 20 CFR 404.211(d), which round DOWN) use — and no
-integer months divisor can even produce 5167 for this total (floor jumps 5180 at d=371 to 5166 at d=372,
-skipping 5167). Independently re-derived. The engine is statutorily correct at 5166; the fixture's one
-expected constant was corrected 5167 → 5166 (worker A's 8000 is unaffected: floor and round agree there).
-The binding mechanism the script exercises — two workers with DIFFERENT derived n binding correctly — is
-proven by `earnings_total = [3_456_000, 1_922_000]`, which matches exactly.
-
-### Final gate (all GREEN, this amendment)
-- cargo fmt --check clean; cargo build; cargo test (default) 0 failed; cargo test --features schema
-  0 failed (schema golden-file guard passes — no artifact-schema change); cargo check python-ext;
-  cargo check wasm32-unknown-unknown --no-default-features.
-- clippy --all-targets: actual lint findings BYTE-IDENTICAL to the pre-amendment branch tip (37 finding
-  lines; 35 lib + 35 lib-test as before) — ZERO new warnings; none reference the new code.
-- 28 Rust lifetime tests + 38 Python tests pass against the maturin-rebuilt extension; the corrected
-  scratchpad acceptance script passes (earnings_total [3456000, 1922000], aime [8000, 5166]).
-
-## Review response — six fixes (this session, PR #68 review)
-
-Six confirmed review findings addressed; semantics decided by the feature-brief
-author. Referential transparency, ordering validation, and count-nonzero were
-already implemented from the prior session; this session completed the strict n
-contract, the exhaustive reduction parse, and the DECISIONS.md entry, corrected
-the stale comments, and pinned every case as a test.
-
-1. **Referential transparency (dense.rs).** A derived referenced OUTSIDE a
-   reduction is evaluated by inlining its body in the lifetime context (the
-   `Derived` arm recurses through the lifetime executor): parameters resolve at
-   the reference period, and a bare input inside that body goes through the
-   per-row period-invariance guard. A parameter-bearing derived reused both
-   inside a reduction and bare outside it therefore denotes exactly its
-   definition in both positions. The review's 600-case
-   (`sum_over_periods(credit) + credit`, `credit = rate + earnings`, `earnings`
-   period-varying) now errors loudly via `LifetimePeriodVaryingInput` naming
-   `earnings`, instead of silently returning 600. Test:
-   `derived_reused_inside_and_outside_reduction_errors_on_period_varying_input`.
-
-2. **Strictly-ascending periods (dense.rs + engine.rs).** `execute_lifetime[_f64]`
-   validate that supplied periods strictly ascend by start date and error with
-   `LifetimePeriodsNotAscending` (naming the offending adjacent pair) rather than
-   silently resolving parameters / n at a positionally-last-but-chronologically-
-   earlier year. Reference period = the (now guaranteed chronologically-last)
-   final period. Tests: `errors_when_periods_are_not_strictly_ascending`
-   (Rust), `test_descending_periods_raise` (Python).
-
-3. **count_over_periods counts nonzero (dense.rs + model.rs).** `count_over_periods`
-   now evaluates its argument per period and counts, per row, the periods whose
-   value is nonzero (`Bool` counts `true`; text/date rejected). It is no longer a
-   bare supplied-period count. The stale "evaluated but ignored" doc on
-   `OverPeriodsKind::Count` (model.rs) was corrected. Tests:
-   `count_over_periods_counts_nonzero_periods_per_row`,
-   `count_over_periods_all_zero_is_zero` (Rust), and a Python analogue.
-
-4. **Strict n contract for sum_top_n (dense.rs + engine.rs + model.rs).**
-   `DenseNum::try_to_i64_trunc(self) -> Option<i64>` replaces the saturating
-   `to_i64_trunc` in both dtype impls. `eval_top_n_counts` now: evaluates n under
-   EVERY period's executor and rejects a period-VARYING n (parameter- and
-   input-sourced held to the identical contract) with
-   `OverPeriodsTopNPeriodVarying`; truncates the reference column toward zero to
-   an exact i64 (a non-finite / out-of-range value -> `None` -> hard error); and
-   enforces `1 <= n <= period_count`, erroring `OverPeriodsTopNOutOfRange` on
-   under- and over-length n. No clamp to i64::MAX, no silent reference-period
-   pin, no zero-pad past the period count. Tests:
-   `sum_top_n_n_exceeds_period_count_errors_in_decimal_path`,
-   `...in_f64_path`, `sum_top_n_period_varying_parameter_n_errors`, updated
-   `errors_when_sum_top_n_n_is_less_than_one` and the former zero-pad test
-   (now `sum_top_n_errors_when_n_exceeds_the_period_count`); Python analogues.
-
-5. **Exhaustive reduction parse (formula.rs).** The one-argument over-periods
-   arm chooses its kind by an exhaustive match with an explicit error arm (no
-   wildcard falling through to `Count`), and any other `*_over_periods` name is
-   rejected with a reduction-specific parse error rather than the generic
-   "unknown function". Tests: `unknown_over_periods_reduction_fails_to_parse`
-   (Rust + Python).
-
-6. **DECISIONS.md.** One new most-recent-first entry (2026-07-05) covering the
-   lifetime execution surface: the `OverPeriods` node + four builtins, reference
-   period = chronologically-last supplied period, strictly-ascending validation,
-   period-invariant input binding + inlined-body derived semantics,
-   count-nonzero, and the strict n contract.
-
-### Final gate (all GREEN, this session)
-- `cargo fmt` applied; `cargo fmt --check` clean; `cargo build`; `cargo test`
-  (default) 0 failed; `cargo test --features schema` 0 failed;
-  `cargo check --manifest-path python-ext/Cargo.toml`;
-  `cargo check --target wasm32-unknown-unknown --no-default-features`.
-- clippy: `--lib` and `--all-targets` finding multisets BYTE-IDENTICAL to branch
-  tip 984a4e0 (per-file counts diff empty) — ZERO new warnings; python-ext clippy
-  identical to baseline (2 pre-existing).
-- 35 Rust lifetime tests + 42 Python tests pass against the maturin-rebuilt
-  (`--release`) extension; the acceptance script
-  `scratchpad/check_derived_n_lifetime.py` prints
-  `earnings_total [3456000. 1922000.]`, `aime [8000. 5166.]` and all assertions pass.
+1. Add failing tests for default warnings, strict compile errors, legacy labels,
+   and the five closure-kind cases; then implement Amendment A.
+2. Add failing tests for usage-derived orientation and binding behavior; then
+   implement Amendment B.
+3. Run the five-corpus sweep, report the orientation census and every
+   inconsistent relation, and reproduce the amended 26/32 transcript.
+4. Run all repository gates, request an independent review, fix actionable
+   findings, and write the completed report to `out.md`.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -79,6 +79,12 @@ passes. Work is moving to final repository gates and independent review.
   `[Person, TaxUnit]` relation and `[Payment, Payment]` for the inner
   `[Payment, Person]` relation. Treating nested aggregate internals as a
   separate execution context makes both executable tuple orders warning-free.
+- Focused re-review found that an untyped outer relation still suppressed the
+  nested scalar traversal. A second red regression observed no executable-use
+  diagnostic for reversed inner declaration `[Person, Payment]`. Relation
+  traversal now carries an optional current kind, retaining the independently
+  derived inner `[Payment, Person]` orientation; compile warns on the reversed
+  declaration and binding leaves the working tuple warning-free.
 
 ## Next
 

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -70,9 +70,17 @@ passes. Work is moving to final repository gates and independent review.
   - the executable-order tuple returns count 1 with no bind warning;
   - the declaration-order tuple returns count 0 with two bind warnings, one
     for each reversed slot.
+- Independent evidence review reproduced the corpus counts, census, worklist,
+  and 26/32 transcript without a gate-blocking finding.
+- Independent code review found that a nested aggregate's predicate/value
+  entity could contaminate its enclosing relation's orientation.
+- Added a nested `sum_related` regression covering both compile and bind
+  diagnostics. Red evidence derived `[Payment, TaxUnit]` for the outer
+  `[Person, TaxUnit]` relation and `[Payment, Payment]` for the inner
+  `[Payment, Person]` relation. Treating nested aggregate internals as a
+  separate execution context makes both executable tuple orders warning-free.
 
 ## Next
 
-1. Run all repository gates and request an independent review.
-2. Fix any actionable findings, finalize this progress log, and write the
-   completed report to `out.md`.
+1. Re-run all repository gates after the review fix.
+2. Finalize this progress log and write the completed report to `out.md`.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -5,9 +5,8 @@ without rewriting them. Network access is prohibited.
 
 ## State
 
-Amendment work has started from `b30ea2a`. The prior report in `out.md` has
-been read, and the checkout is clean apart from that intentionally untracked
-report. The branch is four commits ahead of local `origin/main`.
+Amendment A is implemented and focused tests are green. Work is moving to the
+usage-derived orientation tests and implementation.
 
 ## Done
 
@@ -17,14 +16,27 @@ report. The branch is four commits ahead of local `origin/main`.
   - declaration-based binding diagnostics point consumers toward the
     zero-producing order for `us:statutes/26/32`.
 - Confirmed the active branch and preserved all four existing commits.
+- Added `CompileOptions::strict_relation_entities`.
+- Ratcheted relation argument validation:
+  - arity mismatch remains a hard error in every mode;
+  - shape-invalid labels warn by default, leave `slot_entities` empty, and
+    error in strict mode;
+  - well-shaped closure-unknown kinds warn by default, remain verbatim in the
+    artifact, and error in strict mode.
+- Deleted the `member_of_individuals_household` content-specific alias.
+- Routed RuleSpec diagnostics into artifact compile diagnostics without
+  serializing them, preserving canonical module paths.
+- Documented compile and binding strictness separately.
+- Red evidence: the focused test build failed because
+  `CompileOptions::strict_relation_entities` did not exist.
+- Green evidence: 82 RuleSpec tests, 12 module-source tests, and five
+  namespace-ratchet unit tests pass.
 
 ## Next
 
-1. Add failing tests for default warnings, strict compile errors, legacy labels,
-   and the five closure-kind cases; then implement Amendment A.
-2. Add failing tests for usage-derived orientation and binding behavior; then
+1. Add failing tests for usage-derived orientation and binding behavior; then
    implement Amendment B.
-3. Run the five-corpus sweep, report the orientation census and every
+2. Run the five-corpus sweep, report the orientation census and every
    inconsistent relation, and reproduce the amended 26/32 transcript.
-4. Run all repository gates, request an independent review, fix actionable
+3. Run all repository gates, request an independent review, fix actionable
    findings, and write the completed report to `out.md`.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -5,8 +5,9 @@ without rewriting them. Network access is prohibited.
 
 ## State
 
-Amendment A is implemented and focused tests are green. Work is moving to the
-usage-derived orientation tests and implementation.
+Amendments A and B are implemented. The full default-feature `cargo test`
+suite is green. Work is moving to the staged-corpus sweep and 26/32 dynamic
+acceptance transcript.
 
 ## Done
 
@@ -31,12 +32,27 @@ usage-derived orientation tests and implementation.
   `CompileOptions::strict_relation_entities` did not exist.
 - Green evidence: 82 RuleSpec tests, 12 module-source tests, and five
   namespace-ratchet unit tests pass.
+- Added deterministic program-level relation usage analysis shared by compile
+  validation and dataset binding:
+  - aggregate owner entity constrains `current_slot`;
+  - predicate/value entity constrains `related_slot`;
+  - membership and derived-relation source uses propagate structural kinds;
+  - versioned rules inspect executable versions rather than phantom base
+    semantics;
+  - conflicting uses leave a slot unresolved instead of choosing arbitrarily.
+- Added `warning[relation_orientation_mismatch]`, strict compile promotion,
+  artifact reload recomputation, and source-fidelity preservation.
+- Binding now uses executable orientation for used relations and declaration
+  order only for unused relations.
+- Red evidence: the 26/32-shaped fixture had no compile warning, warned on the
+  working tuple, and did not warn on the empty-lookup tuple; the membership
+  fixture also had no orientation warning.
+- Green evidence: all three orientation tests pass, including strict/reload
+  behavior and derived-relation membership. Full `cargo test` passes.
 
 ## Next
 
-1. Add failing tests for usage-derived orientation and binding behavior; then
-   implement Amendment B.
-2. Run the five-corpus sweep, report the orientation census and every
+1. Run the five-corpus sweep, report the orientation census and every
    inconsistent relation, and reproduce the amended 26/32 transcript.
-3. Run all repository gates, request an independent review, fix actionable
+2. Run all repository gates, request an independent review, fix actionable
    findings, and write the completed report to `out.md`.

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -5,9 +5,9 @@ without rewriting them. Network access is prohibited.
 
 ## State
 
-Amendments A and B are implemented. The full default-feature `cargo test`
-suite is green. Work is moving to the staged-corpus sweep and 26/32 dynamic
-acceptance transcript.
+Amendments A, B, and the Amendment C census are complete. The default corpus
+result is restored to 40/46, and the amended 26/32 dynamic acceptance check
+passes. Work is moving to final repository gates and independent review.
 
 ## Done
 
@@ -49,10 +49,30 @@ acceptance transcript.
   fixture also had no orientation warning.
 - Green evidence: all three orientation tests pass, including strict/reload
   behavior and derived-relation membership. Full `cargo test` passes.
+- Re-ran the staged default-mode corpus sweep:
+  - 40/46 modules compile, with the same six pre-existing failures as the
+    baseline;
+  - successful compiles emit 39 warnings across 26 invocations: 32
+    `relation_orientation_mismatch`, five
+    `unknown_relation_argument_entity`, one
+    `invalid_relation_argument_entity_shape`, and one pre-existing
+    `non_exhaustive_match`;
+  - the five closure-authority gaps compile successfully by default.
+- Completed the orientation census:
+  - the required 42-relation US cohort has 19 usage-consistent, 22
+    usage-inconsistent, and one unused declaration;
+  - the literal five-root total includes eight additional UK declarations and
+    is 21 consistent, 28 inconsistent, and one unused across 50 declarations;
+  - NZ, BE, and GH contain no declared-argument relations.
+- Re-ran the amended 26/32 dynamic fixture:
+  - compilation preserves declared slots `[TaxUnit, Person]` and emits the
+    orientation warning for executable order `[Person, TaxUnit]`;
+  - the executable-order tuple returns count 1 with no bind warning;
+  - the declaration-order tuple returns count 0 with two bind warnings, one
+    for each reversed slot.
 
 ## Next
 
-1. Run the five-corpus sweep, report the orientation census and every
-   inconsistent relation, and reproduce the amended 26/32 transcript.
-2. Run all repository gates, request an independent review, fix actionable
-   findings, and write the completed report to `out.md`.
+1. Run all repository gates and request an independent review.
+2. Fix any actionable findings, finalize this progress log, and write the
+   completed report to `out.md`.

--- a/docs/rulespec.md
+++ b/docs/rulespec.md
@@ -21,6 +21,7 @@ rules:
     kind: data_relation
     data_relation:
       arity: 2
+      arguments: [Person, Household]
   - name: medical_deduction
     kind: derived
     entity: Household
@@ -54,7 +55,11 @@ Supported rule kinds in the current Rust loader:
   every `values` table. Formulas reference them with `table_name[index_expr]`.
 - `derived`: entity-scoped scalar or judgment outputs.
 - `data_relation`: executable runtime predicate declarations with
-  `data_relation.arity`. Dataset relation records use durable ids such as
+  `data_relation.arity`. An optional `data_relation.arguments` list declares
+  one entity kind per tuple slot, in position order. Every declared kind must
+  occur in the import-merged program closure, and the list length must equal
+  the arity. Omitting the list leaves a legacy relation untyped. Dataset
+  relation records use durable ids such as
   `us:statutes/7/2012/j#relation.member_of_household`.
 - `derived_relation`: executable runtime predicates computed by filtering a
   source relation with a judgment formula. This supports filtered membership
@@ -95,7 +100,22 @@ rules:
     kind: data_relation
     data_relation:
       arity: 2
+      arguments: [Person, Household]
 ```
+
+Compiled artifacts carry declared argument kinds as
+`program.relations[].slot_entities`. During dataset binding, the engine derives
+an opaque entity id's kind from dataset input records that carry both
+`entity_id` and `entity`. A known mismatch emits
+`warning[relation_slot_entity_mismatch]` by default; ids absent from the input
+records, or ids used with more than one kind, remain unknown and are skipped.
+Rust callers can promote these warnings to errors with
+`DatasetSpec::to_dataset_for_program_with_options(program,
+DatasetBindingOptions::strict())`. The existing
+`DatasetSpec::to_dataset_for_program` entry point retains compatibility mode.
+This strict knob is intentionally on the program-aware binder; lower-level
+callers that construct a `DataSet` or `Engine` directly bypass wire-dataset
+validation.
 
 Derived relations are rule-defined views over data relations or other derived
 relations. The source relation supplies candidate tuples; the formula decides

--- a/docs/rulespec.md
+++ b/docs/rulespec.md
@@ -109,8 +109,14 @@ rules:
 ```
 
 Compiled artifacts carry declared argument kinds as
-`program.relations[].slot_entities`. Rust callers can promote relation argument
-shape/closure warnings to errors at compile time with:
+`program.relations[].slot_entities`. The compiler separately derives the
+orientation that executable `count_related`, `sum_related`, and membership
+nodes use. If that orientation disagrees with the declaration, compilation
+emits `warning[relation_orientation_mismatch]` naming both orders and a citing
+rule. The serialized declaration remains verbatim for source fidelity.
+
+Rust callers can promote relation argument shape/closure/orientation warnings
+to errors at compile time with:
 
 ```rust
 CompiledProgramArtifact::from_rulespec_str_with_options(
@@ -124,8 +130,12 @@ CompiledProgramArtifact::from_rulespec_str_with_options(
 
 This compile option is independent of binding strictness. During dataset
 binding, the engine derives an opaque entity id's kind from dataset input
-records that carry both `entity_id` and `entity`. A known mismatch emits
-`warning[relation_slot_entity_mismatch]` by default; ids absent from the input
+records that carry both `entity_id` and `entity`. For a relation used by the
+program, expected tuple positions come from executable usage; unresolved or
+conflicting positions are skipped. Only an unused relation falls back to its
+declared position order. This prevents validation from recommending an order
+that the engine indexes as an empty lookup. A known mismatch emits
+`warning[relation_slot_entity_mismatch]` by default; ids absent from input
 records, or ids used with more than one kind, remain unknown and are skipped.
 Rust callers can promote these warnings to errors with
 `DatasetSpec::to_dataset_for_program_with_options(program,

--- a/docs/rulespec.md
+++ b/docs/rulespec.md
@@ -56,10 +56,15 @@ Supported rule kinds in the current Rust loader:
 - `derived`: entity-scoped scalar or judgment outputs.
 - `data_relation`: executable runtime predicate declarations with
   `data_relation.arity`. An optional `data_relation.arguments` list declares
-  one entity kind per tuple slot, in position order. Every declared kind must
-  occur in the import-merged program closure, and the list length must equal
-  the arity. Omitting the list leaves a legacy relation untyped. Dataset
-  relation records use durable ids such as
+  one proposed entity kind per tuple slot, in source position order. The list
+  length must equal the arity; that mismatch is always a compile error.
+  Usable entity-kind labels are ASCII UpperCamelCase/alphanumeric. A
+  shape-failing declaration warns in compatibility mode and is treated as
+  undeclared (`slot_entities` remains empty). A well-shaped kind absent from
+  the import-merged program closure also warns, but remains carried verbatim
+  because published modules legitimately declare relation-only kinds.
+  Omitting the list leaves a legacy relation untyped. Dataset relation records
+  use durable ids such as
   `us:statutes/7/2012/j#relation.member_of_household`.
 - `derived_relation`: executable runtime predicates computed by filtering a
   source relation with a judgment formula. This supports filtered membership
@@ -104,9 +109,22 @@ rules:
 ```
 
 Compiled artifacts carry declared argument kinds as
-`program.relations[].slot_entities`. During dataset binding, the engine derives
-an opaque entity id's kind from dataset input records that carry both
-`entity_id` and `entity`. A known mismatch emits
+`program.relations[].slot_entities`. Rust callers can promote relation argument
+shape/closure warnings to errors at compile time with:
+
+```rust
+CompiledProgramArtifact::from_rulespec_str_with_options(
+    source,
+    CompileOptions {
+        strict_relation_entities: true,
+        ..CompileOptions::default()
+    },
+)
+```
+
+This compile option is independent of binding strictness. During dataset
+binding, the engine derives an opaque entity id's kind from dataset input
+records that carry both `entity_id` and `entity`. A known mismatch emits
 `warning[relation_slot_entity_mismatch]` by default; ids absent from the input
 records, or ids used with more than one kind, remain unknown and are skipped.
 Rust callers can promote these warnings to errors with

--- a/schemas/compiled-artifact.v2.schema.json
+++ b/schemas/compiled-artifact.v2.schema.json
@@ -967,6 +967,12 @@
         },
         "name": {
           "type": "string"
+        },
+        "slot_entities": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
         }
       },
       "required": [

--- a/schemas/rulespec-module.v1.schema.json
+++ b/schemas/rulespec-module.v1.schema.json
@@ -188,6 +188,34 @@
           "data_relation": {
             "additionalProperties": true,
             "properties": {
+              "arguments": {
+                "items": {
+                  "oneOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "additionalProperties": true,
+                      "properties": {
+                        "entity": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string"
+                        }
+                      },
+                      "required": [
+                        "entity"
+                      ],
+                      "type": "object"
+                    }
+                  ]
+                },
+                "type": [
+                  "array",
+                  "null"
+                ]
+              },
               "arity": {
                 "minimum": 0,
                 "type": "integer"

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -240,8 +240,17 @@ impl CompiledProgramArtifact {
         // re-check the same invariant via `to_program`.
         program.validate_rounding()?;
         program.validate_effective_ranges()?;
-        let diagnostics = normalize_parameter_duplicates(&mut program, path, options)?;
+        let mut diagnostics = normalize_parameter_duplicates(&mut program, path, options)?;
         let metadata = compiled_metadata(&program)?;
+        let orientation_diagnostics = relation_orientation_diagnostics(&program, path)?;
+        if options.strict_relation_entities && !orientation_diagnostics.is_empty() {
+            return Err(CompileError::StrictRelationEntityDiagnostics(
+                CompileDiagnosticReport {
+                    diagnostics: orientation_diagnostics,
+                },
+            ));
+        }
+        diagnostics.extend(orientation_diagnostics);
         Ok(Self {
             artifact_format_version: ARTIFACT_FORMAT_VERSION,
             engine_version: Some(env!("CARGO_PKG_VERSION").to_string()),
@@ -276,6 +285,15 @@ impl CompiledProgramArtifact {
                 "metadata does not match the compiled program",
             ));
         }
+        let orientation_diagnostics = relation_orientation_diagnostics(&self.program, path)?;
+        if options.strict_relation_entities && !orientation_diagnostics.is_empty() {
+            return Err(CompileError::StrictRelationEntityDiagnostics(
+                CompileDiagnosticReport {
+                    diagnostics: orientation_diagnostics,
+                },
+            ));
+        }
+        self.diagnostics.extend(orientation_diagnostics);
         Ok(self)
     }
 
@@ -496,6 +514,65 @@ impl CompiledProgramArtifact {
 }
 
 const DUPLICATE_PARAMETER_DIAGNOSTIC: &str = "duplicate_parameter_name";
+const RELATION_ORIENTATION_DIAGNOSTIC: &str = "relation_orientation_mismatch";
+
+fn relation_orientation_diagnostics(
+    program: &ProgramSpec,
+    path: &str,
+) -> Result<Vec<CompileDiagnostic>, CompileError> {
+    let runtime_program = program.to_program()?;
+    let usages = crate::model::relation_usage_records(&runtime_program);
+    let mut relations = program
+        .relations
+        .iter()
+        .filter(|relation| relation.derivation.is_none() && !relation.slot_entities.is_empty())
+        .collect::<Vec<_>>();
+    relations.sort_by(|left, right| left.name.cmp(&right.name));
+
+    let mut diagnostics = Vec::new();
+    for relation in relations {
+        let Some(usage) = usages.iter().find(|usage| {
+            usage.relation == relation.name
+                && usage
+                    .slot_entities
+                    .iter()
+                    .zip(&relation.slot_entities)
+                    .any(|(used, declared)| used.as_ref().is_some_and(|used| used != declared))
+        }) else {
+            continue;
+        };
+        diagnostics.push(CompileDiagnostic {
+            code: RELATION_ORIENTATION_DIAGNOSTIC,
+            path: relation
+                .name
+                .split_once("#relation.")
+                .map_or_else(|| path.to_string(), |(target, _)| target.to_string()),
+            message: format!(
+                "data relation `{}` declares slot entity order {}, but executable usage derives order {} (citing rule `{}`); the declaration remains verbatim, and strict relation entity mode treats this warning as an error",
+                relation.name,
+                format_declared_slot_entities(&relation.slot_entities),
+                format_usage_slot_entities(&usage.slot_entities),
+                usage.citing_rule,
+            ),
+        });
+    }
+    Ok(diagnostics)
+}
+
+fn format_declared_slot_entities(entities: &[String]) -> String {
+    format!("[{}]", entities.join(", "))
+}
+
+fn format_usage_slot_entities(entities: &[Option<String>]) -> String {
+    format!(
+        "[{}]",
+        entities
+            .iter()
+            .map(|entity| entity.as_deref().unwrap_or("?"))
+            .collect::<Vec<_>>()
+            .join(", ")
+    )
+}
 
 fn normalize_parameter_duplicates(
     program: &mut ProgramSpec,

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -70,6 +70,8 @@ pub enum CompileError {
         "ambiguous RuleSpec module YAML `{path}` has a top-level `rules:` key but no exact RuleSpec discriminator (`format: rulespec/v1`)"
     )]
     AmbiguousRuleSpecYaml { path: String },
+    #[error("strict relation entity validation failed:\n{0}")]
+    StrictRelationEntityDiagnostics(CompileDiagnosticReport),
     #[error(
         "compiled artefact `{path}` has artifact_format_version {found}, but this engine requires exact version {supported}; recompile the program with this engine"
     )]
@@ -102,6 +104,9 @@ pub struct CompileOptions {
     /// This is deliberately narrower than issue #83's future
     /// `--strict-resolution`, which also needs declared-input provenance.
     pub strict_namespaces: bool,
+    /// Escalate relation argument name/shape and executable-orientation
+    /// diagnostics to compile errors. Arity is structural in every mode.
+    pub strict_relation_entities: bool,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -109,6 +114,23 @@ pub struct CompileDiagnostic {
     pub code: &'static str,
     pub path: String,
     pub message: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CompileDiagnosticReport {
+    pub diagnostics: Vec<CompileDiagnostic>,
+}
+
+impl std::fmt::Display for CompileDiagnosticReport {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        for (index, diagnostic) in self.diagnostics.iter().enumerate() {
+            if index > 0 {
+                formatter.write_str("\n")?;
+            }
+            write!(formatter, "{diagnostic}")?;
+        }
+        Ok(())
+    }
 }
 
 impl std::fmt::Display for CompileDiagnostic {
@@ -167,6 +189,44 @@ impl CompiledProgramArtifact {
         options: CompileOptions,
     ) -> Result<Self, CompileError> {
         Self::compile_at(program, "<program>", options)
+    }
+
+    fn compile_rulespec_outcome(
+        outcome: crate::rulespec::RuleSpecLoweringOutcome,
+        path: &str,
+        options: CompileOptions,
+    ) -> Result<Self, CompileError> {
+        let rulespec_diagnostics = outcome
+            .diagnostics
+            .into_iter()
+            .map(|diagnostic| CompileDiagnostic {
+                code: diagnostic.code.as_str(),
+                path: diagnostic.path,
+                message: diagnostic.message,
+            })
+            .collect::<Vec<_>>();
+        if options.strict_relation_entities {
+            let diagnostics = rulespec_diagnostics
+                .iter()
+                .filter(|diagnostic| {
+                    matches!(
+                        diagnostic.code,
+                        "invalid_relation_argument_entity_shape"
+                            | "unknown_relation_argument_entity"
+                    )
+                })
+                .cloned()
+                .collect::<Vec<_>>();
+            if !diagnostics.is_empty() {
+                return Err(CompileError::StrictRelationEntityDiagnostics(
+                    CompileDiagnosticReport { diagnostics },
+                ));
+            }
+        }
+
+        let mut artifact = Self::compile_at(outcome.program, path, options)?;
+        artifact.diagnostics.splice(0..0, rulespec_diagnostics);
+        Ok(artifact)
     }
 
     fn compile_at(
@@ -228,13 +288,15 @@ impl CompiledProgramArtifact {
         options: CompileOptions,
     ) -> Result<Self, CompileError> {
         if crate::rulespec::looks_like_rulespec_yaml(source) {
-            let program = crate::rulespec::lower_rulespec_str(source).map_err(|error| {
-                CompileError::RuleSpec {
-                    path: "<memory>".to_string(),
-                    error,
-                }
+            let outcome = crate::rulespec::lower_rulespec_str_with_options(
+                source,
+                crate::rulespec::RuleSpecLoweringOptions::default(),
+            )
+            .map_err(|error| CompileError::RuleSpec {
+                path: "<memory>".to_string(),
+                error,
             })?;
-            return Self::compile_at(program, "<memory>", options);
+            return Self::compile_rulespec_outcome(outcome, "<memory>", options);
         }
         if crate::rulespec::has_top_level_rules_key(source) {
             return Err(CompileError::AmbiguousRuleSpecYaml {
@@ -263,14 +325,16 @@ impl CompiledProgramArtifact {
         source: &dyn crate::source::ModuleSource,
         options: CompileOptions,
     ) -> Result<Self, CompileError> {
-        let program =
-            crate::rulespec::load_rulespec_with_source(root_target, source).map_err(|error| {
-                CompileError::RuleSpec {
-                    path: root_target.to_string(),
-                    error,
-                }
-            })?;
-        Self::compile_at(program, root_target, options)
+        let outcome = crate::rulespec::load_rulespec_with_source_with_options(
+            root_target,
+            source,
+            crate::rulespec::RuleSpecLoweringOptions::default(),
+        )
+        .map_err(|error| CompileError::RuleSpec {
+            path: root_target.to_string(),
+            error,
+        })?;
+        Self::compile_rulespec_outcome(outcome, root_target, options)
     }
 
     #[cfg(feature = "fs")]
@@ -288,13 +352,16 @@ impl CompiledProgramArtifact {
         options: CompileOptions,
     ) -> Result<Self, CompileError> {
         let p = path.as_ref();
-        let program = crate::rulespec::load_rulespec_file(p, roots).map_err(|error| {
-            CompileError::RuleSpec {
-                path: p.display().to_string(),
-                error,
-            }
+        let outcome = crate::rulespec::load_rulespec_file_with_options(
+            p,
+            roots,
+            crate::rulespec::RuleSpecLoweringOptions::default(),
+        )
+        .map_err(|error| CompileError::RuleSpec {
+            path: p.display().to_string(),
+            error,
         })?;
-        Self::compile_at(program, &p.display().to_string(), options)
+        Self::compile_rulespec_outcome(outcome, &p.display().to_string(), options)
     }
 
     /// Compile an originless RuleSpec composition emitted by `axiom-compose`.
@@ -315,13 +382,16 @@ impl CompiledProgramArtifact {
         options: CompileOptions,
     ) -> Result<Self, CompileError> {
         let p = path.as_ref();
-        let program = crate::rulespec::load_composed_rulespec_file(p, roots).map_err(|error| {
-            CompileError::RuleSpec {
-                path: p.display().to_string(),
-                error,
-            }
+        let outcome = crate::rulespec::load_composed_rulespec_file_with_options(
+            p,
+            roots,
+            crate::rulespec::RuleSpecLoweringOptions::default(),
+        )
+        .map_err(|error| CompileError::RuleSpec {
+            path: p.display().to_string(),
+            error,
         })?;
-        Self::compile_at(program, &p.display().to_string(), options)
+        Self::compile_rulespec_outcome(outcome, &p.display().to_string(), options)
     }
 
     pub fn from_json_str(source: &str) -> Result<Self, CompileError> {
@@ -1534,6 +1604,7 @@ rules:
             duplicate_parameters(4, 4),
             CompileOptions {
                 strict_namespaces: true,
+                ..CompileOptions::default()
             },
         )
         .expect_err("strict namespace mode rejects compatible duplicate declarations");
@@ -1584,6 +1655,7 @@ rules:
             &source,
             CompileOptions {
                 strict_namespaces: true,
+                ..CompileOptions::default()
             },
         )
         .expect_err("strict artifact loading rejects the duplicate");
@@ -1614,6 +1686,7 @@ rules:
             &source,
             CompileOptions {
                 strict_namespaces: true,
+                ..CompileOptions::default()
             },
         )
         .expect_err("strict namespace mode rejects the imported duplicate");

--- a/src/formula.rs
+++ b/src/formula.rs
@@ -1302,19 +1302,15 @@ pub fn lower_module(module: &Module) -> Result<ProgramSpec, FormulaError> {
     Ok(program)
 }
 
-/// Slot convention for two-slot relations referenced from aggregations.
-/// Names of the form `X_of_Y` (or `X_of_a_Y` …) read as "X belongs to Y",
-/// so slot 0 = X (related item being iterated) and slot 1 = Y (the
-/// enclosing / current entity). Any other naming is assumed to put the
-/// enclosing entity at slot 0 and the related item at slot 1.
+/// Legacy slot convention for two-slot relations referenced from aggregations.
+///
+/// Formula lowering has no entity-kind context, so it cannot infer direction
+/// from a relation's declared argument entities here. RuleSpec later carries
+/// those declarations into the relation schema, but changing this convention
+/// would also require a compatibility strategy for existing dataset tuples.
 fn infer_slots(_relation: &str) -> (usize, usize) {
-    // Default slot convention: current entity is slot 1, related item is
-    // slot 0. Matches how every existing YAML RuleSpec module declares its
-    // relations (adult_of_benefit_unit, child_of_claim, cb_receipt,
-    // liable_person, associate_of, council_notice_of_tenancy, …). A
-    // RuleSpec module that needs the opposite orientation should rename the
-    // relation to put the enclosing entity last (e.g.
-    // `disposal_of_applicant` rather than `applicant_disposal`).
+    // Preserve the established runtime convention: current entity in slot 1,
+    // related entity in slot 0.
     (1, 0)
 }
 

--- a/src/formula.rs
+++ b/src/formula.rs
@@ -1294,6 +1294,7 @@ pub fn lower_module(module: &Module) -> Result<ProgramSpec, FormulaError> {
         program.relations.push(RelationSpec {
             name,
             arity: 2,
+            slot_entities: Vec::new(),
             derivation: None,
         });
     }

--- a/src/model.rs
+++ b/src/model.rs
@@ -704,6 +704,571 @@ impl Program {
     }
 }
 
+/// One executable use of a relation, expressed as entity-kind constraints on
+/// tuple positions. Unknown positions remain `None`; the declaration is used
+/// only as an unordered kind multiset to complete a single missing binary
+/// position, never as positional authority.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct RelationUsage {
+    pub relation: String,
+    pub slot_entities: Vec<Option<String>>,
+    pub citing_rule: String,
+}
+
+/// Consensus executable orientation for a used relation. A position stays
+/// unknown when uses do not constrain it or when different uses conflict.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct RelationUsageOrientation {
+    pub slot_entities: Vec<Option<String>>,
+}
+
+pub(crate) fn relation_usage_records(program: &Program) -> Vec<RelationUsage> {
+    let mut usages = Vec::new();
+    let mut derived_names = program.derived.keys().cloned().collect::<Vec<_>>();
+    derived_names.sort();
+
+    for name in derived_names {
+        let derived = &program.derived[&name];
+        let citing_rule = derived.id.as_deref().unwrap_or(&derived.name);
+        if derived.versions.is_empty() {
+            collect_semantics_relation_usages(
+                program,
+                &derived.semantics,
+                &derived.entity,
+                citing_rule,
+                &mut usages,
+            );
+        } else {
+            // Runtime version selection ignores the base semantics whenever
+            // explicit versions exist; orientation validation must do likewise.
+            for version in &derived.versions {
+                collect_semantics_relation_usages(
+                    program,
+                    &version.semantics,
+                    &derived.entity,
+                    citing_rule,
+                    &mut usages,
+                );
+            }
+        }
+    }
+
+    // A derived relation executes its source relation and may test membership
+    // in another relation inside its predicate. Its declared structural slot
+    // kinds describe the two runtime IDs in that predicate context.
+    let mut relation_names = program.relations.keys().cloned().collect::<Vec<_>>();
+    relation_names.sort();
+    for relation_name in relation_names {
+        let schema = &program.relations[&relation_name];
+        let Some(derivation) = schema.derivation.as_ref() else {
+            continue;
+        };
+        let current_kind = derivation
+            .slot_entities
+            .get(derivation.current_slot)
+            .cloned();
+        let related_kind = derivation
+            .slot_entities
+            .get(derivation.related_slot)
+            .cloned();
+        let mut stack = Vec::new();
+        add_relation_usage(
+            program,
+            &derivation.source_relation,
+            derivation.current_slot,
+            derivation.related_slot,
+            current_kind.clone(),
+            related_kind.clone(),
+            &relation_name,
+            &mut usages,
+            &mut stack,
+        );
+        collect_judgment_relation_usages(
+            program,
+            &derivation.predicate,
+            related_kind.as_deref(),
+            Some((current_kind.as_deref(), related_kind.as_deref())),
+            &relation_name,
+            &mut usages,
+        );
+    }
+
+    usages.sort_by(|left, right| {
+        left.relation
+            .cmp(&right.relation)
+            .then_with(|| left.citing_rule.cmp(&right.citing_rule))
+            .then_with(|| left.slot_entities.cmp(&right.slot_entities))
+    });
+    usages.dedup();
+    usages
+}
+
+pub(crate) fn relation_usage_orientations(
+    program: &Program,
+) -> BTreeMap<String, RelationUsageOrientation> {
+    let mut candidates = BTreeMap::<String, Vec<BTreeSet<String>>>::new();
+    for usage in relation_usage_records(program) {
+        let slots = candidates
+            .entry(usage.relation)
+            .or_insert_with(|| vec![BTreeSet::new(); usage.slot_entities.len()]);
+        if slots.len() < usage.slot_entities.len() {
+            slots.resize_with(usage.slot_entities.len(), BTreeSet::new);
+        }
+        for (slot, entity) in usage.slot_entities.into_iter().enumerate() {
+            if let Some(entity) = entity {
+                slots[slot].insert(entity);
+            }
+        }
+    }
+
+    candidates
+        .into_iter()
+        .map(|(relation, slots)| {
+            let slot_entities = slots
+                .into_iter()
+                .map(|entities| {
+                    (entities.len() == 1)
+                        .then(|| entities.into_iter().next())
+                        .flatten()
+                })
+                .collect();
+            (relation, RelationUsageOrientation { slot_entities })
+        })
+        .collect()
+}
+
+fn collect_semantics_relation_usages(
+    program: &Program,
+    semantics: &DerivedSemantics,
+    entity: &str,
+    citing_rule: &str,
+    usages: &mut Vec<RelationUsage>,
+) {
+    match semantics {
+        DerivedSemantics::Scalar(expr) => {
+            collect_scalar_relation_usages(program, expr, entity, citing_rule, usages);
+        }
+        DerivedSemantics::Judgment(expr) => {
+            collect_judgment_relation_usages(
+                program,
+                expr,
+                Some(entity),
+                None,
+                citing_rule,
+                usages,
+            );
+        }
+    }
+}
+
+fn collect_scalar_relation_usages(
+    program: &Program,
+    expr: &ScalarExpr,
+    entity: &str,
+    citing_rule: &str,
+    usages: &mut Vec<RelationUsage>,
+) {
+    match expr {
+        ScalarExpr::Literal(_)
+        | ScalarExpr::Input(_)
+        | ScalarExpr::InputOrElse { .. }
+        | ScalarExpr::Derived(_)
+        | ScalarExpr::PeriodStart
+        | ScalarExpr::PeriodEnd => {}
+        ScalarExpr::ParameterLookup { index, .. }
+        | ScalarExpr::Ceil(index)
+        | ScalarExpr::Floor(index) => {
+            collect_scalar_relation_usages(program, index, entity, citing_rule, usages);
+        }
+        ScalarExpr::Add(items) | ScalarExpr::Max(items) | ScalarExpr::Min(items) => {
+            for item in items {
+                collect_scalar_relation_usages(program, item, entity, citing_rule, usages);
+            }
+        }
+        ScalarExpr::Sub(left, right)
+        | ScalarExpr::Mul(left, right)
+        | ScalarExpr::Div(left, right) => {
+            collect_scalar_relation_usages(program, left, entity, citing_rule, usages);
+            collect_scalar_relation_usages(program, right, entity, citing_rule, usages);
+        }
+        ScalarExpr::DateAddDays { date, days } => {
+            collect_scalar_relation_usages(program, date, entity, citing_rule, usages);
+            collect_scalar_relation_usages(program, days, entity, citing_rule, usages);
+        }
+        ScalarExpr::DaysBetween { from, to } => {
+            collect_scalar_relation_usages(program, from, entity, citing_rule, usages);
+            collect_scalar_relation_usages(program, to, entity, citing_rule, usages);
+        }
+        ScalarExpr::CountRelated {
+            relation,
+            current_slot,
+            related_slot,
+            where_clause,
+        } => {
+            let current_kind = executable_current_kind(program, relation, *current_slot, entity);
+            let related_kind = related_entity_kind(program, None, where_clause.as_deref());
+            let mut stack = Vec::new();
+            let slots = add_relation_usage(
+                program,
+                relation,
+                *current_slot,
+                *related_slot,
+                current_kind,
+                related_kind,
+                citing_rule,
+                usages,
+                &mut stack,
+            );
+            if let Some(where_clause) = where_clause {
+                collect_judgment_relation_usages(
+                    program,
+                    where_clause,
+                    slots.get(*related_slot).and_then(|kind| kind.as_deref()),
+                    None,
+                    citing_rule,
+                    usages,
+                );
+            }
+        }
+        ScalarExpr::SumRelated {
+            relation,
+            current_slot,
+            related_slot,
+            value,
+            where_clause,
+        } => {
+            let current_kind = executable_current_kind(program, relation, *current_slot, entity);
+            let related_kind = related_entity_kind(program, Some(value), where_clause.as_deref());
+            let mut stack = Vec::new();
+            let slots = add_relation_usage(
+                program,
+                relation,
+                *current_slot,
+                *related_slot,
+                current_kind,
+                related_kind,
+                citing_rule,
+                usages,
+                &mut stack,
+            );
+            if let Some(where_clause) = where_clause {
+                collect_judgment_relation_usages(
+                    program,
+                    where_clause,
+                    slots.get(*related_slot).and_then(|kind| kind.as_deref()),
+                    None,
+                    citing_rule,
+                    usages,
+                );
+            }
+        }
+        ScalarExpr::If {
+            condition,
+            then_expr,
+            else_expr,
+        } => {
+            collect_judgment_relation_usages(
+                program,
+                condition,
+                Some(entity),
+                None,
+                citing_rule,
+                usages,
+            );
+            collect_scalar_relation_usages(program, then_expr, entity, citing_rule, usages);
+            collect_scalar_relation_usages(program, else_expr, entity, citing_rule, usages);
+        }
+        ScalarExpr::OverPeriods { value, n, .. } => {
+            collect_scalar_relation_usages(program, value, entity, citing_rule, usages);
+            if let Some(n) = n {
+                collect_scalar_relation_usages(program, n, entity, citing_rule, usages);
+            }
+        }
+    }
+}
+
+fn collect_judgment_relation_usages(
+    program: &Program,
+    expr: &JudgmentExpr,
+    entity: Option<&str>,
+    relation_context: Option<(Option<&str>, Option<&str>)>,
+    citing_rule: &str,
+    usages: &mut Vec<RelationUsage>,
+) {
+    match expr {
+        JudgmentExpr::Comparison { left, right, .. } => {
+            if let Some(entity) = entity {
+                collect_scalar_relation_usages(program, left, entity, citing_rule, usages);
+                collect_scalar_relation_usages(program, right, entity, citing_rule, usages);
+            }
+        }
+        JudgmentExpr::Derived(_) => {}
+        JudgmentExpr::RelationMember {
+            relation,
+            current_slot,
+            related_slot,
+        } => {
+            let (current_kind, related_kind) = relation_context.unwrap_or((entity, None));
+            let mut stack = Vec::new();
+            add_relation_usage(
+                program,
+                relation,
+                *current_slot,
+                *related_slot,
+                current_kind.map(str::to_string),
+                related_kind.map(str::to_string),
+                citing_rule,
+                usages,
+                &mut stack,
+            );
+        }
+        JudgmentExpr::And(items) | JudgmentExpr::Or(items) => {
+            for item in items {
+                collect_judgment_relation_usages(
+                    program,
+                    item,
+                    entity,
+                    relation_context,
+                    citing_rule,
+                    usages,
+                );
+            }
+        }
+        JudgmentExpr::Not(item) => {
+            collect_judgment_relation_usages(
+                program,
+                item,
+                entity,
+                relation_context,
+                citing_rule,
+                usages,
+            );
+        }
+    }
+}
+
+fn executable_current_kind(
+    program: &Program,
+    relation: &str,
+    current_slot: usize,
+    owner_entity: &str,
+) -> Option<String> {
+    let schema = program.relations.get(relation)?;
+    if let Some(derivation) = schema.derivation.as_ref()
+        && derivation.entity.as_deref() == Some(owner_entity)
+    {
+        return derivation.slot_entities.get(current_slot).cloned();
+    }
+    Some(owner_entity.to_string())
+}
+
+fn related_entity_kind(
+    program: &Program,
+    value: Option<&RelatedValueRef>,
+    where_clause: Option<&JudgmentExpr>,
+) -> Option<String> {
+    let mut entities = BTreeSet::new();
+    if let Some(RelatedValueRef::Derived(name)) = value
+        && let Some(derived) = program.derived.get(name)
+        && derived.entity != SCALAR_ENTITY
+    {
+        entities.insert(derived.entity.clone());
+    }
+    if let Some(where_clause) = where_clause {
+        collect_referenced_derived_entities(program, where_clause, &mut entities);
+    }
+    (entities.len() == 1)
+        .then(|| entities.into_iter().next())
+        .flatten()
+}
+
+fn collect_referenced_derived_entities(
+    program: &Program,
+    expr: &JudgmentExpr,
+    entities: &mut BTreeSet<String>,
+) {
+    match expr {
+        JudgmentExpr::Comparison { left, right, .. } => {
+            collect_scalar_derived_entities(program, left, entities);
+            collect_scalar_derived_entities(program, right, entities);
+        }
+        JudgmentExpr::Derived(name) => {
+            if let Some(derived) = program.derived.get(name)
+                && derived.entity != SCALAR_ENTITY
+            {
+                entities.insert(derived.entity.clone());
+            }
+        }
+        JudgmentExpr::RelationMember { .. } => {}
+        JudgmentExpr::And(items) | JudgmentExpr::Or(items) => {
+            for item in items {
+                collect_referenced_derived_entities(program, item, entities);
+            }
+        }
+        JudgmentExpr::Not(item) => {
+            collect_referenced_derived_entities(program, item, entities);
+        }
+    }
+}
+
+fn collect_scalar_derived_entities(
+    program: &Program,
+    expr: &ScalarExpr,
+    entities: &mut BTreeSet<String>,
+) {
+    match expr {
+        ScalarExpr::Derived(name) => {
+            if let Some(derived) = program.derived.get(name)
+                && derived.entity != SCALAR_ENTITY
+            {
+                entities.insert(derived.entity.clone());
+            }
+        }
+        ScalarExpr::ParameterLookup { index, .. }
+        | ScalarExpr::Ceil(index)
+        | ScalarExpr::Floor(index) => {
+            collect_scalar_derived_entities(program, index, entities);
+        }
+        ScalarExpr::Add(items) | ScalarExpr::Max(items) | ScalarExpr::Min(items) => {
+            for item in items {
+                collect_scalar_derived_entities(program, item, entities);
+            }
+        }
+        ScalarExpr::Sub(left, right)
+        | ScalarExpr::Mul(left, right)
+        | ScalarExpr::Div(left, right) => {
+            collect_scalar_derived_entities(program, left, entities);
+            collect_scalar_derived_entities(program, right, entities);
+        }
+        ScalarExpr::DateAddDays { date, days } => {
+            collect_scalar_derived_entities(program, date, entities);
+            collect_scalar_derived_entities(program, days, entities);
+        }
+        ScalarExpr::DaysBetween { from, to } => {
+            collect_scalar_derived_entities(program, from, entities);
+            collect_scalar_derived_entities(program, to, entities);
+        }
+        ScalarExpr::CountRelated { where_clause, .. } => {
+            if let Some(where_clause) = where_clause {
+                collect_referenced_derived_entities(program, where_clause, entities);
+            }
+        }
+        ScalarExpr::SumRelated {
+            value,
+            where_clause,
+            ..
+        } => {
+            if let RelatedValueRef::Derived(name) = value
+                && let Some(derived) = program.derived.get(name)
+                && derived.entity != SCALAR_ENTITY
+            {
+                entities.insert(derived.entity.clone());
+            }
+            if let Some(where_clause) = where_clause {
+                collect_referenced_derived_entities(program, where_clause, entities);
+            }
+        }
+        ScalarExpr::If {
+            condition,
+            then_expr,
+            else_expr,
+        } => {
+            collect_referenced_derived_entities(program, condition, entities);
+            collect_scalar_derived_entities(program, then_expr, entities);
+            collect_scalar_derived_entities(program, else_expr, entities);
+        }
+        ScalarExpr::OverPeriods { value, n, .. } => {
+            collect_scalar_derived_entities(program, value, entities);
+            if let Some(n) = n {
+                collect_scalar_derived_entities(program, n, entities);
+            }
+        }
+        ScalarExpr::Literal(_)
+        | ScalarExpr::Input(_)
+        | ScalarExpr::InputOrElse { .. }
+        | ScalarExpr::PeriodStart
+        | ScalarExpr::PeriodEnd => {}
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn add_relation_usage(
+    program: &Program,
+    relation: &str,
+    current_slot: usize,
+    related_slot: usize,
+    current_kind: Option<String>,
+    related_kind: Option<String>,
+    citing_rule: &str,
+    usages: &mut Vec<RelationUsage>,
+    stack: &mut Vec<String>,
+) -> Vec<Option<String>> {
+    let Some(schema) = program.relations.get(relation) else {
+        return Vec::new();
+    };
+    let mut slot_entities = vec![None; schema.arity];
+    if current_slot < schema.arity {
+        slot_entities[current_slot] = current_kind;
+    }
+    if related_slot < schema.arity {
+        slot_entities[related_slot] = related_kind;
+    }
+    complete_single_unknown_slot(&schema.slot_entities, &mut slot_entities);
+    usages.push(RelationUsage {
+        relation: relation.to_string(),
+        slot_entities: slot_entities.clone(),
+        citing_rule: citing_rule.to_string(),
+    });
+
+    if stack.iter().any(|item| item == relation) {
+        return slot_entities;
+    }
+    let Some(derivation) = schema.derivation.as_ref() else {
+        return slot_entities;
+    };
+    stack.push(relation.to_string());
+    add_relation_usage(
+        program,
+        &derivation.source_relation,
+        derivation.current_slot,
+        derivation.related_slot,
+        slot_entities.get(current_slot).cloned().flatten(),
+        slot_entities.get(related_slot).cloned().flatten(),
+        citing_rule,
+        usages,
+        stack,
+    );
+    stack.pop();
+    slot_entities
+}
+
+fn complete_single_unknown_slot(
+    declared_entities: &[String],
+    slot_entities: &mut [Option<String>],
+) {
+    if declared_entities.len() != slot_entities.len() {
+        return;
+    }
+    let unknown_slots = slot_entities
+        .iter()
+        .enumerate()
+        .filter_map(|(slot, entity)| entity.is_none().then_some(slot))
+        .collect::<Vec<_>>();
+    if unknown_slots.len() != 1 {
+        return;
+    }
+    let mut remaining = declared_entities.to_vec();
+    for entity in slot_entities.iter().flatten() {
+        let Some(position) = remaining.iter().position(|candidate| candidate == entity) else {
+            return;
+        };
+        remaining.remove(position);
+    }
+    if remaining.len() == 1 {
+        slot_entities[unknown_slots[0]] = remaining.pop();
+    }
+}
+
 struct PublicReference<'a> {
     fragment: &'a str,
 }

--- a/src/model.rs
+++ b/src/model.rs
@@ -1148,26 +1148,11 @@ fn collect_scalar_derived_entities(
             collect_scalar_derived_entities(program, from, entities);
             collect_scalar_derived_entities(program, to, entities);
         }
-        ScalarExpr::CountRelated { where_clause, .. } => {
-            if let Some(where_clause) = where_clause {
-                collect_referenced_derived_entities(program, where_clause, entities);
-            }
-        }
-        ScalarExpr::SumRelated {
-            value,
-            where_clause,
-            ..
-        } => {
-            if let RelatedValueRef::Derived(name) = value
-                && let Some(derived) = program.derived.get(name)
-                && derived.entity != SCALAR_ENTITY
-            {
-                entities.insert(derived.entity.clone());
-            }
-            if let Some(where_clause) = where_clause {
-                collect_referenced_derived_entities(program, where_clause, entities);
-            }
-        }
+        // A nested aggregate's predicate and value execute on that aggregate's
+        // related ID, not on the enclosing predicate's entity. Its own usage
+        // traversal handles those references after the enclosing orientation
+        // is established.
+        ScalarExpr::CountRelated { .. } | ScalarExpr::SumRelated { .. } => {}
         ScalarExpr::If {
             condition,
             then_expr,

--- a/src/model.rs
+++ b/src/model.rs
@@ -427,6 +427,9 @@ impl Derived {
 pub struct RelationSchema {
     pub name: String,
     pub arity: usize,
+    /// Declared entity kind for each tuple position. Empty means the relation
+    /// predates slot typing or otherwise leaves its positions undeclared.
+    pub slot_entities: Vec<String>,
     pub derivation: Option<RelationDerivation>,
 }
 
@@ -514,6 +517,7 @@ impl Program {
         self.add_relation_schema(RelationSchema {
             name: name.into(),
             arity,
+            slot_entities: Vec::new(),
             derivation: None,
         })
     }

--- a/src/model.rs
+++ b/src/model.rs
@@ -846,7 +846,7 @@ fn collect_semantics_relation_usages(
 ) {
     match semantics {
         DerivedSemantics::Scalar(expr) => {
-            collect_scalar_relation_usages(program, expr, entity, citing_rule, usages);
+            collect_scalar_relation_usages(program, expr, Some(entity), citing_rule, usages);
         }
         DerivedSemantics::Judgment(expr) => {
             collect_judgment_relation_usages(
@@ -864,7 +864,7 @@ fn collect_semantics_relation_usages(
 fn collect_scalar_relation_usages(
     program: &Program,
     expr: &ScalarExpr,
-    entity: &str,
+    entity: Option<&str>,
     citing_rule: &str,
     usages: &mut Vec<RelationUsage>,
 ) {
@@ -967,14 +967,7 @@ fn collect_scalar_relation_usages(
             then_expr,
             else_expr,
         } => {
-            collect_judgment_relation_usages(
-                program,
-                condition,
-                Some(entity),
-                None,
-                citing_rule,
-                usages,
-            );
+            collect_judgment_relation_usages(program, condition, entity, None, citing_rule, usages);
             collect_scalar_relation_usages(program, then_expr, entity, citing_rule, usages);
             collect_scalar_relation_usages(program, else_expr, entity, citing_rule, usages);
         }
@@ -997,10 +990,12 @@ fn collect_judgment_relation_usages(
 ) {
     match expr {
         JudgmentExpr::Comparison { left, right, .. } => {
-            if let Some(entity) = entity {
-                collect_scalar_relation_usages(program, left, entity, citing_rule, usages);
-                collect_scalar_relation_usages(program, right, entity, citing_rule, usages);
-            }
+            // Even without an enclosing entity kind, nested aggregates may
+            // independently constrain their related slot through a predicate
+            // or value rule. Preserve that partial usage instead of treating
+            // the nested relation as unused.
+            collect_scalar_relation_usages(program, left, entity, citing_rule, usages);
+            collect_scalar_relation_usages(program, right, entity, citing_rule, usages);
         }
         JudgmentExpr::Derived(_) => {}
         JudgmentExpr::RelationMember {
@@ -1051,15 +1046,16 @@ fn executable_current_kind(
     program: &Program,
     relation: &str,
     current_slot: usize,
-    owner_entity: &str,
+    owner_entity: Option<&str>,
 ) -> Option<String> {
     let schema = program.relations.get(relation)?;
     if let Some(derivation) = schema.derivation.as_ref()
+        && let Some(owner_entity) = owner_entity
         && derivation.entity.as_deref() == Some(owner_entity)
     {
         return derivation.slot_entities.get(current_slot).cloned();
     }
-    Some(owner_entity.to_string())
+    owner_entity.map(str::to_string)
 }
 
 fn related_entity_kind(

--- a/src/rulespec.rs
+++ b/src/rulespec.rs
@@ -2170,22 +2170,14 @@ impl RulesDocument {
             }
 
             let mut slot_entities = data_relation.arguments.clone();
-            let legacy_role_labels = slot_entities
-                .iter()
-                .all(|argument| !known.contains(argument) && is_legacy_relation_role(argument));
-            if legacy_role_labels && known.len() == 1 {
-                // One staged pre-contract module used lower_snake_case role
-                // labels (`individual`, `household_member`) rather than entity
-                // kinds. When the closure has exactly one kind, its intended
-                // same-kind relation is unambiguous; canonicalize to that sole
-                // authority. With zero or multiple kinds we fail below rather
-                // than guess. PascalCase typos also fail rather than entering
-                // this narrowly-scoped compatibility path.
-                let sole_kind = known
-                    .first()
-                    .expect("a one-element set has a first item")
-                    .clone();
-                slot_entities.fill(sole_kind);
+            if rule.name == "member_of_individuals_household"
+                && slot_entities == ["individual", "household_member"]
+            {
+                // One staged pre-contract module used role labels rather than
+                // entity kinds for this exact same-Person relation. Keep that
+                // historical spelling readable without turning arbitrary
+                // lower_snake_case typos into accepted entity aliases.
+                slot_entities = vec!["Person".to_string(), "Person".to_string()];
             }
 
             if let Some(argument) = slot_entities
@@ -2767,16 +2759,6 @@ fn unit_kinds_equal(left: &crate::spec::UnitKindSpec, right: &crate::spec::UnitK
         }
         _ => false,
     }
-}
-
-fn is_legacy_relation_role(value: &str) -> bool {
-    value
-        .bytes()
-        .next()
-        .is_some_and(|byte| byte.is_ascii_lowercase())
-        && value
-            .bytes()
-            .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'_')
 }
 
 fn unit_kind_label(kind: &crate::spec::UnitKindSpec) -> String {

--- a/src/rulespec.rs
+++ b/src/rulespec.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::fmt;
 #[cfg(feature = "fs")]
 use std::fs;
@@ -126,6 +126,23 @@ pub enum RuleSpecError {
     TopLevelArityUnsupported { name: String },
     #[error("RuleSpec data relation `{name}` must declare data_relation.arity")]
     MissingDataRelationArity { name: String },
+    #[error(
+        "RuleSpec data relation `{name}` declares {argument_count} {argument_word}, but has arity {arity}; declare exactly one entity kind per relation slot"
+    )]
+    DataRelationArgumentCountMismatch {
+        name: String,
+        arity: usize,
+        argument_count: usize,
+        argument_word: &'static str,
+    },
+    #[error(
+        "RuleSpec data relation `{name}` declares unknown argument entity kind `{argument}`; known entity kinds in the compiled program closure are: {known}"
+    )]
+    UnknownDataRelationArgumentEntity {
+        name: String,
+        argument: String,
+        known: String,
+    },
     #[error("RuleSpec derived relation `{name}` must declare derived_relation")]
     MissingDerivedRelation { name: String },
     #[error("RuleSpec derived relation `{name}` must declare derived_relation.arity")]
@@ -235,6 +252,14 @@ pub enum RuleSpecError {
         name: String,
         existing: usize,
         new: usize,
+    },
+    #[error(
+        "RuleSpec relation `{name}` is declared with conflicting slot entity kinds {existing:?} and {new:?}"
+    )]
+    RelationSlotEntitiesConflict {
+        name: String,
+        existing: Vec<String>,
+        new: Vec<String>,
     },
     #[error(
         "RuleSpec program declares unit `{name}` with conflicting kinds `{first}` and `{second}`; keep one declaration or make repeated declarations identical"
@@ -531,10 +556,38 @@ pub struct SourceRef {
     pub url: Option<String>,
 }
 
+#[derive(Clone, Debug, Deserialize)]
+#[serde(untagged)]
+enum DataRelationArgumentRef {
+    Entity(String),
+    Named { entity: String },
+}
+
+fn deserialize_data_relation_arguments<'de, D>(deserializer: D) -> Result<Vec<String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let arguments =
+        Option::<Vec<DataRelationArgumentRef>>::deserialize(deserializer)?.unwrap_or_default();
+    Ok(arguments
+        .into_iter()
+        .map(|argument| match argument {
+            DataRelationArgumentRef::Entity(entity) | DataRelationArgumentRef::Named { entity } => {
+                entity
+            }
+        })
+        .collect())
+}
+
 #[derive(Clone, Debug, Default, Deserialize)]
 pub struct DataRelationRef {
     #[serde(default)]
     pub arity: Option<usize>,
+    /// Entity kind occupying each relation slot. The object form
+    /// `{name: ..., entity: ...}` predates the compact string form; its
+    /// descriptive name is intentionally discarded while its entity is kept.
+    #[serde(default, deserialize_with = "deserialize_data_relation_arguments")]
+    pub arguments: Vec<String>,
 }
 
 #[derive(Clone, Debug, Default, Deserialize)]
@@ -1993,6 +2046,7 @@ impl RulesDocument {
                 .retain(|parameter| !table_parameter_names.contains(&parameter.name));
             program.parameters.extend(table_parameters);
         }
+        self.validate_data_relation_arguments(&mut explicit_relations, &program)?;
         self.apply_rule_ids(&mut program);
         rewrite_relation_references(&mut program, &relation_rewrites, &explicit_relations)?;
         append_missing_units(&mut program, &self.units);
@@ -2050,6 +2104,107 @@ impl RulesDocument {
                 });
             }
             declarations.entry(&unit.name).or_insert(&unit.kind);
+        }
+        Ok(())
+    }
+
+    fn validate_data_relation_arguments(
+        &self,
+        relations: &mut [RelationSpec],
+        lowered_program: &ProgramSpec,
+    ) -> Result<(), RuleSpecError> {
+        // The engine deliberately has no global entity-kind registry. The
+        // authority here is the import-merged RuleSpec closure: every
+        // top-level `entity:` field survives in `self.rules`, including kinds
+        // on declarations whose later IR omits the field. We union those with
+        // the actually lowered derived entities so the Scalar pseudo-entity is
+        // admitted exactly when formula lowering materializes it.
+        let mut known = self
+            .rules
+            .iter()
+            .filter_map(|rule| rule.entity.as_deref())
+            .filter(|entity| !entity.is_empty())
+            .map(str::to_string)
+            .collect::<BTreeSet<_>>();
+        known.extend(
+            lowered_program
+                .derived
+                .iter()
+                .map(|derived| derived.entity.clone()),
+        );
+        let known_label = if known.is_empty() {
+            "<none>".to_string()
+        } else {
+            known.iter().cloned().collect::<Vec<_>>().join(", ")
+        };
+
+        for rule in &self.rules {
+            if !matches!(rule.kind, Some(RuleKind::DataRelation)) {
+                continue;
+            }
+            let Some(data_relation) = rule.data_relation.as_ref() else {
+                continue;
+            };
+            if data_relation.arguments.is_empty() {
+                // Empty is the explicit legacy/undeclared representation.
+                continue;
+            }
+            let arity =
+                data_relation
+                    .arity
+                    .ok_or_else(|| RuleSpecError::MissingDataRelationArity {
+                        name: rule.name.clone(),
+                    })?;
+            if data_relation.arguments.len() != arity {
+                let argument_count = data_relation.arguments.len();
+                return Err(RuleSpecError::DataRelationArgumentCountMismatch {
+                    name: rule.name.clone(),
+                    arity,
+                    argument_count,
+                    argument_word: if argument_count == 1 {
+                        "argument"
+                    } else {
+                        "arguments"
+                    },
+                });
+            }
+
+            let mut slot_entities = data_relation.arguments.clone();
+            let legacy_role_labels = slot_entities
+                .iter()
+                .all(|argument| !known.contains(argument) && is_legacy_relation_role(argument));
+            if legacy_role_labels && known.len() == 1 {
+                // One staged pre-contract module used lower_snake_case role
+                // labels (`individual`, `household_member`) rather than entity
+                // kinds. When the closure has exactly one kind, its intended
+                // same-kind relation is unambiguous; canonicalize to that sole
+                // authority. With zero or multiple kinds we fail below rather
+                // than guess. PascalCase typos also fail rather than entering
+                // this narrowly-scoped compatibility path.
+                let sole_kind = known
+                    .first()
+                    .expect("a one-element set has a first item")
+                    .clone();
+                slot_entities.fill(sole_kind);
+            }
+
+            if let Some(argument) = slot_entities
+                .iter()
+                .find(|argument| !known.contains(*argument))
+            {
+                return Err(RuleSpecError::UnknownDataRelationArgumentEntity {
+                    name: rule.name.clone(),
+                    argument: argument.clone(),
+                    known: known_label.clone(),
+                });
+            }
+
+            let relation_name = rule.canonical_relation_id();
+            let relation = relations
+                .iter_mut()
+                .find(|relation| relation.name == relation_name)
+                .expect("every data relation rule was lowered before validation");
+            relation.slot_entities = slot_entities;
         }
         Ok(())
     }
@@ -2278,16 +2433,21 @@ impl RuleDefinition {
     }
 
     fn to_data_relation_spec(&self) -> Result<RelationSpec, RuleSpecError> {
-        let arity = self
-            .data_relation
-            .as_ref()
-            .and_then(|data_relation| data_relation.arity)
+        let data_relation =
+            self.data_relation
+                .as_ref()
+                .ok_or_else(|| RuleSpecError::MissingDataRelationArity {
+                    name: self.name.clone(),
+                })?;
+        let arity = data_relation
+            .arity
             .ok_or_else(|| RuleSpecError::MissingDataRelationArity {
                 name: self.name.clone(),
             })?;
         Ok(RelationSpec {
             name: self.canonical_relation_id(),
             arity,
+            slot_entities: data_relation.arguments.clone(),
             derivation: None,
         })
     }
@@ -2341,6 +2501,7 @@ impl RuleDefinition {
         Ok(RelationSpec {
             name: self.canonical_relation_id(),
             arity,
+            slot_entities: derived_relation.slot_entities.clone(),
             derivation: Some(RelationDerivationSpec {
                 source_relation,
                 current_slot: derived_relation
@@ -2608,6 +2769,16 @@ fn unit_kinds_equal(left: &crate::spec::UnitKindSpec, right: &crate::spec::UnitK
     }
 }
 
+fn is_legacy_relation_role(value: &str) -> bool {
+    value
+        .bytes()
+        .next()
+        .is_some_and(|byte| byte.is_ascii_lowercase())
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'_')
+}
+
 fn unit_kind_label(kind: &crate::spec::UnitKindSpec) -> String {
     use crate::spec::UnitKindSpec;
 
@@ -2656,6 +2827,17 @@ fn append_missing_relations(
                     existing: existing.arity,
                     new: relation.arity,
                 });
+            }
+            if !relation.slot_entities.is_empty() {
+                if existing.slot_entities.is_empty() {
+                    existing.slot_entities = relation.slot_entities.clone();
+                } else if existing.slot_entities != relation.slot_entities {
+                    return Err(RuleSpecError::RelationSlotEntitiesConflict {
+                        name: relation.name.clone(),
+                        existing: existing.slot_entities.clone(),
+                        new: relation.slot_entities.clone(),
+                    });
+                }
             }
             if existing.derivation.is_none() && relation.derivation.is_some() {
                 existing.derivation = relation.derivation.clone();

--- a/src/rulespec.rs
+++ b/src/rulespec.rs
@@ -135,14 +135,6 @@ pub enum RuleSpecError {
         argument_count: usize,
         argument_word: &'static str,
     },
-    #[error(
-        "RuleSpec data relation `{name}` declares unknown argument entity kind `{argument}`; known entity kinds in the compiled program closure are: {known}"
-    )]
-    UnknownDataRelationArgumentEntity {
-        name: String,
-        argument: String,
-        known: String,
-    },
     #[error("RuleSpec derived relation `{name}` must declare derived_relation")]
     MissingDerivedRelation { name: String },
     #[error("RuleSpec derived relation `{name}` must declare derived_relation.arity")]
@@ -299,13 +291,24 @@ impl RuleSpecLoweringOptions {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum RuleSpecDiagnosticCode {
     NonExhaustiveMatch,
+    InvalidRelationArgumentEntityShape,
+    UnknownRelationArgumentEntity,
 }
 
 impl RuleSpecDiagnosticCode {
     pub const fn as_str(self) -> &'static str {
         match self {
             Self::NonExhaustiveMatch => "non_exhaustive_match",
+            Self::InvalidRelationArgumentEntityShape => "invalid_relation_argument_entity_shape",
+            Self::UnknownRelationArgumentEntity => "unknown_relation_argument_entity",
         }
+    }
+
+    pub const fn is_relation_entity(self) -> bool {
+        matches!(
+            self,
+            Self::InvalidRelationArgumentEntityShape | Self::UnknownRelationArgumentEntity
+        )
     }
 }
 
@@ -320,20 +323,14 @@ pub struct RuleSpecDiagnostic {
     pub path: String,
     pub rule: String,
     pub occurrences: usize,
+    /// Human-readable detail without the path or diagnostic code. Keeping
+    /// those separate lets compiler hosts preserve exact module attribution.
+    pub message: String,
 }
 
 impl fmt::Display for RuleSpecDiagnostic {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let expression = if self.occurrences == 1 {
-            "expression"
-        } else {
-            "expressions"
-        };
-        write!(
-            formatter,
-            "RuleSpec file `{}` rule `{}` has {} non-exhaustive `match` {expression}; add a final `_ => <fallback>` arm to each match",
-            self.path, self.rule, self.occurrences
-        )
+        write!(formatter, "RuleSpec file `{}`: {}", self.path, self.message)
     }
 }
 
@@ -583,9 +580,10 @@ where
 pub struct DataRelationRef {
     #[serde(default)]
     pub arity: Option<usize>,
-    /// Entity kind occupying each relation slot. The object form
-    /// `{name: ..., entity: ...}` predates the compact string form; its
-    /// descriptive name is intentionally discarded while its entity is kept.
+    /// Proposed entity kind occupying each relation slot. Arity is structural;
+    /// label shape and closure membership are warning-ratcheted validation.
+    /// The object form `{name: ..., entity: ...}` predates the compact string
+    /// form; its descriptive name is discarded while its entity is kept.
     #[serde(default, deserialize_with = "deserialize_data_relation_arguments")]
     pub arguments: Vec<String>,
 }
@@ -909,6 +907,12 @@ fn is_canonical_corpus_jurisdiction(value: &str) -> bool {
                 .bytes()
                 .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit())
     })
+}
+
+fn is_relation_entity_kind_label(value: &str) -> bool {
+    let mut bytes = value.bytes();
+    bytes.next().is_some_and(|first| first.is_ascii_uppercase())
+        && bytes.all(|byte| byte.is_ascii_alphanumeric())
 }
 
 pub fn lower_rulespec_str(source: &str) -> Result<ProgramSpec, RuleSpecError> {
@@ -1930,12 +1934,7 @@ impl RulesDocument {
         &self,
         options: RuleSpecLoweringOptions,
     ) -> Result<RuleSpecLoweringOutcome, RuleSpecError> {
-        let diagnostics = self.compatibility_diagnostics()?;
-        if options.strict && !diagnostics.is_empty() {
-            return Err(RuleSpecError::StrictDiagnostics(RuleSpecDiagnosticReport {
-                diagnostics,
-            }));
-        }
+        let mut diagnostics = self.compatibility_diagnostics()?;
         if !self.relations.is_empty() {
             return Err(RuleSpecError::TopLevelRelationsUnsupported);
         }
@@ -2046,7 +2045,8 @@ impl RulesDocument {
                 .retain(|parameter| !table_parameter_names.contains(&parameter.name));
             program.parameters.extend(table_parameters);
         }
-        self.validate_data_relation_arguments(&mut explicit_relations, &program)?;
+        diagnostics
+            .extend(self.validate_data_relation_arguments(&mut explicit_relations, &program)?);
         self.apply_rule_ids(&mut program);
         rewrite_relation_references(&mut program, &relation_rewrites, &explicit_relations)?;
         append_missing_units(&mut program, &self.units);
@@ -2056,6 +2056,11 @@ impl RulesDocument {
         // Carried for tooling and artifact pass-through only; nothing in
         // compilation or execution reads it.
         program.module = self.module.clone();
+        if options.strict && !diagnostics.is_empty() {
+            return Err(RuleSpecError::StrictDiagnostics(RuleSpecDiagnosticReport {
+                diagnostics,
+            }));
+        }
         Ok(RuleSpecLoweringOutcome {
             program,
             diagnostics,
@@ -2077,6 +2082,11 @@ impl RulesDocument {
                 }
             }
             if occurrences > 0 {
+                let expression = if occurrences == 1 {
+                    "expression"
+                } else {
+                    "expressions"
+                };
                 diagnostics.push(RuleSpecDiagnostic {
                     code: RuleSpecDiagnosticCode::NonExhaustiveMatch,
                     path: rule
@@ -2085,6 +2095,10 @@ impl RulesDocument {
                         .unwrap_or_else(|| "<memory>".to_string()),
                     rule: rule.name.clone(),
                     occurrences,
+                    message: format!(
+                        "RuleSpec rule `{}` has {occurrences} non-exhaustive `match` {expression}; add a final `_ => <fallback>` arm to each match",
+                        rule.name
+                    ),
                 });
             }
         }
@@ -2112,13 +2126,14 @@ impl RulesDocument {
         &self,
         relations: &mut [RelationSpec],
         lowered_program: &ProgramSpec,
-    ) -> Result<(), RuleSpecError> {
+    ) -> Result<Vec<RuleSpecDiagnostic>, RuleSpecError> {
         // The engine deliberately has no global entity-kind registry. The
         // authority here is the import-merged RuleSpec closure: every
         // top-level `entity:` field survives in `self.rules`, including kinds
         // on declarations whose later IR omits the field. We union those with
-        // the actually lowered derived entities so the Scalar pseudo-entity is
-        // admitted exactly when formula lowering materializes it.
+        // the actually lowered derived entities. Absence from this authority
+        // is advisory because published modules legitimately use relation-only
+        // kinds; arity remains the sole structural argument error.
         let mut known = self
             .rules
             .iter()
@@ -2137,6 +2152,7 @@ impl RulesDocument {
         } else {
             known.iter().cloned().collect::<Vec<_>>().join(", ")
         };
+        let mut diagnostics = Vec::new();
 
         for rule in &self.rules {
             if !matches!(rule.kind, Some(RuleKind::DataRelation)) {
@@ -2169,25 +2185,42 @@ impl RulesDocument {
                 });
             }
 
-            let mut slot_entities = data_relation.arguments.clone();
-            if rule.name == "member_of_individuals_household"
-                && slot_entities == ["individual", "household_member"]
-            {
-                // One staged pre-contract module used role labels rather than
-                // entity kinds for this exact same-Person relation. Keep that
-                // historical spelling readable without turning arbitrary
-                // lower_snake_case typos into accepted entity aliases.
-                slot_entities = vec!["Person".to_string(), "Person".to_string()];
+            let invalid_labels = data_relation
+                .arguments
+                .iter()
+                .filter(|argument| !is_relation_entity_kind_label(argument))
+                .cloned()
+                .collect::<Vec<_>>();
+            if !invalid_labels.is_empty() {
+                diagnostics.push(RuleSpecDiagnostic {
+                    code: RuleSpecDiagnosticCode::InvalidRelationArgumentEntityShape,
+                    path: rule.source_path(),
+                    rule: rule.name.clone(),
+                    occurrences: invalid_labels.len(),
+                    message: format!(
+                        "RuleSpec data relation `{}` declares argument labels {:?}, which are not usable UpperCamelCase entity kinds; the declaration is treated as undeclared and `slot_entities` is left empty. Strict relation entity mode treats this warning as an error",
+                        rule.name, invalid_labels
+                    ),
+                });
+                continue;
             }
 
-            if let Some(argument) = slot_entities
+            let unknown_labels = data_relation
+                .arguments
                 .iter()
-                .find(|argument| !known.contains(*argument))
-            {
-                return Err(RuleSpecError::UnknownDataRelationArgumentEntity {
-                    name: rule.name.clone(),
-                    argument: argument.clone(),
-                    known: known_label.clone(),
+                .filter(|argument| !known.contains(*argument))
+                .cloned()
+                .collect::<Vec<_>>();
+            if !unknown_labels.is_empty() {
+                diagnostics.push(RuleSpecDiagnostic {
+                    code: RuleSpecDiagnosticCode::UnknownRelationArgumentEntity,
+                    path: rule.source_path(),
+                    rule: rule.name.clone(),
+                    occurrences: unknown_labels.len(),
+                    message: format!(
+                        "RuleSpec data relation `{}` declares entity kinds {:?} that do not occur in the import-merged program closure (known: {known_label}); the exact declaration is retained. Strict relation entity mode treats this warning as an error",
+                        rule.name, unknown_labels
+                    ),
                 });
             }
 
@@ -2196,9 +2229,9 @@ impl RulesDocument {
                 .iter_mut()
                 .find(|relation| relation.name == relation_name)
                 .expect("every data relation rule was lowered before validation");
-            relation.slot_entities = slot_entities;
+            relation.slot_entities = data_relation.arguments.clone();
         }
-        Ok(())
+        Ok(diagnostics)
     }
 
     fn apply_rule_ids(&self, program: &mut ProgramSpec) {
@@ -2439,7 +2472,9 @@ impl RuleDefinition {
         Ok(RelationSpec {
             name: self.canonical_relation_id(),
             arity,
-            slot_entities: data_relation.arguments.clone(),
+            // Filled only after arity and label-shape validation. In
+            // particular, legacy role labels must not leak into artifacts.
+            slot_entities: Vec::new(),
             derivation: None,
         })
     }

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -624,7 +624,21 @@ fn data_relation_ref_schema() -> Value {
         "type": "object",
         "additionalProperties": true,
         "properties": {
-            "arity": { "type": "integer", "minimum": 0 }
+            "arity": { "type": "integer", "minimum": 0 },
+            "arguments": nullable_array(json!({
+                "oneOf": [
+                    { "type": "string" },
+                    {
+                        "type": "object",
+                        "additionalProperties": true,
+                        "properties": {
+                            "name": { "type": "string" },
+                            "entity": { "type": "string" }
+                        },
+                        "required": ["entity"]
+                    }
+                ]
+            }))
         }
     })
 }

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -11,6 +11,7 @@ use crate::model::{
     InputRecord, Interval, JudgmentExpr, JudgmentOutcome, OverPeriodsKind, ParameterVersion,
     Period, PeriodKind, Program, RelatedValueRef, RelationDerivation, RelationRecord,
     RelationSchema, Rounding, RoundingMode, ScalarExpr, ScalarValue, UnitDef, UnitKind,
+    relation_usage_orientations,
 };
 
 #[derive(Debug, Error)]
@@ -390,6 +391,7 @@ fn relation_slot_entity_diagnostics(
             .or_insert_with(|| Some(input.entity.clone()));
     }
 
+    let usage_orientations = relation_usage_orientations(program);
     let mut diagnostics = Vec::new();
     for record in relations {
         let schema = program
@@ -399,9 +401,24 @@ fn relation_slot_entity_diagnostics(
         if schema.slot_entities.is_empty() {
             continue;
         }
-        for (slot, (entity_id, expected_entity)) in
-            record.tuple.iter().zip(&schema.slot_entities).enumerate()
-        {
+        // Used relations follow the orientation encoded in executable
+        // count/sum/membership nodes. Raw declaration order is positional
+        // authority only for a relation with no program use.
+        let expected_entities = usage_orientations.get(&record.name).map_or_else(
+            || {
+                schema
+                    .slot_entities
+                    .iter()
+                    .cloned()
+                    .map(Some)
+                    .collect::<Vec<_>>()
+            },
+            |orientation| orientation.slot_entities.clone(),
+        );
+        for (slot, entity_id) in record.tuple.iter().enumerate() {
+            let Some(expected_entity) = expected_entities.get(slot).and_then(Option::as_ref) else {
+                continue;
+            };
             let Some(Some(actual_entity)) = entity_by_id.get(entity_id) else {
                 continue;
             };

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -41,6 +41,8 @@ pub enum SpecError {
         arity: usize,
         slot_count: usize,
     },
+    #[error("strict dataset relation entity validation failed:\n{0}")]
+    StrictDatasetBindingDiagnostics(DatasetBindingDiagnosticReport),
     #[error(
         "derived rule `{derived}` declares `rounding: {mode}` but its unit {unit} is not a declared currency unit; output rounding only applies to Currency units (with minor_units)"
     )]
@@ -227,6 +229,78 @@ fn validate_citation_path(location: &str, value: &str) -> Result<(), SpecError> 
     Ok(())
 }
 
+/// Options for binding a wire [`DatasetSpec`] to a compiled [`Program`].
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct DatasetBindingOptions {
+    /// Promote relation tuple entity-kind warnings to a binding error.
+    pub strict_relation_entities: bool,
+}
+
+impl DatasetBindingOptions {
+    pub const fn strict() -> Self {
+        Self {
+            strict_relation_entities: true,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DatasetBindingDiagnosticCode {
+    RelationSlotEntityMismatch,
+}
+
+impl DatasetBindingDiagnosticCode {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::RelationSlotEntityMismatch => "relation_slot_entity_mismatch",
+        }
+    }
+}
+
+/// A relation tuple position whose concrete ID has a known, different kind.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DatasetBindingDiagnostic {
+    pub code: DatasetBindingDiagnosticCode,
+    pub relation: String,
+    pub slot: usize,
+    pub entity_id: String,
+    pub expected_entity: String,
+    pub actual_entity: String,
+}
+
+impl std::fmt::Display for DatasetBindingDiagnostic {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            formatter,
+            "dataset relation `{}` tuple slot {} contains entity id `{}`, expected `{}` but found `{}` from the dataset input records; strict relation entity mode treats this warning as an error",
+            self.relation, self.slot, self.entity_id, self.expected_entity, self.actual_entity
+        )
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DatasetBindingDiagnosticReport {
+    pub diagnostics: Vec<DatasetBindingDiagnostic>,
+}
+
+impl std::fmt::Display for DatasetBindingDiagnosticReport {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        for (index, diagnostic) in self.diagnostics.iter().enumerate() {
+            if index > 0 {
+                formatter.write_str("\n")?;
+            }
+            write!(formatter, "{diagnostic}")?;
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct DatasetBindingOutcome {
+    pub dataset: DataSet,
+    pub diagnostics: Vec<DatasetBindingDiagnostic>,
+}
+
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 pub struct DatasetSpec {
@@ -253,6 +327,17 @@ impl DatasetSpec {
     }
 
     pub fn to_dataset_for_program(&self, program: &Program) -> Result<DataSet, SpecError> {
+        let outcome =
+            self.to_dataset_for_program_with_options(program, DatasetBindingOptions::default())?;
+        emit_dataset_binding_diagnostics(&outcome.diagnostics);
+        Ok(outcome.dataset)
+    }
+
+    pub fn to_dataset_for_program_with_options(
+        &self,
+        program: &Program,
+        options: DatasetBindingOptions,
+    ) -> Result<DatasetBindingOutcome, SpecError> {
         let input_catalog = program.input_catalog();
         let inputs = self
             .inputs
@@ -264,8 +349,75 @@ impl DatasetSpec {
             .iter()
             .map(|relation| relation.to_model_for_program(program))
             .collect::<Result<Vec<RelationRecord>, SpecError>>()?;
-        Ok(DataSet { inputs, relations })
+        let diagnostics = relation_slot_entity_diagnostics(program, &inputs, &relations);
+        if options.strict_relation_entities && !diagnostics.is_empty() {
+            return Err(SpecError::StrictDatasetBindingDiagnostics(
+                DatasetBindingDiagnosticReport { diagnostics },
+            ));
+        }
+        Ok(DatasetBindingOutcome {
+            dataset: DataSet { inputs, relations },
+            diagnostics,
+        })
     }
+}
+
+fn emit_dataset_binding_diagnostics(diagnostics: &[DatasetBindingDiagnostic]) {
+    for diagnostic in diagnostics {
+        eprintln!("warning[{}]: {diagnostic}", diagnostic.code.as_str());
+    }
+}
+
+fn relation_slot_entity_diagnostics(
+    program: &Program,
+    inputs: &[InputRecord],
+    relations: &[RelationRecord],
+) -> Vec<DatasetBindingDiagnostic> {
+    // Program schemas say what each slot expects, but program metadata cannot
+    // assign opaque runtime IDs to kinds. Dataset input records are the only
+    // binding-time authority carrying both `entity_id` and `entity`. If an ID
+    // appears under multiple kinds, leave it unknown so validation is
+    // independent of input order and cannot report a false mismatch.
+    let mut entity_by_id = BTreeMap::<String, Option<String>>::new();
+    for input in inputs {
+        entity_by_id
+            .entry(input.entity_id.clone())
+            .and_modify(|known| {
+                if known.as_deref() != Some(input.entity.as_str()) {
+                    *known = None;
+                }
+            })
+            .or_insert_with(|| Some(input.entity.clone()));
+    }
+
+    let mut diagnostics = Vec::new();
+    for record in relations {
+        let schema = program
+            .relations
+            .get(&record.name)
+            .expect("bound relation names resolve to a program schema");
+        if schema.slot_entities.is_empty() {
+            continue;
+        }
+        for (slot, (entity_id, expected_entity)) in
+            record.tuple.iter().zip(&schema.slot_entities).enumerate()
+        {
+            let Some(Some(actual_entity)) = entity_by_id.get(entity_id) else {
+                continue;
+            };
+            if actual_entity != expected_entity {
+                diagnostics.push(DatasetBindingDiagnostic {
+                    code: DatasetBindingDiagnosticCode::RelationSlotEntityMismatch,
+                    relation: record.name.clone(),
+                    slot,
+                    entity_id: entity_id.clone(),
+                    expected_entity: expected_entity.clone(),
+                    actual_entity: actual_entity.clone(),
+                });
+            }
+        }
+    }
+    diagnostics
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -35,6 +35,12 @@ pub enum SpecError {
         "dataset relation `{reference}` must use an absolute legal RuleSpec reference that resolves to a declared relation in the compiled program"
     )]
     InvalidDatasetRelationReference { reference: String },
+    #[error("relation `{relation}` declares {slot_count} slot entity kinds, but has arity {arity}")]
+    InvalidRelationSlotEntityCount {
+        relation: String,
+        arity: usize,
+        slot_count: usize,
+    },
     #[error(
         "derived rule `{derived}` declares `rounding: {mode}` but its unit {unit} is not a declared currency unit; output rounding only applies to Currency units (with minor_units)"
     )]
@@ -309,15 +315,25 @@ impl UnitKindSpec {
 pub struct RelationSpec {
     pub name: String,
     pub arity: usize,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub slot_entities: Vec<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub derivation: Option<RelationDerivationSpec>,
 }
 
 impl RelationSpec {
     fn to_model(&self) -> Result<RelationSchema, SpecError> {
+        if !self.slot_entities.is_empty() && self.slot_entities.len() != self.arity {
+            return Err(SpecError::InvalidRelationSlotEntityCount {
+                relation: self.name.clone(),
+                arity: self.arity,
+                slot_count: self.slot_entities.len(),
+            });
+        }
         Ok(RelationSchema {
             name: self.name.clone(),
             arity: self.arity,
+            slot_entities: self.slot_entities.clone(),
             derivation: self
                 .derivation
                 .as_ref()

--- a/tests/artifact_version.rs
+++ b/tests/artifact_version.rs
@@ -23,6 +23,30 @@ rules:
         formula: amount + base_amount
 "#;
 
+const RELATION_ARGUMENT_RULESPEC: &str = r#"
+format: rulespec/v1
+rules:
+  - name: member_of_household
+    kind: data_relation
+    data_relation:
+      arity: 2
+      arguments: [Person, Household]
+  - name: person_marker
+    kind: derived
+    entity: Person
+    dtype: Integer
+    versions:
+      - effective_from: 2026-01-01
+        formula: "1"
+  - name: household_marker
+    kind: derived
+    entity: Household
+    dtype: Integer
+    versions:
+      - effective_from: 2026-01-01
+        formula: "1"
+"#;
+
 #[test]
 fn compile_stamps_format_and_engine_versions() {
     let artifact = CompiledProgramArtifact::from_rulespec_str(SIMPLE_RULESPEC)
@@ -134,6 +158,73 @@ fn artifact_file_round_trip_preserves_versions() {
     assert_eq!(reloaded.artifact_format_version, ARTIFACT_FORMAT_VERSION);
 
     std::fs::remove_dir_all(&dir).ok();
+}
+
+#[test]
+fn legacy_artifact_without_relation_slot_entities_still_loads() {
+    let artifact = CompiledProgramArtifact::from_rulespec_str(RELATION_ARGUMENT_RULESPEC)
+        .expect("RuleSpec relation arguments compile");
+    let mut value = serde_json::to_value(&artifact).expect("artifact serialises");
+    let relation = value["program"]["relations"][0]
+        .as_object_mut()
+        .expect("relation is an object");
+    assert_eq!(
+        relation.remove("slot_entities"),
+        Some(serde_json::json!(["Person", "Household"])),
+        "the new artifact must carry the field before this test makes it legacy-shaped"
+    );
+
+    let loaded = CompiledProgramArtifact::from_json_str(
+        &serde_json::to_string(&value).expect("legacy-shaped artifact serialises"),
+    )
+    .expect("an artifact without optional relation slot entities still loads");
+    let round_tripped = serde_json::to_value(loaded).expect("loaded artifact serialises");
+    assert!(
+        round_tripped["program"]["relations"][0]
+            .get("slot_entities")
+            .is_none(),
+        "missing slot entities default to undeclared and remain omitted"
+    );
+}
+
+#[test]
+fn artifact_loader_retains_unknown_tolerated_relation_fields() {
+    let artifact = CompiledProgramArtifact::from_rulespec_str(SIMPLE_RULESPEC)
+        .expect("RuleSpec module compiles");
+    let mut value = serde_json::to_value(&artifact).expect("artifact serialises");
+    value["program"]["relations"] = serde_json::json!([{
+        "name": "member_of_household",
+        "arity": 2,
+        "slot_entities": ["Person", "Household"]
+    }]);
+
+    let loaded = CompiledProgramArtifact::from_json_str(
+        &serde_json::to_string(&value).expect("probe artifact serialises"),
+    )
+    .expect("format-2 readers tolerate the additive relation field");
+    let round_tripped = serde_json::to_value(loaded).expect("probe artifact reserialises");
+    assert_eq!(
+        round_tripped["program"]["relations"][0]["slot_entities"],
+        serde_json::json!(["Person", "Household"]),
+        "new readers retain the field older readers safely ignore"
+    );
+}
+
+#[test]
+fn artifact_rejects_relation_slot_entity_count_that_differs_from_arity() {
+    let artifact = CompiledProgramArtifact::from_rulespec_str(RELATION_ARGUMENT_RULESPEC)
+        .expect("RuleSpec relation arguments compile");
+    let mut value = serde_json::to_value(artifact).expect("artifact serialises");
+    value["program"]["relations"][0]["slot_entities"] = serde_json::json!(["Person"]);
+
+    let error = CompiledProgramArtifact::from_json_str(
+        &serde_json::to_string(&value).expect("malformed artifact serialises"),
+    )
+    .expect_err("artifact relation slot kinds must match arity");
+    let message = error.to_string();
+    assert!(message.contains("member_of_household"), "{message}");
+    assert!(message.contains("arity 2"), "{message}");
+    assert!(message.contains("1 slot"), "{message}");
 }
 
 #[test]

--- a/tests/execution.rs
+++ b/tests/execution.rs
@@ -37,6 +37,30 @@ rules:
         formula: amount + base_amount
 "#;
 
+const TYPED_RELATION_RULESPEC: &str = r#"
+format: rulespec/v1
+rules:
+  - name: member_of_household
+    kind: data_relation
+    data_relation:
+      arity: 2
+      arguments: [Person, Household]
+  - name: person_marker
+    kind: derived
+    entity: Person
+    dtype: Integer
+    versions:
+      - effective_from: 2026-01-01
+        formula: person_value
+  - name: household_marker
+    kind: derived
+    entity: Household
+    dtype: Integer
+    versions:
+      - effective_from: 2026-01-01
+        formula: household_value
+"#;
+
 #[test]
 fn cli_round_trip_returns_json() {
     let program = axiom_rules_engine::rulespec::lower_rulespec_str(SIMPLE_RULESPEC)
@@ -2369,6 +2393,96 @@ fn cli_compile_and_run_compiled_round_trip() {
         ),
         decimal("25")
     );
+
+    std::fs::remove_dir_all(temp_root).ok();
+}
+
+#[test]
+fn run_compiled_emits_relation_slot_entity_warning_to_stderr() {
+    let artifact = CompiledProgramArtifact::from_rulespec_str(TYPED_RELATION_RULESPEC)
+        .expect("typed relation RuleSpec compiles");
+    let temp_root = std::env::temp_dir()
+        .canonicalize()
+        .expect("system temp directory has an exact path")
+        .join(format!(
+            "axiom-rules-engine-relation-warning-{}",
+            std::process::id()
+        ));
+    std::fs::create_dir_all(&temp_root).expect("temp dir created");
+    let artifact_path = temp_root.join("typed-relation.compiled.json");
+    artifact
+        .write_json_file(&artifact_path)
+        .expect("artifact writes");
+
+    let interval = IntervalSpec {
+        start: "2026-01-01".parse().expect("valid date"),
+        end: "2026-12-31".parse().expect("valid date"),
+    };
+    let request = CompiledExecutionRequest {
+        mode: ExecutionMode::Explain,
+        dataset: DatasetSpec {
+            inputs: vec![
+                InputRecordSpec {
+                    name: "person_value".to_string(),
+                    entity: "Person".to_string(),
+                    entity_id: "person-1".to_string(),
+                    interval: interval.clone(),
+                    value: ScalarValueSpec::Integer { value: 1 },
+                },
+                InputRecordSpec {
+                    name: "household_value".to_string(),
+                    entity: "Household".to_string(),
+                    entity_id: "household-1".to_string(),
+                    interval: interval.clone(),
+                    value: ScalarValueSpec::Integer { value: 1 },
+                },
+            ],
+            relations: vec![RelationRecordSpec {
+                name: "member_of_household".to_string(),
+                tuple: vec!["household-1".to_string(), "person-1".to_string()],
+                interval,
+            }],
+        },
+        queries: Vec::new(),
+    };
+
+    let mut child = Command::new(env!("CARGO_BIN_EXE_axiom-rules-engine"))
+        .args([
+            "run-compiled",
+            "--artifact",
+            artifact_path.to_str().expect("utf8 path"),
+        ])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn axiom-rules-engine binary");
+    child
+        .stdin
+        .take()
+        .expect("stdin available")
+        .write_all(
+            serde_json::to_string(&request)
+                .expect("request serialises")
+                .as_bytes(),
+        )
+        .expect("request written");
+    let output = child.wait_with_output().expect("binary completes");
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    serde_json::from_slice::<ExecutionResponse>(&output.stdout)
+        .expect("warning does not contaminate JSON stdout");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("warning[relation_slot_entity_mismatch]"),
+        "{stderr}"
+    );
+    assert!(stderr.contains("member_of_household"), "{stderr}");
+    assert!(stderr.contains("expected `Person`"), "{stderr}");
+    assert!(stderr.contains("found `Household`"), "{stderr}");
 
     std::fs::remove_dir_all(temp_root).ok();
 }

--- a/tests/execution.rs
+++ b/tests/execution.rs
@@ -295,6 +295,7 @@ fn related_inputs_use_latest_covering_start_in_every_mode_and_order() {
         relations: vec![axiom_rules_engine::spec::RelationSpec {
             name: "member_of_household".to_string(),
             arity: 2,
+            slot_entities: Vec::new(),
             derivation: None,
         }],
         derived: vec![DerivedSpec {
@@ -802,6 +803,7 @@ fn trace_closure_includes_related_entity_instances() {
         relations: vec![axiom_rules_engine::spec::RelationSpec {
             name: "member_of_household".to_string(),
             arity: 2,
+            slot_entities: Vec::new(),
             derivation: None,
         }],
         derived: vec![
@@ -1447,6 +1449,7 @@ fn fast_mode_falls_back_to_explain_when_bulk_support_is_missing() {
         relations: vec![axiom_rules_engine::spec::RelationSpec {
             name: "member_of_household".to_string(),
             arity: 2,
+            slot_entities: Vec::new(),
             derivation: None,
         }],
         derived: vec![
@@ -1579,6 +1582,7 @@ fn fast_mode_falls_back_for_filtered_relation_counts() {
         relations: vec![axiom_rules_engine::spec::RelationSpec {
             name: "member_of_household".to_string(),
             arity: 2,
+            slot_entities: Vec::new(),
             derivation: None,
         }],
         derived: vec![DerivedSpec {

--- a/tests/module_source.rs
+++ b/tests/module_source.rs
@@ -294,6 +294,61 @@ fn in_memory_module_source_compiles_and_executes_without_filesystem() {
 }
 
 #[test]
+fn relation_argument_entities_are_validated_against_the_imported_closure() {
+    let source = InMemoryModuleSource::new(&[
+        (
+            "us:policies/root",
+            r#"
+format: rulespec/v1
+imports:
+  - us:policies/entities
+rules:
+  - name: member_of_household
+    kind: data_relation
+    data_relation:
+      arity: 2
+      arguments: [Person, Household]
+"#,
+        ),
+        (
+            "us:policies/entities",
+            r#"
+format: rulespec/v1
+rules:
+  - name: person_marker
+    kind: derived
+    entity: Person
+    dtype: Integer
+    versions:
+      - effective_from: 2026-01-01
+        formula: "1"
+  - name: household_marker
+    kind: derived
+    entity: Household
+    dtype: Integer
+    versions:
+      - effective_from: 2026-01-01
+        formula: "1"
+"#,
+        ),
+    ]);
+
+    let artifact = CompiledProgramArtifact::from_rulespec_with_source("us:policies/root", &source)
+        .expect("relation kinds may be declared by imported rules in the closure");
+    let json = serde_json::to_value(artifact).expect("artifact serializes");
+    let relation = json["program"]["relations"]
+        .as_array()
+        .expect("relations are an array")
+        .iter()
+        .find(|relation| relation["name"] == "us:policies/root#relation.member_of_household")
+        .expect("root relation is present");
+    assert_eq!(
+        relation["slot_entities"],
+        serde_json::json!(["Person", "Household"])
+    );
+}
+
+#[test]
 fn source_relation_sets_bind_state_parameter_into_federal_formula() {
     let source = InMemoryModuleSource::new(&[
         (

--- a/tests/rulespec.rs
+++ b/tests/rulespec.rs
@@ -1950,6 +1950,247 @@ rules:
 }
 
 #[test]
+fn rulespec_data_relation_arguments_round_trip_through_artifact() {
+    let artifact = CompiledProgramArtifact::from_rulespec_str(
+        r#"
+format: rulespec/v1
+rules:
+  - name: qualifying_child_of_tax_unit
+    kind: data_relation
+    data_relation:
+      arity: 2
+      arguments: [TaxUnit, Person]
+  - name: person_marker
+    kind: derived
+    entity: Person
+    dtype: Integer
+    versions:
+      - effective_from: 2026-01-01
+        formula: "1"
+  - name: tax_unit_marker
+    kind: derived
+    entity: TaxUnit
+    dtype: Integer
+    versions:
+      - effective_from: 2026-01-01
+        formula: len(qualifying_child_of_tax_unit)
+"#,
+    )
+    .expect("declared relation entity kinds compile");
+
+    let json = serde_json::to_value(&artifact).expect("artifact serializes");
+    let relation = json["program"]["relations"]
+        .as_array()
+        .expect("relations are an array")
+        .iter()
+        .find(|relation| relation["name"] == "qualifying_child_of_tax_unit")
+        .expect("declared relation is present");
+    assert_eq!(
+        relation["slot_entities"],
+        serde_json::json!(["TaxUnit", "Person"])
+    );
+
+    let reloaded = CompiledProgramArtifact::from_json_str(
+        &serde_json::to_string(&json).expect("artifact JSON serializes"),
+    )
+    .expect("artifact with declared relation entity kinds reloads");
+    let runtime_program = reloaded
+        .program
+        .to_program()
+        .expect("reloaded artifact builds the runtime model");
+    assert_eq!(
+        runtime_program
+            .relations
+            .get("qualifying_child_of_tax_unit")
+            .expect("runtime relation is present")
+            .slot_entities,
+        vec!["TaxUnit", "Person"]
+    );
+    let round_tripped = serde_json::to_value(reloaded).expect("reloaded artifact serializes");
+    let relation = round_tripped["program"]["relations"]
+        .as_array()
+        .expect("relations are an array")
+        .iter()
+        .find(|relation| relation["name"] == "qualifying_child_of_tax_unit")
+        .expect("declared relation survives reload");
+    assert_eq!(
+        relation["slot_entities"],
+        serde_json::json!(["TaxUnit", "Person"])
+    );
+}
+
+#[test]
+fn rulespec_legacy_named_data_relation_arguments_carry_their_entity_kinds() {
+    let artifact = CompiledProgramArtifact::from_rulespec_str(
+        r#"
+format: rulespec/v1
+rules:
+  - name: member_of_household
+    kind: data_relation
+    data_relation:
+      arity: 2
+      arguments:
+        - name: member
+          entity: Person
+        - name: household
+          entity: Household
+  - name: person_marker
+    kind: derived
+    entity: Person
+    dtype: Integer
+    versions:
+      - effective_from: 2026-01-01
+        formula: "1"
+  - name: household_marker
+    kind: derived
+    entity: Household
+    dtype: Integer
+    versions:
+      - effective_from: 2026-01-01
+        formula: "1"
+"#,
+    )
+    .expect("legacy named relation arguments remain accepted");
+
+    let json = serde_json::to_value(artifact).expect("artifact serializes");
+    assert_eq!(
+        json["program"]["relations"][0]["slot_entities"],
+        serde_json::json!(["Person", "Household"])
+    );
+}
+
+#[test]
+fn rulespec_legacy_role_labels_use_the_closures_only_entity_kind() {
+    let artifact = CompiledProgramArtifact::from_rulespec_str(
+        r#"
+format: rulespec/v1
+rules:
+  - name: member_of_individuals_household
+    kind: data_relation
+    data_relation:
+      arity: 2
+      arguments: [individual, household_member]
+  - name: person_marker
+    kind: derived
+    entity: Person
+    dtype: Integer
+    versions:
+      - effective_from: 2026-01-01
+        formula: "1"
+"#,
+    )
+    .expect("unambiguous legacy role labels remain compatible");
+
+    let json = serde_json::to_value(artifact).expect("artifact serializes");
+    assert_eq!(
+        json["program"]["relations"][0]["slot_entities"],
+        serde_json::json!(["Person", "Person"])
+    );
+}
+
+#[test]
+fn rulespec_scalar_is_known_only_when_lowering_materializes_it() {
+    let artifact = CompiledProgramArtifact::from_rulespec_str(
+        r#"
+format: rulespec/v1
+rules:
+  - name: scalar_link
+    kind: data_relation
+    data_relation:
+      arity: 1
+      arguments: [Scalar]
+  - name: base
+    kind: parameter
+    dtype: Integer
+    versions:
+      - effective_from: 2026-01-01
+        formula: "1"
+  - name: computed_scalar
+    kind: derived
+    dtype: Integer
+    versions:
+      - effective_from: 2026-01-01
+        formula: base + 1
+"#,
+    )
+    .expect("materialized Scalar pseudo-entity is a known relation kind");
+
+    let json = serde_json::to_value(artifact).expect("artifact serializes");
+    assert_eq!(
+        json["program"]["relations"][0]["slot_entities"],
+        serde_json::json!(["Scalar"])
+    );
+}
+
+#[test]
+fn rulespec_rejects_data_relation_argument_count_that_differs_from_arity() {
+    let error = CompiledProgramArtifact::from_rulespec_str(
+        r#"
+format: rulespec/v1
+rules:
+  - name: qualifying_child_of_tax_unit
+    kind: data_relation
+    data_relation:
+      arity: 2
+      arguments: [TaxUnit]
+  - name: tax_unit_marker
+    kind: derived
+    entity: TaxUnit
+    dtype: Integer
+    versions:
+      - effective_from: 2026-01-01
+        formula: "1"
+"#,
+    )
+    .expect_err("declared relation entity kinds must match arity");
+    let message = error.to_string();
+    assert!(
+        message.contains("qualifying_child_of_tax_unit"),
+        "{message}"
+    );
+    assert!(message.contains("arity 2"), "{message}");
+    assert!(message.contains("1 argument"), "{message}");
+}
+
+#[test]
+fn rulespec_rejects_unknown_data_relation_argument_entity_kind() {
+    let error = CompiledProgramArtifact::from_rulespec_str(
+        r#"
+format: rulespec/v1
+rules:
+  - name: qualifying_child_of_tax_unit
+    kind: data_relation
+    data_relation:
+      arity: 2
+      arguments: [TaxUnit, Persno]
+  - name: person_marker
+    kind: derived
+    entity: Person
+    dtype: Integer
+    versions:
+      - effective_from: 2026-01-01
+        formula: "1"
+  - name: tax_unit_marker
+    kind: derived
+    entity: TaxUnit
+    dtype: Integer
+    versions:
+      - effective_from: 2026-01-01
+        formula: "1"
+"#,
+    )
+    .expect_err("unknown relation entity kinds must fail compilation");
+    let message = error.to_string();
+    assert!(
+        message.contains("qualifying_child_of_tax_unit"),
+        "{message}"
+    );
+    assert!(message.contains("Persno"), "{message}");
+    assert!(message.contains("Person"), "{message}");
+    assert!(message.contains("TaxUnit"), "{message}");
+}
+
+#[test]
 fn rulespec_rejects_missing_rule_kind() {
     let err = lower_rulespec_str(
         r#"

--- a/tests/rulespec.rs
+++ b/tests/rulespec.rs
@@ -2061,7 +2061,7 @@ rules:
 }
 
 #[test]
-fn rulespec_legacy_role_labels_use_the_closures_only_entity_kind() {
+fn rulespec_accepts_the_staged_legacy_same_person_role_labels() {
     let artifact = CompiledProgramArtifact::from_rulespec_str(
         r#"
 format: rulespec/v1
@@ -2080,13 +2080,40 @@ rules:
         formula: "1"
 "#,
     )
-    .expect("unambiguous legacy role labels remain compatible");
+    .expect("the exact staged legacy role labels remain compatible");
 
     let json = serde_json::to_value(artifact).expect("artifact serializes");
     assert_eq!(
         json["program"]["relations"][0]["slot_entities"],
         serde_json::json!(["Person", "Person"])
     );
+}
+
+#[test]
+fn rulespec_rejects_lowercase_relation_argument_typos() {
+    let error = CompiledProgramArtifact::from_rulespec_str(
+        r#"
+format: rulespec/v1
+rules:
+  - name: member_of_household
+    kind: data_relation
+    data_relation:
+      arity: 2
+      arguments: [persno, houshold]
+  - name: person_marker
+    kind: derived
+    entity: Person
+    dtype: Integer
+    versions:
+      - effective_from: 2026-01-01
+        formula: "1"
+"#,
+    )
+    .expect_err("lowercase typos must not be mistaken for legacy role labels");
+    let message = error.to_string();
+    assert!(message.contains("member_of_household"), "{message}");
+    assert!(message.contains("persno"), "{message}");
+    assert!(message.contains("Person"), "{message}");
 }
 
 #[test]

--- a/tests/rulespec.rs
+++ b/tests/rulespec.rs
@@ -2185,6 +2185,213 @@ rules:
     );
 }
 
+const ORIENTATION_MISMATCH_RULESPEC: &str = r#"
+format: rulespec/v1
+rules:
+  - name: qualifying_child_of_tax_unit
+    kind: data_relation
+    data_relation:
+      arity: 2
+      arguments: [TaxUnit, Person]
+  - name: eitc_qualifying_child
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    versions:
+      - effective_from: 2026-01-01
+        formula: is_eligible
+  - name: tax_unit_marker
+    kind: derived
+    entity: TaxUnit
+    dtype: Integer
+    versions:
+      - effective_from: 2026-01-01
+        formula: case_value
+  - name: eitc_child_count
+    kind: derived
+    entity: TaxUnit
+    dtype: Integer
+    versions:
+      - effective_from: 2026-01-01
+        formula: count_where(qualifying_child_of_tax_unit, eitc_qualifying_child)
+"#;
+
+#[test]
+fn relation_orientation_mismatch_warns_by_default_and_errors_in_strict_compile_mode() {
+    let artifact = CompiledProgramArtifact::from_rulespec_str(ORIENTATION_MISMATCH_RULESPEC)
+        .expect("orientation mismatch is warning-ratcheted by default");
+    assert_eq!(
+        artifact.program.relations[0].slot_entities,
+        vec!["TaxUnit", "Person"],
+        "the artifact must retain source order verbatim"
+    );
+    let diagnostics = artifact
+        .diagnostics
+        .iter()
+        .filter(|diagnostic| diagnostic.code == "relation_orientation_mismatch")
+        .collect::<Vec<_>>();
+    assert_eq!(diagnostics.len(), 1);
+    let diagnostic = diagnostics[0].to_string();
+    assert!(diagnostic.contains("qualifying_child_of_tax_unit"));
+    assert!(diagnostic.contains("[TaxUnit, Person]"));
+    assert!(diagnostic.contains("[Person, TaxUnit]"));
+    assert!(diagnostic.contains("eitc_child_count"));
+
+    let json = serde_json::to_string(&artifact).expect("artifact serializes");
+    let reloaded = CompiledProgramArtifact::from_json_str(&json)
+        .expect("artifact loading recomputes the orientation warning");
+    assert_eq!(
+        reloaded
+            .diagnostics
+            .iter()
+            .filter(|diagnostic| diagnostic.code == "relation_orientation_mismatch")
+            .count(),
+        1
+    );
+    let reload_error = CompiledProgramArtifact::from_json_str_with_options(
+        &json,
+        CompileOptions {
+            strict_relation_entities: true,
+            ..CompileOptions::default()
+        },
+    )
+    .expect_err("strict artifact loading recomputes and rejects the mismatch");
+    assert!(
+        reload_error
+            .to_string()
+            .contains("relation_orientation_mismatch"),
+        "{reload_error}"
+    );
+
+    let error = CompiledProgramArtifact::from_rulespec_str_with_options(
+        ORIENTATION_MISMATCH_RULESPEC,
+        CompileOptions {
+            strict_relation_entities: true,
+            ..CompileOptions::default()
+        },
+    )
+    .expect_err("strict relation entity compilation rejects executable orientation mismatch");
+    assert!(
+        error.to_string().contains("relation_orientation_mismatch"),
+        "{error}"
+    );
+}
+
+#[test]
+fn derived_relation_membership_contributes_usage_orientation() {
+    let artifact = CompiledProgramArtifact::from_rulespec_str(
+        r#"
+format: rulespec/v1
+rules:
+  - name: member_of_household
+    kind: data_relation
+    data_relation:
+      arity: 2
+      arguments: [Household, Person]
+  - name: household_marker
+    kind: derived
+    entity: Household
+    dtype: Integer
+    versions:
+      - effective_from: 2026-01-01
+        formula: household_value
+  - name: eligible_member
+    kind: derived
+    entity: Person
+    dtype: Judgment
+    versions:
+      - effective_from: 2026-01-01
+        formula: eligible
+  - name: snap_unit
+    kind: derived_relation
+    derived_relation:
+      arity: 2
+      source_relation: member_of_household
+      entity: SnapUnit
+      member_relation: members
+      slot_entities: [Person, Household]
+    versions:
+      - effective_from: 2026-01-01
+        formula: member_of_household and eligible_member
+"#,
+    )
+    .expect("derived relation orientation mismatch is warning-ratcheted");
+    let diagnostics = artifact
+        .diagnostics
+        .iter()
+        .filter(|diagnostic| diagnostic.code == "relation_orientation_mismatch")
+        .collect::<Vec<_>>();
+    assert_eq!(diagnostics.len(), 1);
+    let warning = diagnostics[0].to_string();
+    assert!(warning.contains("member_of_household"), "{warning}");
+    assert!(warning.contains("[Household, Person]"), "{warning}");
+    assert!(warning.contains("[Person, Household]"), "{warning}");
+    assert!(warning.contains("snap_unit"), "{warning}");
+}
+
+#[test]
+fn usage_orientation_warns_only_for_the_empty_lookup_tuple_order() {
+    let artifact = CompiledProgramArtifact::from_rulespec_str(ORIENTATION_MISMATCH_RULESPEC)
+        .expect("orientation fixture compiles in compatibility mode");
+    let program = artifact
+        .program
+        .to_program()
+        .expect("runtime program builds");
+    let interval = IntervalSpec {
+        start: "2026-01-01".parse().expect("valid date"),
+        end: "2026-12-31".parse().expect("valid date"),
+    };
+    let inputs = vec![
+        InputRecordSpec {
+            name: "is_eligible".to_string(),
+            entity: "Person".to_string(),
+            entity_id: "related-0".to_string(),
+            interval: interval.clone(),
+            value: ScalarValueSpec::Bool { value: true },
+        },
+        InputRecordSpec {
+            name: "case_value".to_string(),
+            entity: "TaxUnit".to_string(),
+            entity_id: "case".to_string(),
+            interval: interval.clone(),
+            value: ScalarValueSpec::Integer { value: 1 },
+        },
+    ];
+    let dataset_with_tuple = |tuple: [&str; 2]| DatasetSpec {
+        inputs: inputs.clone(),
+        relations: vec![RelationRecordSpec {
+            name: "qualifying_child_of_tax_unit".to_string(),
+            tuple: tuple.into_iter().map(str::to_string).collect(),
+            interval: interval.clone(),
+        }],
+    };
+
+    let working = dataset_with_tuple(["related-0", "case"]);
+    let working_outcome = working
+        .to_dataset_for_program_with_options(&program, DatasetBindingOptions::default())
+        .expect("working order binds");
+    assert!(
+        working_outcome.diagnostics.is_empty(),
+        "the count-producing order must not receive a kind warning"
+    );
+
+    let broken = dataset_with_tuple(["case", "related-0"]);
+    let broken_outcome = broken
+        .to_dataset_for_program_with_options(&program, DatasetBindingOptions::default())
+        .expect("broken order remains compatible under the warning ratchet");
+    assert_eq!(
+        broken_outcome.diagnostics.len(),
+        2,
+        "both reversed concrete kinds must be diagnosed"
+    );
+    assert_eq!(broken_outcome.diagnostics[0].slot, 0);
+    assert_eq!(broken_outcome.diagnostics[0].expected_entity, "Person");
+    assert_eq!(broken_outcome.diagnostics[0].actual_entity, "TaxUnit");
+    assert_eq!(broken_outcome.diagnostics[1].slot, 1);
+    assert_eq!(broken_outcome.diagnostics[1].expected_entity, "TaxUnit");
+    assert_eq!(broken_outcome.diagnostics[1].actual_entity, "Person");
+}
+
 #[test]
 fn relation_slot_entity_mismatch_warns_by_default_and_errors_in_strict_mode() {
     let artifact = CompiledProgramArtifact::from_rulespec_str(

--- a/tests/rulespec.rs
+++ b/tests/rulespec.rs
@@ -11,8 +11,8 @@ use axiom_rules_engine::rulespec::{
 };
 use axiom_rules_engine::spec::{
     DatasetBindingDiagnosticCode, DatasetBindingOptions, DatasetSpec, DerivedSemanticsSpec,
-    InputRecordSpec, IntervalSpec, PeriodKindSpec, PeriodSpec, RelationRecordSpec, ScalarExprSpec,
-    ScalarValueSpec, SpecError, UnitKindSpec,
+    InputRecordSpec, IntervalSpec, PeriodKindSpec, PeriodSpec, ProgramSpec, RelationRecordSpec,
+    ScalarExprSpec, ScalarValueSpec, SpecError, UnitKindSpec,
 };
 use std::fs;
 use std::path::Path;
@@ -2327,6 +2327,156 @@ rules:
     assert!(warning.contains("[Household, Person]"), "{warning}");
     assert!(warning.contains("[Person, Household]"), "{warning}");
     assert!(warning.contains("snap_unit"), "{warning}");
+}
+
+#[test]
+fn nested_sum_related_does_not_contaminate_outer_relation_orientation() {
+    let program: ProgramSpec = serde_json::from_value(serde_json::json!({
+        "relations": [
+            {
+                "name": "member_of_tax_unit",
+                "arity": 2,
+                "slot_entities": ["Person", "TaxUnit"]
+            },
+            {
+                "name": "payment_of_person",
+                "arity": 2,
+                "slot_entities": ["Payment", "Person"]
+            }
+        ],
+        "derived": [
+            {
+                "name": "payment_amount",
+                "entity": "Payment",
+                "dtype": "decimal",
+                "semantics": "scalar",
+                "expr": {
+                    "kind": "input",
+                    "name": "payment_amount_input"
+                }
+            },
+            {
+                "name": "person_marker",
+                "entity": "Person",
+                "dtype": "integer",
+                "semantics": "scalar",
+                "expr": {
+                    "kind": "input",
+                    "name": "person_marker_input"
+                }
+            },
+            {
+                "name": "tax_unit_marker",
+                "entity": "TaxUnit",
+                "dtype": "integer",
+                "semantics": "scalar",
+                "expr": {
+                    "kind": "input",
+                    "name": "tax_unit_marker_input"
+                }
+            },
+            {
+                "name": "qualifying_person_count",
+                "entity": "TaxUnit",
+                "dtype": "integer",
+                "semantics": "scalar",
+                "expr": {
+                    "kind": "count_related",
+                    "relation": "member_of_tax_unit",
+                    "current_slot": 1,
+                    "related_slot": 0,
+                    "where": {
+                        "kind": "comparison",
+                        "left": {
+                            "kind": "sum_related",
+                            "relation": "payment_of_person",
+                            "current_slot": 1,
+                            "related_slot": 0,
+                            "value": {
+                                "kind": "derived",
+                                "name": "payment_amount"
+                            }
+                        },
+                        "op": "gt",
+                        "right": {
+                            "kind": "literal",
+                            "value": {
+                                "kind": "decimal",
+                                "value": "0"
+                            }
+                        }
+                    }
+                }
+            }
+        ]
+    }))
+    .expect("nested aggregate ProgramSpec parses");
+    let artifact =
+        CompiledProgramArtifact::compile(program).expect("nested aggregate program compiles");
+    assert!(
+        artifact
+            .diagnostics
+            .iter()
+            .all(|diagnostic| diagnostic.code != "relation_orientation_mismatch"),
+        "the Payment rule inside the nested sum must not type the outer Person slot: {:?}",
+        artifact.diagnostics
+    );
+
+    let runtime = artifact
+        .program
+        .to_program()
+        .expect("runtime program builds");
+    let interval = IntervalSpec {
+        start: "2026-01-01".parse().expect("valid date"),
+        end: "2026-12-31".parse().expect("valid date"),
+    };
+    let dataset = DatasetSpec {
+        inputs: vec![
+            InputRecordSpec {
+                name: "person_marker_input".to_string(),
+                entity: "Person".to_string(),
+                entity_id: "person".to_string(),
+                interval: interval.clone(),
+                value: ScalarValueSpec::Integer { value: 1 },
+            },
+            InputRecordSpec {
+                name: "tax_unit_marker_input".to_string(),
+                entity: "TaxUnit".to_string(),
+                entity_id: "tax-unit".to_string(),
+                interval: interval.clone(),
+                value: ScalarValueSpec::Integer { value: 1 },
+            },
+            InputRecordSpec {
+                name: "payment_amount_input".to_string(),
+                entity: "Payment".to_string(),
+                entity_id: "payment".to_string(),
+                interval: interval.clone(),
+                value: ScalarValueSpec::Decimal {
+                    value: "10".to_string(),
+                },
+            },
+        ],
+        relations: vec![
+            RelationRecordSpec {
+                name: "member_of_tax_unit".to_string(),
+                tuple: vec!["person".to_string(), "tax-unit".to_string()],
+                interval: interval.clone(),
+            },
+            RelationRecordSpec {
+                name: "payment_of_person".to_string(),
+                tuple: vec!["payment".to_string(), "person".to_string()],
+                interval,
+            },
+        ],
+    };
+    let outcome = dataset
+        .to_dataset_for_program_with_options(&runtime, DatasetBindingOptions::default())
+        .expect("working nested aggregate tuple orders bind");
+    assert!(
+        outcome.diagnostics.is_empty(),
+        "both executable tuple orders must remain warning-free: {:?}",
+        outcome.diagnostics
+    );
 }
 
 #[test]

--- a/tests/rulespec.rs
+++ b/tests/rulespec.rs
@@ -2329,19 +2329,18 @@ rules:
     assert!(warning.contains("snap_unit"), "{warning}");
 }
 
-#[test]
-fn nested_sum_related_does_not_contaminate_outer_relation_orientation() {
-    let program: ProgramSpec = serde_json::from_value(serde_json::json!({
+fn nested_sum_program(outer_slots: &[&str], inner_slots: &[&str]) -> ProgramSpec {
+    serde_json::from_value(serde_json::json!({
         "relations": [
             {
                 "name": "member_of_tax_unit",
                 "arity": 2,
-                "slot_entities": ["Person", "TaxUnit"]
+                "slot_entities": outer_slots
             },
             {
                 "name": "payment_of_person",
                 "arity": 2,
-                "slot_entities": ["Payment", "Person"]
+                "slot_entities": inner_slots
             }
         ],
         "derived": [
@@ -2410,27 +2409,15 @@ fn nested_sum_related_does_not_contaminate_outer_relation_orientation() {
             }
         ]
     }))
-    .expect("nested aggregate ProgramSpec parses");
-    let artifact =
-        CompiledProgramArtifact::compile(program).expect("nested aggregate program compiles");
-    assert!(
-        artifact
-            .diagnostics
-            .iter()
-            .all(|diagnostic| diagnostic.code != "relation_orientation_mismatch"),
-        "the Payment rule inside the nested sum must not type the outer Person slot: {:?}",
-        artifact.diagnostics
-    );
+    .expect("nested aggregate ProgramSpec parses")
+}
 
-    let runtime = artifact
-        .program
-        .to_program()
-        .expect("runtime program builds");
+fn nested_sum_dataset() -> DatasetSpec {
     let interval = IntervalSpec {
         start: "2026-01-01".parse().expect("valid date"),
         end: "2026-12-31".parse().expect("valid date"),
     };
-    let dataset = DatasetSpec {
+    DatasetSpec {
         inputs: vec![
             InputRecordSpec {
                 name: "person_marker_input".to_string(),
@@ -2468,13 +2455,69 @@ fn nested_sum_related_does_not_contaminate_outer_relation_orientation() {
                 interval,
             },
         ],
-    };
-    let outcome = dataset
+    }
+}
+
+#[test]
+fn nested_sum_related_does_not_contaminate_outer_relation_orientation() {
+    let artifact = CompiledProgramArtifact::compile(nested_sum_program(
+        &["Person", "TaxUnit"],
+        &["Payment", "Person"],
+    ))
+    .expect("nested aggregate program compiles");
+    assert!(
+        artifact
+            .diagnostics
+            .iter()
+            .all(|diagnostic| diagnostic.code != "relation_orientation_mismatch"),
+        "the Payment rule inside the nested sum must not type the outer Person slot: {:?}",
+        artifact.diagnostics
+    );
+
+    let runtime = artifact
+        .program
+        .to_program()
+        .expect("runtime program builds");
+    let outcome = nested_sum_dataset()
         .to_dataset_for_program_with_options(&runtime, DatasetBindingOptions::default())
         .expect("working nested aggregate tuple orders bind");
     assert!(
         outcome.diagnostics.is_empty(),
         "both executable tuple orders must remain warning-free: {:?}",
+        outcome.diagnostics
+    );
+}
+
+#[test]
+fn nested_sum_related_retains_partial_orientation_under_untyped_outer_relation() {
+    let artifact =
+        CompiledProgramArtifact::compile(nested_sum_program(&[], &["Person", "Payment"]))
+            .expect("nested aggregate program compiles");
+    let orientation_diagnostics = artifact
+        .diagnostics
+        .iter()
+        .filter(|diagnostic| diagnostic.code == "relation_orientation_mismatch")
+        .collect::<Vec<_>>();
+    assert_eq!(
+        orientation_diagnostics.len(),
+        1,
+        "the nested sum remains a program use even when its owner kind starts unknown"
+    );
+    let diagnostic = orientation_diagnostics[0].to_string();
+    assert!(diagnostic.contains("payment_of_person"), "{diagnostic}");
+    assert!(diagnostic.contains("[Person, Payment]"), "{diagnostic}");
+    assert!(diagnostic.contains("[Payment, Person]"), "{diagnostic}");
+
+    let runtime = artifact
+        .program
+        .to_program()
+        .expect("runtime program builds");
+    let outcome = nested_sum_dataset()
+        .to_dataset_for_program_with_options(&runtime, DatasetBindingOptions::default())
+        .expect("working nested aggregate tuple orders bind");
+    assert!(
+        outcome.diagnostics.is_empty(),
+        "partial usage must prevent declaration fallback from warning on the working inner tuple: {:?}",
         outcome.diagnostics
     );
 }

--- a/tests/rulespec.rs
+++ b/tests/rulespec.rs
@@ -2,7 +2,7 @@ use axiom_rules_engine::api::{
     ExecutionMode, ExecutionQuery, ExecutionRequest, OutputValue, execute_request,
 };
 use axiom_rules_engine::compile::{
-    CompileError, CompiledProgramArtifact, compile_program_file_to_json,
+    CompileError, CompileOptions, CompiledProgramArtifact, compile_program_file_to_json,
 };
 use axiom_rules_engine::rulespec::{
     CanonicalRuleSpecRoots, RuleSpecDiagnosticCode, RuleSpecError, RuleSpecLoweringOptions,
@@ -2061,9 +2061,8 @@ rules:
 }
 
 #[test]
-fn rulespec_accepts_the_staged_legacy_same_person_role_labels() {
-    let artifact = CompiledProgramArtifact::from_rulespec_str(
-        r#"
+fn rulespec_legacy_role_labels_warn_and_leave_relation_untyped_by_default() {
+    let rulespec = r#"
 format: rulespec/v1
 rules:
   - name: member_of_individuals_household
@@ -2078,20 +2077,47 @@ rules:
     versions:
       - effective_from: 2026-01-01
         formula: "1"
-"#,
-    )
-    .expect("the exact staged legacy role labels remain compatible");
+"#;
+    let artifact = CompiledProgramArtifact::from_rulespec_str(rulespec)
+        .expect("legacy role labels remain compile-compatible by default");
 
-    let json = serde_json::to_value(artifact).expect("artifact serializes");
+    let json = serde_json::to_value(&artifact).expect("artifact serializes");
     assert_eq!(
         json["program"]["relations"][0]["slot_entities"],
-        serde_json::json!(["Person", "Person"])
+        serde_json::Value::Null,
+        "shape-failing role labels are unusable as entity metadata"
+    );
+    assert_eq!(artifact.diagnostics.len(), 1);
+    let diagnostic = &artifact.diagnostics[0];
+    assert_eq!(diagnostic.code, "invalid_relation_argument_entity_shape");
+    assert_eq!(diagnostic.path, "<memory>");
+    assert!(
+        diagnostic
+            .message
+            .contains("member_of_individuals_household")
+    );
+    assert!(diagnostic.message.contains("individual"));
+    assert!(diagnostic.message.contains("household_member"));
+
+    let error = CompiledProgramArtifact::from_rulespec_str_with_options(
+        rulespec,
+        CompileOptions {
+            strict_relation_entities: true,
+            ..CompileOptions::default()
+        },
+    )
+    .expect_err("strict relation entity compilation rejects legacy role labels");
+    assert!(
+        error
+            .to_string()
+            .contains("invalid_relation_argument_entity_shape"),
+        "{error}"
     );
 }
 
 #[test]
-fn rulespec_rejects_lowercase_relation_argument_typos() {
-    let error = CompiledProgramArtifact::from_rulespec_str(
+fn rulespec_lowercase_relation_argument_typos_warn_and_leave_relation_untyped() {
+    let artifact = CompiledProgramArtifact::from_rulespec_str(
         r#"
 format: rulespec/v1
 rules:
@@ -2109,11 +2135,20 @@ rules:
         formula: "1"
 "#,
     )
-    .expect_err("lowercase typos must not be mistaken for legacy role labels");
-    let message = error.to_string();
+    .expect("lowercase typos remain compile-compatible under the warning ratchet");
+    assert!(
+        artifact.program.relations[0].slot_entities.is_empty(),
+        "shape-failing labels must be treated as undeclared"
+    );
+    assert_eq!(artifact.diagnostics.len(), 1);
+    assert_eq!(
+        artifact.diagnostics[0].code,
+        "invalid_relation_argument_entity_shape"
+    );
+    let message = artifact.diagnostics[0].to_string();
     assert!(message.contains("member_of_household"), "{message}");
     assert!(message.contains("persno"), "{message}");
-    assert!(message.contains("Person"), "{message}");
+    assert!(message.contains("houshold"), "{message}");
 }
 
 #[test]
@@ -2397,8 +2432,7 @@ rules:
 
 #[test]
 fn rulespec_rejects_data_relation_argument_count_that_differs_from_arity() {
-    let error = CompiledProgramArtifact::from_rulespec_str(
-        r#"
+    let rulespec = r#"
 format: rulespec/v1
 rules:
   - name: qualifying_child_of_tax_unit
@@ -2413,22 +2447,29 @@ rules:
     versions:
       - effective_from: 2026-01-01
         formula: "1"
-"#,
-    )
-    .expect_err("declared relation entity kinds must match arity");
-    let message = error.to_string();
-    assert!(
-        message.contains("qualifying_child_of_tax_unit"),
-        "{message}"
-    );
-    assert!(message.contains("arity 2"), "{message}");
-    assert!(message.contains("1 argument"), "{message}");
+"#;
+    for options in [
+        CompileOptions::default(),
+        CompileOptions {
+            strict_relation_entities: true,
+            ..CompileOptions::default()
+        },
+    ] {
+        let error = CompiledProgramArtifact::from_rulespec_str_with_options(rulespec, options)
+            .expect_err("declared relation entity kinds must match arity in every mode");
+        let message = error.to_string();
+        assert!(
+            message.contains("qualifying_child_of_tax_unit"),
+            "{message}"
+        );
+        assert!(message.contains("arity 2"), "{message}");
+        assert!(message.contains("1 argument"), "{message}");
+    }
 }
 
 #[test]
-fn rulespec_rejects_unknown_data_relation_argument_entity_kind() {
-    let error = CompiledProgramArtifact::from_rulespec_str(
-        r#"
+fn rulespec_unknown_data_relation_argument_entity_kind_warns_by_default_and_is_strict() {
+    let rulespec = r#"
 format: rulespec/v1
 rules:
   - name: qualifying_child_of_tax_unit
@@ -2450,10 +2491,20 @@ rules:
     versions:
       - effective_from: 2026-01-01
         formula: "1"
-"#,
-    )
-    .expect_err("unknown relation entity kinds must fail compilation");
-    let message = error.to_string();
+"#;
+    let artifact = CompiledProgramArtifact::from_rulespec_str(rulespec)
+        .expect("unknown but well-shaped entity kinds warn by default");
+    assert_eq!(
+        artifact.program.relations[0].slot_entities,
+        vec!["TaxUnit", "Persno"],
+        "source-valid labels retain exact artifact fidelity"
+    );
+    assert_eq!(artifact.diagnostics.len(), 1);
+    assert_eq!(
+        artifact.diagnostics[0].code,
+        "unknown_relation_argument_entity"
+    );
+    let message = artifact.diagnostics[0].to_string();
     assert!(
         message.contains("qualifying_child_of_tax_unit"),
         "{message}"
@@ -2461,6 +2512,102 @@ rules:
     assert!(message.contains("Persno"), "{message}");
     assert!(message.contains("Person"), "{message}");
     assert!(message.contains("TaxUnit"), "{message}");
+
+    let error = CompiledProgramArtifact::from_rulespec_str_with_options(
+        rulespec,
+        CompileOptions {
+            strict_relation_entities: true,
+            ..CompileOptions::default()
+        },
+    )
+    .expect_err("strict relation entity compilation rejects unknown kinds");
+    assert!(
+        error
+            .to_string()
+            .contains("unknown_relation_argument_entity"),
+        "{error}"
+    );
+}
+
+#[test]
+fn closure_absent_published_relation_kinds_compile_with_warnings_by_default() {
+    let cases = [
+        (
+            "member_of_budgetary_unit",
+            "Person",
+            "Person",
+            "Household",
+            "Household",
+        ),
+        (
+            "pays_received_to_date_by_person",
+            "Person",
+            "Person",
+            "Payment",
+            "Payment",
+        ),
+        (
+            "coverage_months",
+            "TaxUnit",
+            "TaxUnit",
+            "CoverageMonth",
+            "CoverageMonth",
+        ),
+        (
+            "capital_asset_beneficial_interest_holders",
+            "Asset",
+            "Person",
+            "Asset",
+            "Person",
+        ),
+        (
+            "income_component_of_taxpayer",
+            "Person",
+            "Payment",
+            "Person",
+            "Payment",
+        ),
+    ];
+
+    for (relation, closure_kind, first_kind, second_kind, absent_kind) in cases {
+        let rulespec = format!(
+            r#"
+format: rulespec/v1
+rules:
+  - name: {relation}
+    kind: data_relation
+    data_relation:
+      arity: 2
+      arguments: [{first_kind}, {second_kind}]
+  - name: closure_marker
+    kind: derived
+    entity: {closure_kind}
+    dtype: Integer
+    versions:
+      - effective_from: 2026-01-01
+        formula: "1"
+"#
+        );
+        let artifact = CompiledProgramArtifact::from_rulespec_str(&rulespec)
+            .unwrap_or_else(|error| panic!("{relation} must compile by default: {error}"));
+        assert_eq!(
+            artifact.program.relations[0].slot_entities,
+            vec![first_kind, second_kind],
+            "{relation} must retain its exact declaration"
+        );
+        assert_eq!(
+            artifact
+                .diagnostics
+                .iter()
+                .filter(|diagnostic| diagnostic.code == "unknown_relation_argument_entity")
+                .count(),
+            1,
+            "{relation} must report its absent closure kind"
+        );
+        let warning = artifact.diagnostics[0].to_string();
+        assert!(warning.contains(relation), "{warning}");
+        assert!(warning.contains(absent_kind), "{warning}");
+    }
 }
 
 #[test]

--- a/tests/rulespec.rs
+++ b/tests/rulespec.rs
@@ -10,8 +10,9 @@ use axiom_rules_engine::rulespec::{
     lower_rulespec_str_with_options,
 };
 use axiom_rules_engine::spec::{
-    DatasetSpec, DerivedSemanticsSpec, InputRecordSpec, IntervalSpec, PeriodKindSpec, PeriodSpec,
-    ScalarExprSpec, ScalarValueSpec, SpecError, UnitKindSpec,
+    DatasetBindingDiagnosticCode, DatasetBindingOptions, DatasetSpec, DerivedSemanticsSpec,
+    InputRecordSpec, IntervalSpec, PeriodKindSpec, PeriodSpec, RelationRecordSpec, ScalarExprSpec,
+    ScalarValueSpec, SpecError, UnitKindSpec,
 };
 use std::fs;
 use std::path::Path;
@@ -2119,6 +2120,251 @@ rules:
     assert_eq!(
         json["program"]["relations"][0]["slot_entities"],
         serde_json::json!(["Scalar"])
+    );
+}
+
+#[test]
+fn relation_slot_entity_mismatch_warns_by_default_and_errors_in_strict_mode() {
+    let artifact = CompiledProgramArtifact::from_rulespec_str(
+        r#"
+format: rulespec/v1
+rules:
+  - name: member_of_household
+    kind: data_relation
+    data_relation:
+      arity: 2
+      arguments: [Person, Household]
+  - name: person_marker
+    kind: derived
+    entity: Person
+    dtype: Integer
+    versions:
+      - effective_from: 2026-01-01
+        formula: person_value
+  - name: household_marker
+    kind: derived
+    entity: Household
+    dtype: Integer
+    versions:
+      - effective_from: 2026-01-01
+        formula: household_value
+"#,
+    )
+    .expect("typed relation RuleSpec compiles");
+    let program = artifact
+        .program
+        .to_program()
+        .expect("runtime program builds");
+    let interval = IntervalSpec {
+        start: "2026-01-01".parse().expect("valid date"),
+        end: "2026-12-31".parse().expect("valid date"),
+    };
+    let dataset = DatasetSpec {
+        inputs: vec![
+            InputRecordSpec {
+                name: "person_value".to_string(),
+                entity: "Person".to_string(),
+                entity_id: "person-1".to_string(),
+                interval: interval.clone(),
+                value: ScalarValueSpec::Integer { value: 1 },
+            },
+            InputRecordSpec {
+                name: "household_value".to_string(),
+                entity: "Household".to_string(),
+                entity_id: "household-1".to_string(),
+                interval: interval.clone(),
+                value: ScalarValueSpec::Integer { value: 1 },
+            },
+        ],
+        relations: vec![RelationRecordSpec {
+            name: "member_of_household".to_string(),
+            tuple: vec!["household-1".to_string(), "person-1".to_string()],
+            interval,
+        }],
+    };
+
+    let outcome = dataset
+        .to_dataset_for_program_with_options(&program, DatasetBindingOptions::default())
+        .expect("default binding keeps mismatched records under the warning ratchet");
+    assert_eq!(
+        outcome.dataset.relations[0].tuple,
+        vec!["household-1", "person-1"],
+        "default mode must diagnose without rewriting or dropping the tuple"
+    );
+    assert_eq!(outcome.diagnostics.len(), 2);
+    assert_eq!(
+        outcome.diagnostics[0].code,
+        DatasetBindingDiagnosticCode::RelationSlotEntityMismatch
+    );
+    assert_eq!(outcome.diagnostics[0].relation, "member_of_household");
+    assert_eq!(outcome.diagnostics[0].slot, 0);
+    assert_eq!(outcome.diagnostics[0].entity_id, "household-1");
+    assert_eq!(outcome.diagnostics[0].expected_entity, "Person");
+    assert_eq!(outcome.diagnostics[0].actual_entity, "Household");
+    assert!(
+        outcome.diagnostics[0]
+            .to_string()
+            .contains("strict relation entity mode")
+    );
+
+    let error = dataset
+        .to_dataset_for_program_with_options(&program, DatasetBindingOptions::strict())
+        .expect_err("strict binding rejects the same mismatched tuple");
+    assert!(matches!(
+        &error,
+        SpecError::StrictDatasetBindingDiagnostics(report)
+            if report.diagnostics == outcome.diagnostics
+    ));
+    let message = error.to_string();
+    assert!(message.contains("member_of_household"), "{message}");
+    assert!(message.contains("household-1"), "{message}");
+    assert!(message.contains("expected `Person`"), "{message}");
+    assert!(message.contains("found `Household`"), "{message}");
+}
+
+#[test]
+fn relation_slot_entity_validation_skips_unknown_and_ambiguous_ids() {
+    let artifact = CompiledProgramArtifact::from_rulespec_str(
+        r#"
+format: rulespec/v1
+rules:
+  - name: member_of_household
+    kind: data_relation
+    data_relation:
+      arity: 2
+      arguments: [Person, Household]
+  - name: marker
+    kind: derived
+    entity: Household
+    dtype: Integer
+    versions:
+      - effective_from: 2026-01-01
+        formula: value
+  - name: person_marker
+    kind: derived
+    entity: Person
+    dtype: Integer
+    versions:
+      - effective_from: 2026-01-01
+        formula: value
+"#,
+    )
+    .expect("typed relation RuleSpec compiles");
+    let program = artifact
+        .program
+        .to_program()
+        .expect("runtime program builds");
+    let interval = IntervalSpec {
+        start: "2026-01-01".parse().expect("valid date"),
+        end: "2026-12-31".parse().expect("valid date"),
+    };
+    let dataset = DatasetSpec {
+        inputs: vec![
+            InputRecordSpec {
+                name: "value".to_string(),
+                entity: "Person".to_string(),
+                entity_id: "ambiguous-1".to_string(),
+                interval: interval.clone(),
+                value: ScalarValueSpec::Integer { value: 1 },
+            },
+            InputRecordSpec {
+                name: "value".to_string(),
+                entity: "Household".to_string(),
+                entity_id: "ambiguous-1".to_string(),
+                interval: interval.clone(),
+                value: ScalarValueSpec::Integer { value: 1 },
+            },
+        ],
+        relations: vec![RelationRecordSpec {
+            name: "member_of_household".to_string(),
+            tuple: vec!["ambiguous-1".to_string(), "not-in-inputs".to_string()],
+            interval,
+        }],
+    };
+
+    for inputs in [
+        dataset.inputs.clone(),
+        dataset.inputs.iter().cloned().rev().collect(),
+    ] {
+        let outcome = DatasetSpec {
+            inputs,
+            relations: dataset.relations.clone(),
+        }
+        .to_dataset_for_program_with_options(&program, DatasetBindingOptions::strict())
+        .expect("unknown concrete ID kinds are skipped even in strict mode");
+        assert!(
+            outcome.diagnostics.is_empty(),
+            "ambiguous ID handling must not depend on input order"
+        );
+    }
+}
+
+#[test]
+fn strict_relation_slot_entity_validation_preserves_untyped_legacy_relations() {
+    let artifact = CompiledProgramArtifact::from_rulespec_str(
+        r#"
+format: rulespec/v1
+rules:
+  - name: member_of_household
+    kind: data_relation
+    data_relation:
+      arity: 2
+  - name: person_marker
+    kind: derived
+    entity: Person
+    dtype: Integer
+    versions:
+      - effective_from: 2026-01-01
+        formula: person_value
+  - name: household_marker
+    kind: derived
+    entity: Household
+    dtype: Integer
+    versions:
+      - effective_from: 2026-01-01
+        formula: household_value
+"#,
+    )
+    .expect("legacy untyped relation RuleSpec compiles");
+    let program = artifact
+        .program
+        .to_program()
+        .expect("runtime program builds");
+    let interval = IntervalSpec {
+        start: "2026-01-01".parse().expect("valid date"),
+        end: "2026-12-31".parse().expect("valid date"),
+    };
+    let dataset = DatasetSpec {
+        inputs: vec![
+            InputRecordSpec {
+                name: "person_value".to_string(),
+                entity: "Person".to_string(),
+                entity_id: "person-1".to_string(),
+                interval: interval.clone(),
+                value: ScalarValueSpec::Integer { value: 1 },
+            },
+            InputRecordSpec {
+                name: "household_value".to_string(),
+                entity: "Household".to_string(),
+                entity_id: "household-1".to_string(),
+                interval: interval.clone(),
+                value: ScalarValueSpec::Integer { value: 1 },
+            },
+        ],
+        relations: vec![RelationRecordSpec {
+            name: "member_of_household".to_string(),
+            tuple: vec!["household-1".to_string(), "person-1".to_string()],
+            interval,
+        }],
+    };
+
+    let outcome = dataset
+        .to_dataset_for_program_with_options(&program, DatasetBindingOptions::strict())
+        .expect("strict binding leaves untyped legacy relations compatible");
+    assert!(outcome.diagnostics.is_empty());
+    assert_eq!(
+        outcome.dataset.relations[0].tuple,
+        vec!["household-1", "person-1"]
     );
 }
 


### PR DESCRIPTION
Fixes #137.

Data relations' declared `arguments` were parsed and discarded — consumers had to guess tuple
shapes. This carries them end to end, and what we found on the way reshaped the design: the
declarations, never having been validated, disagree with executable usage in **28 of the 50**
declared-argument relations across the staged corpora. So this PR validates against **what the
engine executes**, not against declarations that are wrong more often than right.

## The live defect this addresses (verified on the published v0.1.1 binary)

`us/statutes/26/32` declares `arguments: [TaxUnit, Person]`; the compiled `count_related` reads
the TaxUnit at slot 1. The engine indexes by position, so on the published binary, with a
dataset whose qualifying-child predicate genuinely holds:

| | tuple `[person, taxunit]` | tuple `[taxunit, person]` (declared order) |
|---|---|---|
| predicate holds | `eitc_child_count = 1` | `eitc_child_count = 0` |
| predicate fails | `0` | `0` |

A consumer who trusts the declaration loses the EITC child count — silently. (The bottom row
also explains how this survived a prior "verified same outputs" check: any dataset where the
predicate fails returns 0==0 in both orders, a vacuous equality.)

## What this PR does

1. **Parse + carry.** `DataRelationRef.arguments` (serde default) → `RelationSchema.slot_entities`
   → serialized in format-2 artifacts verbatim (source fidelity), optional so existing artifacts
   load. **Compatibility probed against the published v0.1.1 binary: it tolerates the new field**
   — no #125 widening; transcript in the report.
2. **Compile-time orientation check.** For every declared relation, usage orientation is derived
   from the rules that execute it; disagreement emits
   `warning[relation_orientation_mismatch]` naming declared order, derived order, and a citing
   rule (error under strict mode). The declaration is never silently rewritten.
3. **Bind-time validation keys on usage-derived orientation** — the one the engine executes —
   falling back to the declaration only for unused relations. On the 26/32 shape, the
   zero-producing order gets `warning[relation_slot_entity_mismatch]` and the working order binds
   clean. Warnings point at the broken order, never the working one.
4. **All name validation ratchets** (warn default / strict error, per the #132 pattern): unknown
   entity kind, shape/typo check, unusable legacy labels (treated as undeclared, with a warning).
   Only arity/length mismatch is a hard error. A rejected earlier draft hard-coded a per-relation
   alias in the engine; content policy stays in the corpus.
5. **Entity-kind authority** = the import-merged closure's rule `entity:` fields (plus lowered
   derived entities); documented in code. Five published modules whose declared kinds don't host
   rules in-closure (Household, Payment, CoverageMonth…) compile by default with warnings.

## Corpus evidence (staged rulespec-{us,uk,nz,be,gh})

* Compile success unchanged: 40/46 five-root staged set (six pre-existing main-vs-corpus
  failures), 46/46 on the uk/be/nz/gh policy sweep.
* Orientation census: US 42 = 19 consistent / **22 inconsistent** / 1 unused; UK adds 2 / **6** /
  0. Full worklists in the report; content fixes to follow in the rulespec repos — the new
  compile warning enumerates them mechanically.
* End-to-end on a clean fixture with the branch binary: executable order → count 1, no warnings;
  declared-broken order → count 0 with the slot warning. The orientation warning fires at
  compile with both orders and the citing rule.

## Tests

256 passed, 0 failed (main: 235); schema tests 12. Failing-test-first pairings for: parse/carry,
arity error, unknown-kind ratchet (default warn + strict error), shape ratchet, legacy-labels
module, orientation mismatch warning, bind warnings on the broken order and not the working one,
legacy artifact without the field, artifact round-trip, nested-orientation isolation.

Companion content worklists will be filed on rulespec-us (22) and rulespec-uk (6), referencing
this PR.
