### PR TITLE
Add exactly_one judgment formula sugar

### DIFF
--- a/docs/rulespec.md
+++ b/docs/rulespec.md
@@ -442,6 +442,28 @@ rules:
         delegation: us:regulations/7-cfr/273/9#snap_state_standard_utility_allowance_delegation
 ```
 
+### Mutual exclusivity: `exactly_one`
+
+Judgment formulas accept `exactly_one(a, b, ...)` (two or more arguments,
+each any judgment-position expression: a fact reference, a comparison, a
+negation). It holds when exactly one argument holds. It lowers to an
+Or-of-And-of-Nots expansion — branch *i* asserts argument *i* and negates the
+rest — with the same truth table as the hand-written form, so outcomes match
+manual expansions on every input. The lowered tree is flat: one n-ary `or`
+over n `and` branches, where hand-chained `and`/`or` operators nest as binary
+pairs, so compiled structure and traces come out shallower than the manual
+form. Prefer it wherever a rule validates a choose-one set, such as filing
+statuses:
+
+```yaml
+versions:
+  - effective_from: '2026-01-01'
+    formula: exactly_one(filing_status_single, filing_status_married_separate, filing_status_joint, filing_status_head_of_household)
+```
+
+replaces the four-branch expansion whose leaf-reference count grows with the
+square of the option count.
+
 ## Currency rounding
 
 A `derived` rule whose `unit` is a currency may declare an output-rounding

--- a/src/formula.rs
+++ b/src/formula.rs
@@ -1875,8 +1875,9 @@ fn lower_to_judgment(e: &Expr, ctx: &LowerCtx) -> Result<JudgmentExprSpec, Formu
         // previously wrote by hand. The lowered tree is flat n-ary — one Or
         // over n And branches — where hand-written `and`/`or` chains nest as
         // binary pairs, so the compiled structure is shallower but the
-        // outcomes are identical (the exactly_one integration tests prove
-        // equivalence exhaustively).
+        // outcomes are identical (the exactly_one integration tests check
+        // sugar against the manual expansion over every Boolean assignment
+        // and for short-circuit and missing-input-fault behavior).
         Expr::Call { func, args } => match func.as_str() {
             "exactly_one" => {
                 if args.len() < 2 {

--- a/src/formula.rs
+++ b/src/formula.rs
@@ -1869,6 +1869,52 @@ fn lower_to_judgment(e: &Expr, ctx: &LowerCtx) -> Result<JudgmentExprSpec, Formu
                 ));
             }
         },
+        // `exactly_one(a, b, ...)` is mutual-exclusivity sugar: it lowers to
+        // an Or-of-And-of-Nots expansion (branch i asserts item i and negates
+        // every other item) with the same truth table as the form encoders
+        // previously wrote by hand. The lowered tree is flat n-ary — one Or
+        // over n And branches — where hand-written `and`/`or` chains nest as
+        // binary pairs, so the compiled structure is shallower but the
+        // outcomes are identical (the exactly_one integration tests prove
+        // equivalence exhaustively).
+        Expr::Call { func, args } => match func.as_str() {
+            "exactly_one" => {
+                if args.len() < 2 {
+                    return Err(FormulaError::lower(format!(
+                        "exactly_one takes at least 2 arguments, got {}",
+                        args.len()
+                    )));
+                }
+                let items = args
+                    .iter()
+                    .map(|arg| lower_to_judgment(arg, ctx))
+                    .collect::<Result<Vec<_>, _>>()?;
+                JudgmentExprSpec::Or {
+                    items: (0..items.len())
+                        .map(|holds| JudgmentExprSpec::And {
+                            items: items
+                                .iter()
+                                .enumerate()
+                                .map(|(position, item)| {
+                                    if position == holds {
+                                        item.clone()
+                                    } else {
+                                        JudgmentExprSpec::Not {
+                                            item: Box::new(item.clone()),
+                                        }
+                                    }
+                                })
+                                .collect(),
+                        })
+                        .collect(),
+                }
+            }
+            other => {
+                return Err(FormulaError::lower(format!(
+                    "unknown function `{other}` in judgment position"
+                )));
+            }
+        },
         _ => {
             return Err(FormulaError::lower(format!(
                 "expression shape not supported in judgment position: {:?}",

--- a/tests/exactly_one.rs
+++ b/tests/exactly_one.rs
@@ -1,0 +1,258 @@
+//! `exactly_one(...)` is authoring sugar: it must lower to the same
+//! Or-of-And-of-Nots expansion encoders previously wrote by hand, so the
+//! compiled program, evaluation, and traces are indistinguishable from the
+//! manual form.
+
+use axiom_rules_engine::api::{
+    ExecutionMode, ExecutionQuery, ExecutionRequest, OutputValue, execute_request,
+};
+use axiom_rules_engine::spec::{
+    DatasetSpec, InputRecordSpec, IntervalSpec, JudgmentOutcomeSpec, PeriodKindSpec, PeriodSpec,
+    ScalarValueSpec,
+};
+
+const SUGARED_RULESPEC: &str = r#"
+format: rulespec/v1
+rules:
+  - name: filing_status_is_valid
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    versions:
+      - effective_from: 2026-01-01
+        formula: exactly_one(status_single, status_married_separate, status_joint, status_head_of_household)
+"#;
+
+const EXPANDED_RULESPEC: &str = r#"
+format: rulespec/v1
+rules:
+  - name: filing_status_is_valid
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    versions:
+      - effective_from: 2026-01-01
+        formula: |-
+          (
+            status_single
+            and not status_married_separate
+            and not status_joint
+            and not status_head_of_household
+          )
+          or (
+            not status_single
+            and status_married_separate
+            and not status_joint
+            and not status_head_of_household
+          )
+          or (
+            not status_single
+            and not status_married_separate
+            and status_joint
+            and not status_head_of_household
+          )
+          or (
+            not status_single
+            and not status_married_separate
+            and not status_joint
+            and status_head_of_household
+          )
+"#;
+
+fn simple_period() -> PeriodSpec {
+    PeriodSpec {
+        kind: PeriodKindSpec::Month,
+        start: chrono::NaiveDate::from_ymd_opt(2026, 1, 1).expect("valid date"),
+        end: chrono::NaiveDate::from_ymd_opt(2026, 1, 31).expect("valid date"),
+    }
+}
+
+fn judgment_output(output: &OutputValue) -> JudgmentOutcomeSpec {
+    match output {
+        OutputValue::Judgment { outcome, .. } => *outcome,
+        other => panic!("expected judgment output, got {other:?}"),
+    }
+}
+
+fn status_dataset(period: &PeriodSpec, statuses: [bool; 4]) -> DatasetSpec {
+    let names = [
+        "status_single",
+        "status_married_separate",
+        "status_joint",
+        "status_head_of_household",
+    ];
+    DatasetSpec {
+        inputs: names
+            .into_iter()
+            .zip(statuses)
+            .map(|(name, value)| InputRecordSpec {
+                name: name.to_string(),
+                entity: "TaxUnit".to_string(),
+                entity_id: "tax-unit-1".to_string(),
+                interval: IntervalSpec {
+                    start: period.start,
+                    end: period.end,
+                },
+                value: ScalarValueSpec::Bool { value },
+            })
+            .collect(),
+        relations: vec![],
+    }
+}
+
+fn run(rulespec: &str, statuses: [bool; 4]) -> JudgmentOutcomeSpec {
+    let period = simple_period();
+    let program =
+        axiom_rules_engine::rulespec::lower_rulespec_str(rulespec).expect("RuleSpec lowers");
+    let response = execute_request(ExecutionRequest {
+        mode: ExecutionMode::Explain,
+        program,
+        dataset: status_dataset(&period, statuses),
+        queries: vec![ExecutionQuery {
+            assessment_date: None,
+            entity_id: "tax-unit-1".to_string(),
+            period,
+            outputs: vec!["filing_status_is_valid".to_string()],
+        }],
+    })
+    .expect("request executes");
+    judgment_output(
+        response.results[0]
+            .outputs
+            .get("filing_status_is_valid")
+            .expect("judgment output"),
+    )
+}
+
+#[test]
+fn exactly_one_lowers_to_a_flat_or_of_and_of_nots() {
+    let program = axiom_rules_engine::rulespec::lower_rulespec_str(SUGARED_RULESPEC)
+        .expect("sugared RuleSpec lowers");
+    let program = serde_json::to_value(&program).expect("program serialises");
+    let expr = program
+        .pointer("/derived/0/expr")
+        .expect("judgment expression is serialised");
+
+    let holds = |name: &str| {
+        serde_json::json!({
+            "kind": "comparison",
+            "left": {"kind": "input", "name": name},
+            "op": "eq",
+            "right": {"kind": "literal", "value": {"kind": "bool", "value": true}},
+        })
+    };
+    let not_holds = |name: &str| serde_json::json!({"kind": "not", "item": holds(name)});
+    let names = [
+        "status_single",
+        "status_married_separate",
+        "status_joint",
+        "status_head_of_household",
+    ];
+    let expected = serde_json::json!({
+        "kind": "or",
+        "items": names
+            .iter()
+            .enumerate()
+            .map(|(branch, _)| {
+                serde_json::json!({
+                    "kind": "and",
+                    "items": names
+                        .iter()
+                        .enumerate()
+                        .map(|(position, name)| if position == branch {
+                            holds(name)
+                        } else {
+                            not_holds(name)
+                        })
+                        .collect::<Vec<_>>(),
+                })
+            })
+            .collect::<Vec<_>>(),
+    });
+    assert_eq!(
+        expr, &expected,
+        "exactly_one must lower to one flat Or over n And-of-Nots branches",
+    );
+}
+
+#[test]
+fn exactly_one_matches_the_expansion_on_every_input_combination() {
+    for bits in 0..16u8 {
+        let statuses = [
+            bits & 1 != 0,
+            bits & 2 != 0,
+            bits & 4 != 0,
+            bits & 8 != 0,
+        ];
+        let sugared = run(SUGARED_RULESPEC, statuses);
+        let expanded = run(EXPANDED_RULESPEC, statuses);
+        assert_eq!(sugared, expanded, "divergence at inputs {statuses:?}");
+        let expected = if statuses.iter().filter(|held| **held).count() == 1 {
+            JudgmentOutcomeSpec::Holds
+        } else {
+            JudgmentOutcomeSpec::NotHolds
+        };
+        assert_eq!(sugared, expected, "wrong outcome at inputs {statuses:?}");
+    }
+}
+
+#[test]
+fn exactly_one_accepts_arbitrary_judgment_arguments() {
+    let rulespec = r#"
+format: rulespec/v1
+rules:
+  - name: single_path_applies
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    versions:
+      - effective_from: 2026-01-01
+        formula: exactly_one(status_single, monthly_income > 1000, not status_joint)
+"#;
+    axiom_rules_engine::rulespec::lower_rulespec_str(rulespec)
+        .expect("judgment-shaped arguments lower");
+}
+
+#[test]
+fn exactly_one_rejects_fewer_than_two_arguments() {
+    let rulespec = r#"
+format: rulespec/v1
+rules:
+  - name: degenerate
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    versions:
+      - effective_from: 2026-01-01
+        formula: exactly_one(status_single)
+"#;
+    let error = axiom_rules_engine::rulespec::lower_rulespec_str(rulespec)
+        .expect_err("single-argument exactly_one must be rejected")
+        .to_string();
+    assert!(
+        error.contains("exactly_one takes at least 2 arguments"),
+        "error must name the arity contract, got: {error}",
+    );
+}
+
+#[test]
+fn unknown_judgment_functions_are_named_in_the_error() {
+    let rulespec = r#"
+format: rulespec/v1
+rules:
+  - name: bad_call
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    versions:
+      - effective_from: 2026-01-01
+        formula: only_one(status_single, status_joint)
+"#;
+    let error = axiom_rules_engine::rulespec::lower_rulespec_str(rulespec)
+        .expect_err("unknown judgment function must be rejected")
+        .to_string();
+    assert!(
+        error.contains("unknown function `only_one` in judgment position"),
+        "error must name the unknown function, got: {error}",
+    );
+}

--- a/tests/exactly_one.rs
+++ b/tests/exactly_one.rs
@@ -178,12 +178,7 @@ fn exactly_one_lowers_to_a_flat_or_of_and_of_nots() {
 #[test]
 fn exactly_one_matches_the_expansion_on_every_input_combination() {
     for bits in 0..16u8 {
-        let statuses = [
-            bits & 1 != 0,
-            bits & 2 != 0,
-            bits & 4 != 0,
-            bits & 8 != 0,
-        ];
+        let statuses = [bits & 1 != 0, bits & 2 != 0, bits & 4 != 0, bits & 8 != 0];
         let sugared = run(SUGARED_RULESPEC, statuses);
         let expanded = run(EXPANDED_RULESPEC, statuses);
         assert_eq!(sugared, expanded, "divergence at inputs {statuses:?}");

--- a/tests/exactly_one.rs
+++ b/tests/exactly_one.rs
@@ -244,8 +244,8 @@ fn exactly_one_matches_the_expansion_under_missing_inputs() {
     // Missing inputs are not a third truth value at this surface: an input
     // fault fires when a read reaches it, and short-circuiting can resolve a
     // branch before any missing read happens. The sugar's contract is that
-    // both behaviors track the manual expansion exactly, because the lowered
-    // trees are identical.
+    // both behaviors track the manual expansion exactly, because both forms
+    // read the same inputs in the same order.
 
     // The first two statuses both hold: every branch short-circuits on one
     // of them, so the last two statuses are never read and the outcome is

--- a/tests/exactly_one.rs
+++ b/tests/exactly_one.rs
@@ -1,7 +1,10 @@
-//! `exactly_one(...)` is authoring sugar: it must lower to the same
-//! Or-of-And-of-Nots expansion encoders previously wrote by hand, so the
-//! compiled program, evaluation, and traces are indistinguishable from the
-//! manual form.
+//! `exactly_one(...)` is authoring sugar with a precise contract: it lowers
+//! to an Or-of-And-of-Nots expansion behaving exactly like the form encoders
+//! previously wrote by hand — same outcomes on every Boolean assignment,
+//! same short-circuit reads, and the same missing-input faults when a read
+//! reaches an absent input. The lowered tree is flat n-ary where
+//! hand-chained operators nest as binary pairs, so compiled structure and
+//! trace text render the flatter shape while behavior stays identical.
 
 use axiom_rules_engine::api::{
     ExecutionMode, ExecutionQuery, ExecutionRequest, OutputValue, execute_request,
@@ -188,6 +191,136 @@ fn exactly_one_matches_the_expansion_on_every_input_combination() {
             JudgmentOutcomeSpec::NotHolds
         };
         assert_eq!(sugared, expected, "wrong outcome at inputs {statuses:?}");
+    }
+}
+
+fn partial_status_dataset(period: &PeriodSpec, supplied: &[(&str, bool)]) -> DatasetSpec {
+    DatasetSpec {
+        inputs: supplied
+            .iter()
+            .map(|(name, value)| InputRecordSpec {
+                name: name.to_string(),
+                entity: "TaxUnit".to_string(),
+                entity_id: "tax-unit-1".to_string(),
+                interval: IntervalSpec {
+                    start: period.start,
+                    end: period.end,
+                },
+                value: ScalarValueSpec::Bool { value: *value },
+            })
+            .collect(),
+        relations: vec![],
+    }
+}
+
+fn run_partial(rulespec: &str, supplied: &[(&str, bool)]) -> Result<JudgmentOutcomeSpec, String> {
+    let period = simple_period();
+    let program =
+        axiom_rules_engine::rulespec::lower_rulespec_str(rulespec).expect("RuleSpec lowers");
+    execute_request(ExecutionRequest {
+        mode: ExecutionMode::Explain,
+        program,
+        dataset: partial_status_dataset(&period, supplied),
+        queries: vec![ExecutionQuery {
+            assessment_date: None,
+            entity_id: "tax-unit-1".to_string(),
+            period,
+            outputs: vec!["filing_status_is_valid".to_string()],
+        }],
+    })
+    .map(|response| {
+        judgment_output(
+            response.results[0]
+                .outputs
+                .get("filing_status_is_valid")
+                .expect("judgment output"),
+        )
+    })
+    .map_err(|error| format!("{error:?}"))
+}
+
+#[test]
+fn exactly_one_matches_the_expansion_under_missing_inputs() {
+    // Missing inputs are not a third truth value at this surface: an input
+    // fault fires when a read reaches it, and short-circuiting can resolve a
+    // branch before any missing read happens. The sugar's contract is that
+    // both behaviors track the manual expansion exactly, because the lowered
+    // trees are identical.
+
+    // The first two statuses both hold: every branch short-circuits on one
+    // of them, so the last two statuses are never read and the outcome is
+    // determined with half the inputs absent.
+    let determined = [("status_single", true), ("status_married_separate", true)];
+    let sugared = run_partial(SUGARED_RULESPEC, &determined);
+    let expanded = run_partial(EXPANDED_RULESPEC, &determined);
+    assert_eq!(sugared, expanded, "divergence with inputs {determined:?}");
+    assert_eq!(sugared, Ok(JudgmentOutcomeSpec::NotHolds));
+
+    // Statuses one and three hold: the first branch reads the (absent)
+    // second status before anything can short-circuit, so both forms fault
+    // on the same missing input.
+    let faulting = [("status_single", true), ("status_joint", true)];
+    let sugared = run_partial(SUGARED_RULESPEC, &faulting);
+    let expanded = run_partial(EXPANDED_RULESPEC, &faulting);
+    assert_eq!(sugared, expanded, "divergence with inputs {faulting:?}");
+    let error = sugared.expect_err("unreachable inputs must fault");
+    assert!(
+        error.contains("MissingInput") && error.contains("status_married_separate"),
+        "fault must name the first missing read, got: {error}",
+    );
+
+    // Nothing supplied: both forms fault on the first read.
+    let empty: [(&str, bool); 0] = [];
+    let sugared = run_partial(SUGARED_RULESPEC, &empty);
+    let expanded = run_partial(EXPANDED_RULESPEC, &empty);
+    assert_eq!(sugared, expanded, "divergence with no inputs");
+    let error = sugared.expect_err("empty dataset must fault");
+    assert!(
+        error.contains("MissingInput") && error.contains("status_single"),
+        "fault must name the first missing read, got: {error}",
+    );
+}
+
+const SUGARED_PAIR_RULESPEC: &str = r#"
+format: rulespec/v1
+rules:
+  - name: filing_status_is_valid
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    versions:
+      - effective_from: 2026-01-01
+        formula: exactly_one(status_single, status_joint)
+"#;
+
+const EXPANDED_PAIR_RULESPEC: &str = r#"
+format: rulespec/v1
+rules:
+  - name: filing_status_is_valid
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    versions:
+      - effective_from: 2026-01-01
+        formula: |-
+          (status_single and not status_joint)
+          or (not status_single and status_joint)
+"#;
+
+#[test]
+fn exactly_one_pair_is_exclusive_or() {
+    // The minimum arity behaves as exclusive-or and matches its expansion.
+    for (single, joint) in [(false, false), (false, true), (true, false), (true, true)] {
+        let supplied = [("status_single", single), ("status_joint", joint)];
+        let sugared = run_partial(SUGARED_PAIR_RULESPEC, &supplied);
+        let expanded = run_partial(EXPANDED_PAIR_RULESPEC, &supplied);
+        assert_eq!(sugared, expanded, "pair divergence at {supplied:?}");
+        let expected = if single ^ joint {
+            JudgmentOutcomeSpec::Holds
+        } else {
+            JudgmentOutcomeSpec::NotHolds
+        };
+        assert_eq!(sugared, Ok(expected), "pair wrong outcome at {supplied:?}");
     }
 }
 


### PR DESCRIPTION
The authoring half of #142 — the route-2 first-class graph variant and the encoder-prompt guidance stay tracked there.

## What

Judgment formulas accept `exactly_one(a, b, ...)` — two or more arguments, each any judgment-position expression. Lowers in `lower_to_judgment` to the Or-of-And-of-Nots expansion (branch i asserts item i, negates the rest). No spec, model, engine, schema, wasm, or dense changes: downstream consumers keep seeing plain `and`/`or`/`not`.

Also: unknown functions in judgment position now error with the function's name (`` unknown function `only_one` in judgment position ``) instead of the `std::mem::discriminant` catch-all.

## Shape note (found by the tests)

Hand-chained `and`/`or` lower as nested binary pairs; the sugar lowers flat — one n-ary `Or` over n `And` branches. Same truth table (the test suite proves sugar ≡ manual expansion exhaustively over all 16 input combinations of the four-status case), shallower compiled tree and traces. docs/rulespec.md states this explicitly.

## What this does NOT do

The graph viewer still renders the expansion (~n² edges). Collapsing it to a single "exactly one" gate needs the route-2 first-class variant from #142 — deliberately out of scope here so the artifact grammar stays unchanged. Encoder-prompt guidance in axiom-encode is a follow-up once this lands.

## Tests

`tests/exactly_one.rs` (5): flat-shape structural assert on the lowered JSON; exhaustive 16-combination equivalence vs the hand expansion (mirrors the DC filing-status rule); arbitrary judgment-shaped arguments (fact, comparison, negation); arity < 2 rejected with a named error; unknown-function error names the function.

Full suite: `cargo fmt --all -- --check` clean, `cargo test --features schema` green locally.

Motivating case: rulespec-us `us-dc/policies/income_tax/2026_resident_liability_source_hold.yaml`, surfaced in Calliope's launch walkthrough (https://www.youtube.com/watch?v=tHs0ZJTs0oA ~2:05–2:12).

New format capability — leaving the merge to Max per the dual-approval carve-out; sol review requested alongside.

🤖 Generated with [Claude Code](https://claude.com/claude-code)