### PR TITLE
Markdown audit: canonicalize domains and fix stale references

### DIFF
--- a/docs/concept-naming.md
+++ b/docs/concept-naming.md
@@ -51,7 +51,7 @@ the term as an acronym, spell the words out.
 
 Display surfaces derive labels from fragments by title-casing word by word
 and upper-casing tokens found in an acronym registry. The canonical
-registries are `RULE_NAME_ACRONYMS` in `axiom-foundation.org`
+registries are `RULE_NAME_ACRONYMS` in `axiom.org`
 `src/components/axiom/graph-viewer/citations.ts` and
 `rulespec-graph-viewer` `src/citations.ts`; the app carries further sets
 following the same convention for program labels, breadcrumbs, and document


### PR DESCRIPTION
Living docs still carried the pre-rename axiom-foundation.org host (canonical: axiom.org; app.axiom-foundation.org stays — it is the live app host). Dated run logs and ADRs were left untouched as history.

Applied: docs/concept-naming.md:54

Part of the org-wide markdown audit from Calliope's walkthrough follow-up (scan: 1,267 md files across 46 active public repos).

🤖 Generated with [Claude Code](https://claude.com/claude-code)