### PR TITLE
Reference the exactly_one judgment function

### DIFF
--- a/docs/rulespec-format.md
+++ b/docs/rulespec-format.md
@@ -275,7 +275,12 @@ A `dtype: Judgment` formula composes:
 - bare Boolean facts (an undeclared name lowers to an input compared against
   `true`);
 - inside `derived_relation` predicate formulas only: relation-predicate
-  names, which lower to membership tests.
+  names, which lower to membership tests;
+- `exactly_one(a, b, ...)` — two or more judgment-position arguments; holds
+  when exactly one holds. Lowers to a flat n-ary or-of-and-of-nots with the
+  same outcomes, short-circuit reads, and missing-input faults as the
+  hand-written expansion — see the mutual-exclusivity section of
+  [rulespec.md](rulespec.md).
 
 Scalar constructs (`if`, `match`, arithmetic, the function table above) are
 rejected in judgment position, and judgment constructs are rejected in scalar


### PR DESCRIPTION
Follow-up promised on #144/#142: docs/rulespec-format.md's judgment-position list gains exactly_one, cross-linked to the rulespec.md entry #144 added. Doc-only; the example-lowering drift guard passes on this head (post-#144 main, where the construct exists).

🤖 Generated with [Claude Code](https://claude.com/claude-code)