### PR TITLE
Cut the crate at 0.2.0 with an honest registry description

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "axiom-rules-engine"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "chrono",
  "jsonschema",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "axiom-rules-engine"
 version = "0.2.0"
 edition = "2024"
 license = "Apache-2.0"
-description = "Temporal-relational runtime for compiling and executing Axiom RuleSpec (experimental API)"
+description = "Temporal-relational runtime for compiling and executing Axiom RuleSpec (experimental API)."
 repository = "https://github.com/TheAxiomFoundation/axiom-rules-engine"
 keywords = ["rules-engine", "rules-as-code", "legal", "policy", "rulespec"]
 # The published crate carries the library, CLI, and format docs only. Tests,

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "axiom-rules-engine"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 license = "Apache-2.0"
-description = "Prototype temporal-relational Axiom Rules Engine in Rust"
+description = "Temporal-relational runtime for compiling and executing Axiom RuleSpec (experimental API)"
 repository = "https://github.com/TheAxiomFoundation/axiom-rules-engine"
 keywords = ["rules-engine", "rules-as-code", "legal", "policy", "rulespec"]
 # The published crate carries the library, CLI, and format docs only. Tests,

--- a/src/main.rs
+++ b/src/main.rs
@@ -68,7 +68,7 @@ mod tests {
 
     #[test]
     fn version_line_uses_package_version() {
-        assert_eq!(version_line(), "axiom-rules-engine 0.1.0");
+        assert_eq!(version_line(), "axiom-rules-engine 0.2.0");
     }
 
     /// Top-level help must name every command `run` dispatches on, so adding a command


### PR DESCRIPTION
Executes the #141 joint fable+sol verdict on Max's go.

- `version`: 0.1.0 → **0.2.0** — main is 35 commits past the v0.1.1 GitHub release and still declared 0.1.0; publishing that to crates.io would make one version number identify two different artifacts. 0.2.0 gives the publish a clean, taggable identity.
- `description`: "Temporal-relational runtime for compiling and executing Axiom RuleSpec (experimental API)" (sol's wording — drops "Prototype" branding, keeps the experimental-API honesty).
- `src/main.rs` version_line test literal aligned.

Verified on this head: 278 tests pass (`--features schema`), fmt clean, `cargo package --list` = 27 files, `cargo publish --dry-run` packages v0.2.0.

After merge, the remaining steps are Max's per the plan: tag `v0.2.0` on the merge commit (also fires the cargo-dist binary release), `cargo publish` from that checkout, then owner setup (two stewards + a `crate-publishers` team, Trusted Publishing after).

🤖 Generated with [Claude Code](https://claude.com/claude-code)