### PR TITLE
Carry exactly_one first-class through specs and artifacts

### DIFF
--- a/docs/rulespec-format.md
+++ b/docs/rulespec-format.md
@@ -277,10 +277,11 @@ A `dtype: Judgment` formula composes:
 - inside `derived_relation` predicate formulas only: relation-predicate
   names, which lower to membership tests;
 - `exactly_one(a, b, ...)` — two or more judgment-position arguments; holds
-  when exactly one holds. Lowers to a flat n-ary or-of-and-of-nots with the
-  same outcomes, short-circuit reads, and missing-input faults as the
-  hand-written expansion — see the mutual-exclusivity section of
-  [rulespec.md](rulespec.md).
+  when exactly one holds. Serialises as a first-class `exactly_one` node
+  (one n-input gate in artifacts and graphs); evaluation lowers it to the
+  or-of-and-of-nots expansion, keeping outcomes, short-circuit reads, and
+  missing-input faults identical to the hand-written form — see the
+  mutual-exclusivity section of [rulespec.md](rulespec.md).
 
 Scalar constructs (`if`, `match`, arithmetic, the function table above) are
 rejected in judgment position, and judgment constructs are rejected in scalar
@@ -299,7 +300,8 @@ Scalar kinds: `literal`, `input`, `input_or_else`, `derived`,
 `count_related`, `sum_related`, `if`, `over_periods`.
 
 Judgment kinds: `comparison` (with `op` one of `lt`, `lte`, `gt`, `gte`,
-`eq`, `ne`), `derived`, `relation_member`, `and`, `or`, `not`.
+`eq`, `ne`), `derived`, `relation_member`, `and`, `or`, `not`,
+`exactly_one`.
 
 Literal values carry their own `kind`: `bool`, `integer`, `decimal`, `text`,
 or `date`.

--- a/docs/rulespec.md
+++ b/docs/rulespec.md
@@ -447,13 +447,13 @@ rules:
 
 Judgment formulas accept `exactly_one(a, b, ...)` (two or more arguments,
 each any judgment-position expression: a fact reference, a comparison, a
-negation). It holds when exactly one argument holds. It lowers to an
-Or-of-And-of-Nots expansion — branch *i* asserts argument *i* and negates the
-rest — with the same truth table as the hand-written form, so outcomes match
-manual expansions on every input. The lowered tree is flat: one n-ary `or`
-over n `and` branches, where hand-chained `and`/`or` operators nest as binary
-pairs, so compiled structure and traces come out shallower than the manual
-form. Prefer it wherever a rule validates a choose-one set, such as filing
+negation). It holds when exactly one argument holds. It serialises as a
+first-class `exactly_one` node in specs and compiled artifacts, so graph
+consumers see one n-input gate instead of the ~n² expansion. Evaluation
+lowers the node to the Or-of-And-of-Nots expansion — branch *i* asserts
+argument *i* and negates the rest — so outcomes, short-circuit reads,
+missing-input faults, and trace text stay identical to the hand-written
+form on every input. Prefer it wherever a rule validates a choose-one set, such as filing
 statuses:
 
 ```yaml

--- a/docs/rulespec.md
+++ b/docs/rulespec.md
@@ -450,10 +450,11 @@ each any judgment-position expression: a fact reference, a comparison, a
 negation). It holds when exactly one argument holds. It serialises as a
 first-class `exactly_one` node in specs and compiled artifacts, so graph
 consumers see one n-input gate instead of the ~n² expansion. Evaluation
-lowers the node to the Or-of-And-of-Nots expansion — branch *i* asserts
-argument *i* and negates the rest — so outcomes, short-circuit reads,
-missing-input faults, and trace text stay identical to the hand-written
-form on every input. Prefer it wherever a rule validates a choose-one set, such as filing
+lowers the node to the flat Or-of-And-of-Nots expansion — branch *i*
+asserts argument *i* and negates the rest — so outcomes, short-circuit
+reads, and missing-input faults match hand-written expansions on every
+input. Trace text renders the flat lowering, which is shallower than the
+binary nesting hand-chained `and`/`or` produce. Prefer it wherever a rule validates a choose-one set, such as filing
 statuses:
 
 ```yaml

--- a/schemas/compiled-artifact.v2.schema.json
+++ b/schemas/compiled-artifact.v2.schema.json
@@ -639,6 +639,35 @@
             "item"
           ],
           "type": "object"
+        },
+        {
+          "allOf": [
+            {
+              "not": {
+                "required": [
+                  "corpus_citation_paths"
+                ]
+              }
+            }
+          ],
+          "description": "Holds when exactly one item holds. First-class in the serialized\nsurface so artifacts and graph consumers see one n-input gate;\n`to_model` lowers it to the Or-of-And-of-Nots expansion, so\nevaluation, short-circuit reads, missing-input faults, and trace\ntext are byte-identical to the hand-written form. Expression-level,\nadditive to the serialized surface — no artifact-format-version bump.",
+          "properties": {
+            "items": {
+              "items": {
+                "$ref": "#/$defs/JudgmentExprSpec"
+              },
+              "type": "array"
+            },
+            "kind": {
+              "const": "exactly_one",
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "items"
+          ],
+          "type": "object"
         }
       ]
     },

--- a/schemas/compiled-artifact.v2.schema.json
+++ b/schemas/compiled-artifact.v2.schema.json
@@ -650,7 +650,7 @@
               }
             }
           ],
-          "description": "Holds when exactly one item holds. First-class in the serialized\nsurface so artifacts and graph consumers see one n-input gate;\n`to_model` lowers it to the Or-of-And-of-Nots expansion, so\nevaluation, short-circuit reads, missing-input faults, and trace\ntext are byte-identical to the hand-written form. Expression-level,\nadditive to the serialized surface — no artifact-format-version bump.",
+          "description": "Holds when exactly one item holds. First-class in the serialized\nsurface so artifacts and graph consumers see one n-input gate;\n`to_model` lowers it to the flat Or-of-And-of-Nots expansion the\nformula sugar produced before this variant existed, so evaluation,\nshort-circuit reads, missing-input faults, and trace text are\nunchanged. Outcomes and faults also match hand-written expansions\non every input; trace TEXT does not match those byte-for-byte,\nbecause hand-chained and/or nest as binary pairs while this\nlowering is flat n-ary. Expression-level, additive to the\nserialized surface — no artifact-format-version bump.",
           "properties": {
             "items": {
               "items": {

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -1130,7 +1130,9 @@ fn collect_fast_blockers_from_judgment_expr(
             collect_fast_blockers_from_scalar_expr(derived_name, right, blockers);
         }
         JudgmentExprSpec::Derived { .. } | JudgmentExprSpec::RelationMember { .. } => {}
-        JudgmentExprSpec::And { items } | JudgmentExprSpec::Or { items } => {
+        JudgmentExprSpec::And { items }
+        | JudgmentExprSpec::Or { items }
+        | JudgmentExprSpec::ExactlyOne { items } => {
             for item in items {
                 collect_fast_blockers_from_judgment_expr(derived_name, item, blockers);
             }
@@ -1354,7 +1356,9 @@ fn collect_judgment_dependencies(
             dependencies.insert(name.clone());
         }
         JudgmentExprSpec::RelationMember { .. } => {}
-        JudgmentExprSpec::And { items } | JudgmentExprSpec::Or { items } => {
+        JudgmentExprSpec::And { items }
+        | JudgmentExprSpec::Or { items }
+        | JudgmentExprSpec::ExactlyOne { items } => {
             for item in items {
                 collect_judgment_dependencies(item, dependencies, relation_dependencies);
             }
@@ -1450,7 +1454,9 @@ fn collect_relation_members_from_judgment(
         JudgmentExprSpec::RelationMember { relation, .. } => {
             relations.insert(relation.clone());
         }
-        JudgmentExprSpec::And { items } | JudgmentExprSpec::Or { items } => {
+        JudgmentExprSpec::And { items }
+        | JudgmentExprSpec::Or { items }
+        | JudgmentExprSpec::ExactlyOne { items } => {
             for item in items {
                 collect_relation_members_from_judgment(item, relations);
             }

--- a/src/formula.rs
+++ b/src/formula.rs
@@ -1869,15 +1869,14 @@ fn lower_to_judgment(e: &Expr, ctx: &LowerCtx) -> Result<JudgmentExprSpec, Formu
                 ));
             }
         },
-        // `exactly_one(a, b, ...)` is mutual-exclusivity sugar: it lowers to
-        // an Or-of-And-of-Nots expansion (branch i asserts item i and negates
-        // every other item) with the same truth table as the form encoders
-        // previously wrote by hand. The lowered tree is flat n-ary — one Or
-        // over n And branches — where hand-written `and`/`or` chains nest as
-        // binary pairs, so the compiled structure is shallower but the
-        // outcomes are identical (the exactly_one integration tests check
-        // sugar against the manual expansion over every Boolean assignment
-        // and for short-circuit and missing-input-fault behavior).
+        // `exactly_one(a, b, ...)` lowers to a first-class spec node, so
+        // artifacts and graph consumers carry one n-input gate instead of the
+        // ~n² expansion. The spec's `to_model` performs the Or-of-And-of-Nots
+        // lowering, so evaluation, short-circuit reads, missing-input faults,
+        // and trace text stay byte-identical to the hand-written form (the
+        // exactly_one integration tests check sugar against the manual
+        // expansion over every Boolean assignment and for short-circuit and
+        // missing-input-fault behavior).
         Expr::Call { func, args } => match func.as_str() {
             "exactly_one" => {
                 if args.len() < 2 {
@@ -1886,28 +1885,11 @@ fn lower_to_judgment(e: &Expr, ctx: &LowerCtx) -> Result<JudgmentExprSpec, Formu
                         args.len()
                     )));
                 }
-                let items = args
-                    .iter()
-                    .map(|arg| lower_to_judgment(arg, ctx))
-                    .collect::<Result<Vec<_>, _>>()?;
-                JudgmentExprSpec::Or {
-                    items: (0..items.len())
-                        .map(|holds| JudgmentExprSpec::And {
-                            items: items
-                                .iter()
-                                .enumerate()
-                                .map(|(position, item)| {
-                                    if position == holds {
-                                        item.clone()
-                                    } else {
-                                        JudgmentExprSpec::Not {
-                                            item: Box::new(item.clone()),
-                                        }
-                                    }
-                                })
-                                .collect(),
-                        })
-                        .collect(),
+                JudgmentExprSpec::ExactlyOne {
+                    items: args
+                        .iter()
+                        .map(|arg| lower_to_judgment(arg, ctx))
+                        .collect::<Result<Vec<_>, _>>()?,
                 }
             }
             other => {

--- a/src/formula.rs
+++ b/src/formula.rs
@@ -1871,12 +1871,14 @@ fn lower_to_judgment(e: &Expr, ctx: &LowerCtx) -> Result<JudgmentExprSpec, Formu
         },
         // `exactly_one(a, b, ...)` lowers to a first-class spec node, so
         // artifacts and graph consumers carry one n-input gate instead of the
-        // ~n² expansion. The spec's `to_model` performs the Or-of-And-of-Nots
-        // lowering, so evaluation, short-circuit reads, missing-input faults,
-        // and trace text stay byte-identical to the hand-written form (the
-        // exactly_one integration tests check sugar against the manual
-        // expansion over every Boolean assignment and for short-circuit and
-        // missing-input-fault behavior).
+        // ~n² expansion. The spec's `to_model` performs the same flat
+        // Or-of-And-of-Nots lowering this arm used to do inline, so
+        // evaluation, short-circuit reads, missing-input faults, and trace
+        // text are unchanged from the pre-first-class sugar. Outcomes and
+        // faults also match hand-written expansions on every input (the
+        // exactly_one integration tests check exactly that); trace text does
+        // not match the manual form byte-for-byte, because hand-chained
+        // and/or nest binary while this lowering is flat n-ary.
         Expr::Call { func, args } => match func.as_str() {
             "exactly_one" => {
                 if args.len() < 2 {

--- a/src/rulespec.rs
+++ b/src/rulespec.rs
@@ -3211,7 +3211,9 @@ fn rewrite_relation_alias_in_judgment(
                 *relation = relation_name.to_string();
             }
         }
-        JudgmentExprSpec::And { items } | JudgmentExprSpec::Or { items } => {
+        JudgmentExprSpec::And { items }
+        | JudgmentExprSpec::Or { items }
+        | JudgmentExprSpec::ExactlyOne { items } => {
             for item in items {
                 rewrite_relation_alias_in_judgment(item, alias, relation_name);
             }
@@ -3499,7 +3501,9 @@ fn collect_judgment_relation_names(expr: &JudgmentExprSpec, names: &mut HashSet<
             collect_scalar_relation_names(left, names);
             collect_scalar_relation_names(right, names);
         }
-        JudgmentExprSpec::And { items } | JudgmentExprSpec::Or { items } => {
+        JudgmentExprSpec::And { items }
+        | JudgmentExprSpec::Or { items }
+        | JudgmentExprSpec::ExactlyOne { items } => {
             for item in items {
                 collect_judgment_relation_names(item, names);
             }
@@ -3725,7 +3729,9 @@ fn rewrite_judgment_relation_references(
         JudgmentExprSpec::RelationMember { relation, .. } => {
             rewrite_relation_name(relation, origin_target, rewrites);
         }
-        JudgmentExprSpec::And { items } | JudgmentExprSpec::Or { items } => {
+        JudgmentExprSpec::And { items }
+        | JudgmentExprSpec::Or { items }
+        | JudgmentExprSpec::ExactlyOne { items } => {
             for item in items {
                 rewrite_judgment_relation_references(
                     item,
@@ -3806,11 +3812,11 @@ fn judgment_uses_imported_derived(
             derived_reference_is_imported(name, origin_target, derived_origin_targets)
         }
         JudgmentExprSpec::RelationMember { .. } => false,
-        JudgmentExprSpec::And { items } | JudgmentExprSpec::Or { items } => {
-            items.iter().any(|item| {
-                judgment_uses_imported_derived(item, origin_target, derived_origin_targets)
-            })
-        }
+        JudgmentExprSpec::And { items }
+        | JudgmentExprSpec::Or { items }
+        | JudgmentExprSpec::ExactlyOne { items } => items.iter().any(|item| {
+            judgment_uses_imported_derived(item, origin_target, derived_origin_targets)
+        }),
         JudgmentExprSpec::Not { item } => {
             judgment_uses_imported_derived(item, origin_target, derived_origin_targets)
         }

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -1199,10 +1199,14 @@ pub enum JudgmentExprSpec {
     },
     /// Holds when exactly one item holds. First-class in the serialized
     /// surface so artifacts and graph consumers see one n-input gate;
-    /// `to_model` lowers it to the Or-of-And-of-Nots expansion, so
-    /// evaluation, short-circuit reads, missing-input faults, and trace
-    /// text are byte-identical to the hand-written form. Expression-level,
-    /// additive to the serialized surface — no artifact-format-version bump.
+    /// `to_model` lowers it to the flat Or-of-And-of-Nots expansion the
+    /// formula sugar produced before this variant existed, so evaluation,
+    /// short-circuit reads, missing-input faults, and trace text are
+    /// unchanged. Outcomes and faults also match hand-written expansions
+    /// on every input; trace TEXT does not match those byte-for-byte,
+    /// because hand-chained and/or nest as binary pairs while this
+    /// lowering is flat n-ary. Expression-level, additive to the
+    /// serialized surface — no artifact-format-version bump.
     ExactlyOne {
         items: Vec<JudgmentExprSpec>,
     },

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -1197,6 +1197,15 @@ pub enum JudgmentExprSpec {
     Not {
         item: Box<JudgmentExprSpec>,
     },
+    /// Holds when exactly one item holds. First-class in the serialized
+    /// surface so artifacts and graph consumers see one n-input gate;
+    /// `to_model` lowers it to the Or-of-And-of-Nots expansion, so
+    /// evaluation, short-circuit reads, missing-input faults, and trace
+    /// text are byte-identical to the hand-written form. Expression-level,
+    /// additive to the serialized surface — no artifact-format-version bump.
+    ExactlyOne {
+        items: Vec<JudgmentExprSpec>,
+    },
 }
 
 impl JudgmentExprSpec {
@@ -1230,6 +1239,31 @@ impl JudgmentExprSpec {
                     .collect::<Result<Vec<JudgmentExpr>, SpecError>>()?,
             )),
             Self::Not { item } => Ok(JudgmentExpr::Not(Box::new(item.to_model()?))),
+            Self::ExactlyOne { items } => {
+                let lowered = items
+                    .iter()
+                    .map(JudgmentExprSpec::to_model)
+                    .collect::<Result<Vec<JudgmentExpr>, SpecError>>()?;
+                Ok(JudgmentExpr::Or(
+                    (0..lowered.len())
+                        .map(|holds| {
+                            JudgmentExpr::And(
+                                lowered
+                                    .iter()
+                                    .enumerate()
+                                    .map(|(position, item)| {
+                                        if position == holds {
+                                            item.clone()
+                                        } else {
+                                            JudgmentExpr::Not(Box::new(item.clone()))
+                                        }
+                                    })
+                                    .collect(),
+                            )
+                        })
+                        .collect(),
+                ))
+            }
         }
     }
 }

--- a/tests/exactly_one.rs
+++ b/tests/exactly_one.rs
@@ -128,7 +128,9 @@ fn run(rulespec: &str, statuses: [bool; 4]) -> JudgmentOutcomeSpec {
 }
 
 #[test]
-fn exactly_one_lowers_to_a_flat_or_of_and_of_nots() {
+fn exactly_one_lowers_to_a_first_class_gate() {
+    // The serialized surface — what artifacts and graph consumers read —
+    // carries one n-input exactly_one node, not the ~n² expansion.
     let program = axiom_rules_engine::rulespec::lower_rulespec_str(SUGARED_RULESPEC)
         .expect("sugared RuleSpec lowers");
     let program = serde_json::to_value(&program).expect("program serialises");
@@ -144,7 +146,6 @@ fn exactly_one_lowers_to_a_flat_or_of_and_of_nots() {
             "right": {"kind": "literal", "value": {"kind": "bool", "value": true}},
         })
     };
-    let not_holds = |name: &str| serde_json::json!({"kind": "not", "item": holds(name)});
     let names = [
         "status_single",
         "status_married_separate",
@@ -152,30 +153,33 @@ fn exactly_one_lowers_to_a_flat_or_of_and_of_nots() {
         "status_head_of_household",
     ];
     let expected = serde_json::json!({
-        "kind": "or",
-        "items": names
-            .iter()
-            .enumerate()
-            .map(|(branch, _)| {
-                serde_json::json!({
-                    "kind": "and",
-                    "items": names
-                        .iter()
-                        .enumerate()
-                        .map(|(position, name)| if position == branch {
-                            holds(name)
-                        } else {
-                            not_holds(name)
-                        })
-                        .collect::<Vec<_>>(),
-                })
-            })
-            .collect::<Vec<_>>(),
+        "kind": "exactly_one",
+        "items": names.iter().map(|name| holds(name)).collect::<Vec<_>>(),
     });
     assert_eq!(
         expr, &expected,
-        "exactly_one must lower to one flat Or over n And-of-Nots branches",
+        "exactly_one must serialise as one first-class gate with n inputs",
     );
+}
+
+#[test]
+fn structured_exactly_one_yaml_round_trips_and_matches_the_sugar() {
+    // The structured spec surface accepts kind: exactly_one directly, and a
+    // structured judgment behaves identically to the formula sugar.
+    use axiom_rules_engine::spec::JudgmentExprSpec;
+    let yaml = r#"
+kind: exactly_one
+items:
+  - kind: derived
+    name: a
+  - kind: derived
+    name: b
+"#;
+    let parsed: JudgmentExprSpec =
+        serde_yaml::from_str(yaml).expect("structured exactly_one parses");
+    let back = serde_json::to_value(&parsed).expect("re-serialises");
+    assert_eq!(back["kind"], "exactly_one");
+    assert_eq!(back["items"].as_array().map(Vec::len), Some(2));
 }
 
 #[test]


### PR DESCRIPTION
Route 2 of #142, Max-commissioned. The #144 sugar desugared at formula lowering, so artifacts carried the ~n² expansion and the graph rendered sixteen wires for the DC filing-status shape. Now:

- `JudgmentExprSpec::ExactlyOne { items }` — first-class in the serialized surface; `to_model()` performs the same Or-of-And-of-Nots lowering #144 did at the formula layer, so the **model is unchanged**: outcomes, short-circuit reads, missing-input faults, and trace text are byte-identical by construction (the untouched equivalence suite passes as-is).
- Formula `exactly_one(...)` now lowers to the node; all seven items-walkers (compile dependency extraction ×3, rulespec alias/validation walkers ×4 — one previously behind a wildcard) treat it like `and`/`or`.
- Additive serialized-surface change per the over-periods precedent — no artifact-format-version bump; compiled-artifact v2 schema regenerated (+29 lines, v1 and the authoring-module schema byte-identical).
- Tests: the lowering-shape test now asserts the single gate; new structured-YAML round-trip; the exhaustive Boolean-assignment and fault-parity suites pass **unmodified**. 279 tests green with schema features; fmt clean.
- Docs updated to the new truth (rulespec.md mutual-exclusivity, format-reference bullet + lowered-vocabulary list).

Consumer follow-ups (small, next PRs): axiom-api runtime-graph render() gains an `exactly_one` case so formula strings say `exactly_one(a, b, …)`; the viewers already render function calls as one operator node with n input wires (InteractiveRuleGraph.tsx call case) and just gain verdict coloring + client eval. Adoption in encodings tracked at axiom-encode#1336.

🤖 Generated with [Claude Code](https://claude.com/claude-code)