### PR TITLE
migrate scan: inventory hand-expanded exactly-one patterns

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ pub mod compile;
 pub mod dense;
 pub mod engine;
 mod formula;
+pub mod migrate;
 pub mod model;
 pub mod rulespec;
 #[cfg(feature = "schema")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -332,6 +332,7 @@ fn run_migrate(args: Vec<String>) -> Result<(), Box<dyn std::error::Error>> {
                     "rule": hit.rule,
                     "site": hit.site,
                     "arity": hit.arity,
+                    "idiom": hit.idiom,
                 }))
                 .collect::<Vec<_>>(),
             "unscanned": unscanned
@@ -345,8 +346,8 @@ fn run_migrate(args: Vec<String>) -> Result<(), Box<dyn std::error::Error>> {
 
     for (file, hit) in &hits {
         println!(
-            "{file}: rule `{}` {} (arity {})",
-            hit.rule, hit.site, hit.arity
+            "{file}: rule `{}` {} (arity {}, {})",
+            hit.rule, hit.site, hit.arity, hit.idiom
         );
     }
     println!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,6 +37,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
             "run-compiled" => return run_compiled(args.collect()),
             #[cfg(feature = "schema")]
             "emit-schemas" => return run_emit_schemas(args.collect()),
+            "migrate" => return run_migrate(args.collect()),
             _ => return Err(format!("unknown command `{command}`\n\n{TOP_USAGE}").into()),
         }
     }
@@ -113,6 +114,8 @@ commands:
                     axiom-compose.
   run-compiled      Execute a compiled artifact against a JSON request on stdin.
   emit-schemas      Write JSON Schemas for the wire types (schema feature only).
+  migrate           Corpus-migration tooling; `migrate scan <path>...` inventories
+                    hand-expanded exactly-one patterns (#152).
   version           Print the engine version.
   help              Print this message.
 
@@ -265,6 +268,122 @@ fn run_emit_schemas(args: Vec<String>) -> Result<(), Box<dyn std::error::Error>>
     let written = axiom_rules_engine::schema::write_all_to_dir(&out_dir)?;
     for path in written {
         println!("wrote {}", path.display());
+    }
+    Ok(())
+}
+
+/// `migrate scan <file-or-dir>...`: inventory hand-expanded exactly-one
+/// patterns across RuleSpec sources. Detection lowers each module through the
+/// real loader and walks the serialized spec (see `migrate`); files that do
+/// not lower standalone are reported as unscanned, never as pattern-free.
+fn run_migrate(args: Vec<String>) -> Result<(), Box<dyn std::error::Error>> {
+    let mut args = args.into_iter();
+    match args.next().as_deref() {
+        Some("scan") => {}
+        Some(other) => return Err(format!("unknown migrate subcommand `{other}`").into()),
+        None => return Err("usage: migrate scan [--json] <file-or-dir>...".into()),
+    }
+    let mut json = false;
+    let mut roots: Vec<PathBuf> = Vec::new();
+    for arg in args {
+        if arg == "--json" {
+            json = true;
+        } else {
+            roots.push(PathBuf::from(arg));
+        }
+    }
+    if roots.is_empty() {
+        return Err("usage: migrate scan [--json] <file-or-dir>...".into());
+    }
+
+    let mut files: Vec<PathBuf> = Vec::new();
+    for root in &roots {
+        collect_yaml_files(root, &mut files)?;
+    }
+    files.sort();
+
+    let mut hits: Vec<(String, axiom_rules_engine::migrate::ExpandedExactlyOne)> = Vec::new();
+    let mut unscanned: Vec<(String, String)> = Vec::new();
+    let mut scanned = 0usize;
+    for file in &files {
+        let source = std::fs::read_to_string(file)?;
+        if !source.contains("format: rulespec/v1") {
+            continue;
+        }
+        let shown = file.display().to_string();
+        match axiom_rules_engine::migrate::scan_source(&source) {
+            Ok(found) => {
+                scanned += 1;
+                for hit in found {
+                    hits.push((shown.clone(), hit));
+                }
+            }
+            Err(error) => unscanned.push((shown, error.to_string())),
+        }
+    }
+
+    if json {
+        let payload = serde_json::json!({
+            "scanned_modules": scanned,
+            "hits": hits
+                .iter()
+                .map(|(file, hit)| serde_json::json!({
+                    "file": file,
+                    "rule": hit.rule,
+                    "site": hit.site,
+                    "arity": hit.arity,
+                }))
+                .collect::<Vec<_>>(),
+            "unscanned": unscanned
+                .iter()
+                .map(|(file, error)| serde_json::json!({"file": file, "error": error}))
+                .collect::<Vec<_>>(),
+        });
+        println!("{}", serde_json::to_string_pretty(&payload)?);
+        return Ok(());
+    }
+
+    for (file, hit) in &hits {
+        println!(
+            "{file}: rule `{}` {} (arity {})",
+            hit.rule, hit.site, hit.arity
+        );
+    }
+    println!(
+        "scanned {scanned} modules: {} hand-expanded exactly-one site(s), {} unscanned",
+        hits.len(),
+        unscanned.len(),
+    );
+    for (file, error) in &unscanned {
+        eprintln!("unscanned {file}: {error}");
+    }
+    Ok(())
+}
+
+/// Recursively collect `.yaml` sources under `root`, skipping companion test
+/// files and dot-directories.
+fn collect_yaml_files(
+    root: &std::path::Path,
+    files: &mut Vec<PathBuf>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    if root.is_file() {
+        files.push(root.to_path_buf());
+        return Ok(());
+    }
+    for entry in std::fs::read_dir(root)? {
+        let path = entry?.path();
+        let name = path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or_default();
+        if name.starts_with('.') {
+            continue;
+        }
+        if path.is_dir() {
+            collect_yaml_files(&path, files)?;
+        } else if name.ends_with(".yaml") && !name.ends_with(".test.yaml") {
+            files.push(path);
+        }
     }
     Ok(())
 }

--- a/src/migrate.rs
+++ b/src/migrate.rs
@@ -1,0 +1,180 @@
+//! Corpus migrations: engine-versioned codemods with machine-checked gates.
+//!
+//! A migration pairs a detector (spec-level, via the engine's own lowering —
+//! never text patterns) with a rewriter and an equivalence gate. This module
+//! carries the detector side; see the corpus-migrations design (#152).
+//!
+//! The pilot detector finds hand-expanded exactly-one patterns: an `or` whose
+//! n branches are each an `and` of the same n base judgments, branch i
+//! asserting base i and negating the rest — the shape `exactly_one(...)`
+//! replaces (#142). Detection walks the serialized `ProgramSpec` JSON, the
+//! same `kind:`-tagged form compiled artifacts carry, so structural equality
+//! of base judgments is exact serialization equality.
+
+use serde_json::Value;
+
+use crate::rulespec::{RuleSpecError, lower_rulespec_str};
+
+/// One detected hand-expanded exactly-one site.
+#[derive(Debug, Clone, PartialEq, serde::Serialize)]
+pub struct ExpandedExactlyOne {
+    /// Name of the derived rule the expression belongs to.
+    pub rule: String,
+    /// Where in the rule the expression sits: `expr` or `versions[i].expr`.
+    pub site: String,
+    /// Number of mutually exclusive base judgments.
+    pub arity: usize,
+}
+
+/// Scan one RuleSpec module source for hand-expanded exactly-one patterns.
+///
+/// Lowers through the real loader; a source that does not lower is the
+/// caller's to report as unscanned rather than silently pattern-free.
+pub fn scan_source(source: &str) -> Result<Vec<ExpandedExactlyOne>, RuleSpecError> {
+    let program = lower_rulespec_str(source)?;
+    let value = serde_json::to_value(&program)
+        .expect("ProgramSpec serialization is infallible for lowered programs");
+    let mut found = Vec::new();
+    if let Some(derived) = value.get("derived").and_then(Value::as_array) {
+        for rule in derived {
+            let name = rule
+                .get("name")
+                .and_then(Value::as_str)
+                .unwrap_or("<unnamed>")
+                .to_string();
+            // Versions are the authored surface; the rule-level `expr`
+            // mirrors one of them, so scanning both would double-count.
+            let versions = rule.get("versions").and_then(Value::as_array);
+            match versions {
+                Some(versions) if !versions.is_empty() => {
+                    for (index, version) in versions.iter().enumerate() {
+                        if let Some(expr) = version.get("expr") {
+                            collect_sites(
+                                expr,
+                                &name,
+                                &format!("versions[{index}].expr"),
+                                &mut found,
+                            );
+                        }
+                    }
+                }
+                _ => {
+                    if let Some(expr) = rule.get("expr") {
+                        collect_sites(expr, &name, "expr", &mut found);
+                    }
+                }
+            }
+        }
+    }
+    Ok(found)
+}
+
+fn collect_sites(value: &Value, rule: &str, site: &str, found: &mut Vec<ExpandedExactlyOne>) {
+    if let Some((arity, bases)) = expanded_exactly_one(value) {
+        found.push(ExpandedExactlyOne {
+            rule: rule.to_string(),
+            site: site.to_string(),
+            arity,
+        });
+        // The branches of a detected expansion are its own machinery; only
+        // the base judgments can legitimately contain further candidates.
+        for base in bases {
+            collect_sites(base, rule, site, found);
+        }
+        return;
+    }
+    // Only MAXIMAL and/or chains are candidates: descend to the flattened
+    // leaves of a chain, never into intermediate same-kind nodes, so a
+    // proper sub-chain of a wider `or` cannot fire as its own gate.
+    for kind in ["or", "and"] {
+        if let Some(leaves) = flatten_chain(value, kind) {
+            for leaf in leaves {
+                collect_sites(leaf, rule, site, found);
+            }
+            return;
+        }
+    }
+    match value {
+        Value::Object(map) => {
+            for child in map.values() {
+                collect_sites(child, rule, site, found);
+            }
+        }
+        Value::Array(items) => {
+            for child in items {
+                collect_sites(child, rule, site, found);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Returns the arity and base judgments when `value` is an or-chain of n
+/// and-chains over the same n base judgments in the canonical exactly-one
+/// expansion shape. Hand-chained `and`/`or` lower as nested binary pairs, so
+/// both chains are flattened associatively before the shape check — the flat
+/// n-ary form (which only the retired inline desugar produced) matches too.
+fn expanded_exactly_one(value: &Value) -> Option<(usize, Vec<&Value>)> {
+    let branches = flatten_chain(value, "or")?;
+    let n = branches.len();
+    if n < 2 {
+        return None;
+    }
+    let first = flatten_chain(branches[0], "and")?;
+    if first.len() != n {
+        return None;
+    }
+    // Base judgment j comes from branch 0: positive at position 0, negated
+    // elsewhere. Every base must be extractable or the shape does not match.
+    let mut base: Vec<&Value> = Vec::with_capacity(n);
+    for (position, item) in first.iter().enumerate() {
+        if position == 0 {
+            base.push(item);
+        } else {
+            base.push(not_item(item)?);
+        }
+    }
+    for (branch_index, branch) in branches.iter().enumerate() {
+        let items = flatten_chain(branch, "and")?;
+        if items.len() != n {
+            return None;
+        }
+        for (position, item) in items.iter().enumerate() {
+            let matches = if position == branch_index {
+                **item == *base[position]
+            } else {
+                not_item(item).is_some_and(|inner| *inner == *base[position])
+            };
+            if !matches {
+                return None;
+            }
+        }
+    }
+    Some((n, base))
+}
+
+/// Flatten an associative `and`/`or` chain into its leaves, in source order.
+/// Nested binary nodes of the same kind dissolve; anything else is a leaf.
+fn flatten_chain<'v>(value: &'v Value, kind: &str) -> Option<Vec<&'v Value>> {
+    let map = value.as_object()?;
+    if map.get("kind")?.as_str()? != kind {
+        return None;
+    }
+    let items = map.get("items")?.as_array()?;
+    let mut leaves = Vec::new();
+    for item in items {
+        match flatten_chain(item, kind) {
+            Some(nested) => leaves.extend(nested),
+            None => leaves.push(item),
+        }
+    }
+    Some(leaves)
+}
+
+fn not_item(value: &Value) -> Option<&Value> {
+    let map = value.as_object()?;
+    if map.get("kind")?.as_str()? != "not" {
+        return None;
+    }
+    map.get("item")
+}

--- a/src/migrate.rs
+++ b/src/migrate.rs
@@ -24,6 +24,11 @@ pub struct ExpandedExactlyOne {
     pub site: String,
     /// Number of mutually exclusive base judgments.
     pub arity: usize,
+    /// Which hand-written idiom matched: `or_of_ands` (branch i asserts base
+    /// i, negates the rest) or `pairwise_exclusions` (a disjunction of the
+    /// bases conjoined with NOT terms forbidding every unordered pair —
+    /// covers both the flat all-pairs and the factored triangular forms).
+    pub idiom: &'static str,
 }
 
 /// Scan one RuleSpec module source for hand-expanded exactly-one patterns.
@@ -70,11 +75,17 @@ pub fn scan_source(source: &str) -> Result<Vec<ExpandedExactlyOne>, RuleSpecErro
 }
 
 fn collect_sites(value: &Value, rule: &str, site: &str, found: &mut Vec<ExpandedExactlyOne>) {
-    if let Some((arity, bases)) = expanded_exactly_one(value) {
+    let detected = expanded_exactly_one(value)
+        .map(|(arity, bases)| (arity, bases, "or_of_ands"))
+        .or_else(|| {
+            pairwise_exclusions(value).map(|(arity, bases)| (arity, bases, "pairwise_exclusions"))
+        });
+    if let Some((arity, bases, idiom)) = detected {
         found.push(ExpandedExactlyOne {
             rule: rule.to_string(),
             site: site.to_string(),
             arity,
+            idiom,
         });
         // The branches of a detected expansion are its own machinery; only
         // the base judgments can legitimately contain further candidates.
@@ -151,6 +162,80 @@ fn expanded_exactly_one(value: &Value) -> Option<(usize, Vec<&Value>)> {
         }
     }
     Some((n, base))
+}
+
+/// Returns the arity and bases when `value` is the disjunction+exclusions
+/// idiom: an and-chain containing exactly one or-chain over n distinct bases
+/// (at least one holds) plus NOT terms whose forbidden pairs cover every
+/// unordered pair of bases (at most one holds) — and nothing else. Each NOT
+/// body must be `x and y` or `x and (y1 or y2 or ...)` with every operand a
+/// base; coverage is checked as a set, so the flat all-pairs form and the
+/// factored triangular form both match, in any order.
+fn pairwise_exclusions(value: &Value) -> Option<(usize, Vec<&Value>)> {
+    let leaves = flatten_chain(value, "and")?;
+    let mut bases: Option<Vec<&Value>> = None;
+    let mut exclusion_bodies: Vec<&Value> = Vec::new();
+    for leaf in &leaves {
+        if flatten_chain(leaf, "or").is_some() {
+            if bases.is_some() {
+                return None;
+            }
+            bases = Some(flatten_chain(leaf, "or")?);
+        } else if let Some(body) = not_item(leaf) {
+            exclusion_bodies.push(body);
+        } else {
+            return None;
+        }
+    }
+    let bases = bases?;
+    let n = bases.len();
+    if n < 2 || exclusion_bodies.is_empty() {
+        return None;
+    }
+    let keys: Vec<String> = bases.iter().map(|base| base.to_string()).collect();
+    let index_of = |value: &Value| -> Option<usize> {
+        let key = value.to_string();
+        keys.iter().position(|candidate| *candidate == key)
+    };
+    if keys.iter().collect::<std::collections::HashSet<_>>().len() != n {
+        return None;
+    }
+    let mut covered = std::collections::HashSet::new();
+    for body in exclusion_bodies {
+        let pair = flatten_chain(body, "and")?;
+        if pair.len() != 2 {
+            return None;
+        }
+        // Accept either orientation: `x and (…)` or `(…) and x`.
+        let (single, group) = if index_of(pair[0]).is_some() {
+            (pair[0], pair[1])
+        } else {
+            (pair[1], pair[0])
+        };
+        let left = index_of(single)?;
+        match flatten_chain(group, "or") {
+            Some(rest) => {
+                for member in rest {
+                    let right = index_of(member)?;
+                    if right == left {
+                        return None;
+                    }
+                    covered.insert((left.min(right), left.max(right)));
+                }
+            }
+            None => {
+                let right = index_of(group)?;
+                if right == left {
+                    return None;
+                }
+                covered.insert((left.min(right), left.max(right)));
+            }
+        }
+    }
+    if covered.len() != n * (n - 1) / 2 {
+        return None;
+    }
+    Some((n, bases))
 }
 
 /// Flatten an associative `and`/`or` chain into its leaves, in source order.

--- a/tests/migrate_scan.rs
+++ b/tests/migrate_scan.rs
@@ -1,0 +1,131 @@
+//! The migrate-scan detector must find real hand-written expansions (which
+//! lower as nested binary and/or chains), ignore already-migrated sugar, and
+//! refuse near-miss shapes.
+
+use axiom_rules_engine::migrate::scan_source;
+
+const HAND_EXPANDED: &str = r#"
+format: rulespec/v1
+rules:
+  - name: filing_status_is_valid
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    versions:
+      - effective_from: 2026-01-01
+        formula: |-
+          (
+            status_single
+            and not status_married_separate
+            and not status_joint
+            and not status_head_of_household
+          )
+          or (
+            not status_single
+            and status_married_separate
+            and not status_joint
+            and not status_head_of_household
+          )
+          or (
+            not status_single
+            and not status_married_separate
+            and status_joint
+            and not status_head_of_household
+          )
+          or (
+            not status_single
+            and not status_married_separate
+            and not status_joint
+            and status_head_of_household
+          )
+"#;
+
+#[test]
+fn finds_the_hand_expanded_shape_through_binary_nesting() {
+    let hits = scan_source(HAND_EXPANDED).expect("module lowers");
+    assert_eq!(hits.len(), 1, "exactly one site: {hits:?}");
+    assert_eq!(hits[0].rule, "filing_status_is_valid");
+    assert_eq!(hits[0].site, "versions[0].expr");
+    assert_eq!(hits[0].arity, 4);
+}
+
+#[test]
+fn ignores_already_migrated_sugar() {
+    let rulespec = r#"
+format: rulespec/v1
+rules:
+  - name: filing_status_is_valid
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    versions:
+      - effective_from: 2026-01-01
+        formula: exactly_one(status_single, status_married_separate, status_joint, status_head_of_household)
+"#;
+    let hits = scan_source(rulespec).expect("module lowers");
+    assert!(hits.is_empty(), "sugar is not a candidate: {hits:?}");
+}
+
+#[test]
+fn finds_the_minimum_arity_pair() {
+    let rulespec = r#"
+format: rulespec/v1
+rules:
+  - name: one_election
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    versions:
+      - effective_from: 2026-01-01
+        formula: |-
+          (takes_standard_deduction and not itemizes)
+          or (not takes_standard_deduction and itemizes)
+"#;
+    let hits = scan_source(rulespec).expect("module lowers");
+    assert_eq!(hits.len(), 1);
+    assert_eq!(hits[0].arity, 2);
+}
+
+#[test]
+fn refuses_or_of_ands_that_is_not_exactly_one() {
+    // Overlapping branches: no negations of the complement set.
+    let rulespec = r#"
+format: rulespec/v1
+rules:
+  - name: any_route_applies
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    versions:
+      - effective_from: 2026-01-01
+        formula: |-
+          (is_elderly and has_income)
+          or (is_disabled and has_income)
+"#;
+    let hits = scan_source(rulespec).expect("module lowers");
+    assert!(
+        hits.is_empty(),
+        "overlapping branches are not a gate: {hits:?}"
+    );
+}
+
+#[test]
+fn refuses_mismatched_branch_and_base_counts() {
+    // Three branches over two bases (an at-least pattern, not exactly-one).
+    let rulespec = r#"
+format: rulespec/v1
+rules:
+  - name: lopsided
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    versions:
+      - effective_from: 2026-01-01
+        formula: |-
+          (a and not b)
+          or (not a and b)
+          or (a and b)
+"#;
+    let hits = scan_source(rulespec).expect("module lowers");
+    assert!(hits.is_empty(), "three branches over two bases: {hits:?}");
+}

--- a/tests/migrate_scan.rs
+++ b/tests/migrate_scan.rs
@@ -129,3 +129,100 @@ rules:
     let hits = scan_source(rulespec).expect("module lowers");
     assert!(hits.is_empty(), "three branches over two bases: {hits:?}");
 }
+
+#[test]
+fn finds_the_flat_pairwise_exclusion_idiom() {
+    // The Hawaii/Wisconsin shape: disjunction of the statuses, then a NOT
+    // for every unordered pair.
+    let rulespec = r#"
+format: rulespec/v1
+rules:
+  - name: filing_status_is_valid
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    versions:
+      - effective_from: 2026-01-01
+        formula: |-
+          (a or b or c or d)
+          and not (a and b)
+          and not (a and c)
+          and not (a and d)
+          and not (b and c)
+          and not (b and d)
+          and not (c and d)
+"#;
+    let hits = scan_source(rulespec).expect("module lowers");
+    assert_eq!(hits.len(), 1, "{hits:?}");
+    assert_eq!(hits[0].idiom, "pairwise_exclusions");
+    assert_eq!(hits[0].arity, 4);
+}
+
+#[test]
+fn finds_the_factored_triangular_exclusion_idiom() {
+    // The North Dakota shape: each status excludes the ones after it.
+    let rulespec = r#"
+format: rulespec/v1
+rules:
+  - name: filing_status_is_valid
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    versions:
+      - effective_from: 2026-01-01
+        formula: |-
+          (a or b or c or d)
+          and not (a and (b or c or d))
+          and not (b and (c or d))
+          and not (c and d)
+"#;
+    let hits = scan_source(rulespec).expect("module lowers");
+    assert_eq!(hits.len(), 1, "{hits:?}");
+    assert_eq!(hits[0].idiom, "pairwise_exclusions");
+    assert_eq!(hits[0].arity, 4);
+}
+
+#[test]
+fn refuses_incomplete_pair_coverage() {
+    // Missing not(c and d): at-most-one does not hold, so this is not a gate.
+    let rulespec = r#"
+format: rulespec/v1
+rules:
+  - name: leaky
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    versions:
+      - effective_from: 2026-01-01
+        formula: |-
+          (a or b or c or d)
+          and not (a and (b or c or d))
+          and not (b and (c or d))
+"#;
+    let hits = scan_source(rulespec).expect("module lowers");
+    assert!(
+        hits.is_empty(),
+        "incomplete coverage is not a gate: {hits:?}"
+    );
+}
+
+#[test]
+fn refuses_pairwise_shape_with_extra_conjuncts() {
+    // A residency conjunct rides along: the chain is not a pure gate.
+    let rulespec = r#"
+format: rulespec/v1
+rules:
+  - name: entangled
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    versions:
+      - effective_from: 2026-01-01
+        formula: |-
+          is_resident
+          and (a or b)
+          and not (a and b)
+"#;
+    let hits = scan_source(rulespec).expect("module lowers");
+    assert!(hits.is_empty(), "extra conjuncts are not a gate: {hits:?}");
+}


### PR DESCRIPTION
First piece of #152 (corpus migrations, Max-ratified design): the detector and its CLI. `migrate scan [--json] <file-or-dir>...` lowers every RuleSpec module through the real loader and walks the serialized spec — never text patterns — for the canonical exactly-one expansion: an or-chain of n and-chains over the same n base judgments, branch i positive at i and negated elsewhere.

What the tests pinned (and caught during development):
- Hand-chained `and`/`or` lower as **nested binary** pairs, so the detector flattens associative chains before shape-checking — the naive flat-shape detector matches only the retired inline desugar and finds zero real expansions.
- Only **maximal** chains are candidates: a proper sub-chain of a wider `or` is structurally a perfect smaller gate (the lopsided three-branch case's first two branches form an XOR) and must not fire.
- Versions are the authored surface; the rule-level `expr` mirrors one, so scanning both double-counts.
- Already-migrated sugar (`exactly_one` nodes) is not a candidate; overlapping or-of-ands and branch/base count mismatches are refused.

5/5 detector tests; full suite green with schema features; fmt clean. Rewriter + model-equality gate are the next piece; this lands first so the wave decision is made against a real corpus count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)