### PR TITLE
migrate apply: gated exactly-one rewrites

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -280,8 +280,14 @@ fn run_migrate(args: Vec<String>) -> Result<(), Box<dyn std::error::Error>> {
     let mut args = args.into_iter();
     match args.next().as_deref() {
         Some("scan") => {}
+        Some("apply") => return run_migrate_apply(args.collect()),
         Some(other) => return Err(format!("unknown migrate subcommand `{other}`").into()),
-        None => return Err("usage: migrate scan [--json] <file-or-dir>...".into()),
+        None => {
+            return Err(
+                "usage: migrate scan [--json] <file-or-dir>... | migrate apply [--json] [--write] <file-or-dir>..."
+                    .into(),
+            );
+        }
     }
     let mut json = false;
     let mut roots: Vec<PathBuf> = Vec::new();
@@ -386,5 +392,131 @@ fn collect_yaml_files(
             files.push(path);
         }
     }
+    Ok(())
+}
+
+/// `migrate apply [--json] [--write] <file-or-dir>...`: rewrite detected
+/// hand-expanded exactly-one sites to `exactly_one(...)`, gating every
+/// rewrite on engine-executed behavioral equivalence over all 2^n base
+/// assignments plus a rescan proving the pattern is gone. Dry-run by
+/// default; `--write` saves. Sites with non-fact bases are reported for
+/// hands and left untouched.
+fn run_migrate_apply(args: Vec<String>) -> Result<(), Box<dyn std::error::Error>> {
+    let mut json = false;
+    let mut write = false;
+    let mut roots: Vec<PathBuf> = Vec::new();
+    for arg in args {
+        match arg.as_str() {
+            "--json" => json = true,
+            "--write" => write = true,
+            other => roots.push(PathBuf::from(other)),
+        }
+    }
+    if roots.is_empty() {
+        return Err("usage: migrate apply [--json] [--write] <file-or-dir>...".into());
+    }
+    let mut files: Vec<PathBuf> = Vec::new();
+    for root in &roots {
+        collect_yaml_files(root, &mut files)?;
+    }
+    files.sort();
+
+    let mut reports: Vec<serde_json::Value> = Vec::new();
+    let mut rewritten_files = 0usize;
+    let mut gated_ok = 0usize;
+    let mut manual_total = 0usize;
+    for file in &files {
+        let original = std::fs::read_to_string(file)?;
+        if !original.contains("format: rulespec/v1") {
+            continue;
+        }
+        let shown = file.display().to_string();
+        let mut source = original.clone();
+        loop {
+            let (plans, manual) = match axiom_rules_engine::migrate::plan_rewrites(&source) {
+                Ok(result) => result,
+                Err(error) => {
+                    reports.push(serde_json::json!({
+                        "file": shown, "unscanned": error.to_string(),
+                    }));
+                    break;
+                }
+            };
+            for site in &manual {
+                manual_total += 1;
+                reports.push(serde_json::json!({
+                    "file": shown, "rule": site.rule, "site": site.site,
+                    "manual": site.reason, "idiom": site.idiom,
+                }));
+            }
+            let Some(plan) = plans.first() else { break };
+            let version_index: usize = plan
+                .site
+                .trim_start_matches("versions[")
+                .trim_end_matches("].expr")
+                .parse()
+                .map_err(|_| format!("unparseable site `{}`", plan.site))?;
+            let old_formula = axiom_rules_engine::migrate::extract_version_formula(
+                &source,
+                &plan.rule,
+                version_index,
+            )
+            .ok_or_else(|| format!("{shown}: cannot locate formula for `{}`", plan.rule))?;
+            let gate = axiom_rules_engine::migrate::gate_rewrite(
+                &old_formula,
+                &plan.replacement,
+                &plan.bases,
+            )
+            .map_err(|error| format!("{shown}: gate failed for `{}`: {error}", plan.rule))?;
+            if !(gate.outcomes_match && gate.rescan_clean) {
+                return Err(format!(
+                    "{shown}: gate REFUSED `{}` ({} assignments, outcomes_match={}, rescan_clean={})",
+                    plan.rule, gate.assignments, gate.outcomes_match, gate.rescan_clean
+                )
+                .into());
+            }
+            gated_ok += 1;
+            reports.push(serde_json::json!({
+                "file": shown, "rule": plan.rule, "site": plan.site,
+                "idiom": plan.idiom, "arity": plan.arity,
+                "replacement": plan.replacement,
+                "gate": {"assignments": gate.assignments, "outcomes_match": true, "rescan_clean": true},
+            }));
+            source = axiom_rules_engine::migrate::replace_version_formula(
+                &source,
+                &plan.rule,
+                version_index,
+                &plan.replacement,
+            )
+            .ok_or_else(|| format!("{shown}: text surgery failed for `{}`", plan.rule))?;
+        }
+        if source != original {
+            rewritten_files += 1;
+            if write {
+                std::fs::write(file, &source)?;
+            }
+        }
+    }
+
+    if json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&serde_json::json!({
+                "mode": if write { "write" } else { "dry-run" },
+                "rewrites_gated": gated_ok,
+                "files_rewritten": rewritten_files,
+                "manual_sites": manual_total,
+                "reports": reports,
+            }))?
+        );
+        return Ok(());
+    }
+    for report in &reports {
+        println!("{report}");
+    }
+    println!(
+        "{}: {gated_ok} rewrite(s) across {rewritten_files} file(s), {manual_total} manual site(s)",
+        if write { "written" } else { "dry-run" },
+    );
     Ok(())
 }

--- a/src/migrate.rs
+++ b/src/migrate.rs
@@ -263,3 +263,389 @@ fn not_item(value: &Value) -> Option<&Value> {
     }
     map.get("item")
 }
+
+/// A planned rewrite of one detected site into `exactly_one(...)`.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct RewritePlan {
+    pub rule: String,
+    pub site: String,
+    pub arity: usize,
+    pub idiom: &'static str,
+    /// Base judgments as bare fact names, in read order.
+    pub bases: Vec<String>,
+    /// The replacement formula source.
+    pub replacement: String,
+}
+
+/// A site that cannot be rewritten mechanically and stays for hands.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct ManualSite {
+    pub rule: String,
+    pub site: String,
+    pub arity: usize,
+    pub idiom: &'static str,
+    pub reason: String,
+}
+
+/// Plan `exactly_one` rewrites for every detected site whose bases are all
+/// bare fact references; anything richer is reported for hands, never
+/// guessed at.
+pub fn plan_rewrites(source: &str) -> Result<(Vec<RewritePlan>, Vec<ManualSite>), RuleSpecError> {
+    let program = lower_rulespec_str(source)?;
+    let value = serde_json::to_value(&program)
+        .expect("ProgramSpec serialization is infallible for lowered programs");
+    let mut plans = Vec::new();
+    let mut manual = Vec::new();
+    if let Some(derived) = value.get("derived").and_then(Value::as_array) {
+        for rule in derived {
+            let name = rule
+                .get("name")
+                .and_then(Value::as_str)
+                .unwrap_or("<unnamed>")
+                .to_string();
+            let Some(versions) = rule.get("versions").and_then(Value::as_array) else {
+                continue;
+            };
+            for (index, version) in versions.iter().enumerate() {
+                let Some(expr) = version.get("expr") else {
+                    continue;
+                };
+                let site = format!("versions[{index}].expr");
+                let detected = expanded_exactly_one(expr)
+                    .map(|(arity, bases)| (arity, bases, "or_of_ands"))
+                    .or_else(|| {
+                        pairwise_exclusions(expr)
+                            .map(|(arity, bases)| (arity, bases, "pairwise_exclusions"))
+                    });
+                let Some((arity, bases, idiom)) = detected else {
+                    continue;
+                };
+                match bases
+                    .iter()
+                    .map(|base| base_fact_name(base))
+                    .collect::<Option<Vec<_>>>()
+                {
+                    Some(names) => {
+                        let replacement = format!("exactly_one({})", names.join(", "));
+                        plans.push(RewritePlan {
+                            rule: name.clone(),
+                            site,
+                            arity,
+                            idiom,
+                            bases: names,
+                            replacement,
+                        });
+                    }
+                    None => manual.push(ManualSite {
+                        rule: name.clone(),
+                        site,
+                        arity,
+                        idiom,
+                        reason: "a base judgment is not a bare fact reference".to_string(),
+                    }),
+                }
+            }
+        }
+    }
+    Ok((plans, manual))
+}
+
+/// Bare fact name behind a base judgment: a derived reference, or the
+/// input/derived `== true` comparison the lowerer builds for bool facts.
+fn base_fact_name(base: &Value) -> Option<String> {
+    let map = base.as_object()?;
+    match map.get("kind")?.as_str()? {
+        "derived" => Some(map.get("name")?.as_str()?.to_string()),
+        "comparison" => {
+            if map.get("op")?.as_str()? != "eq" {
+                return None;
+            }
+            let right = map.get("right")?.as_object()?;
+            if right.get("kind")?.as_str()? != "literal" {
+                return None;
+            }
+            let value = right.get("value")?.as_object()?;
+            if value.get("kind")?.as_str()? != "bool" || value.get("value")? != &Value::Bool(true) {
+                return None;
+            }
+            let left = map.get("left")?.as_object()?;
+            match left.get("kind")?.as_str()? {
+                "input" | "derived" => Some(left.get("name")?.as_str()?.to_string()),
+                _ => None,
+            }
+        }
+        _ => None,
+    }
+}
+
+/// Replace the formula of `rule`'s `versions[index]` in RuleSpec source text,
+/// preserving everything else byte-for-byte. Handles block (`|-`) and inline
+/// scalars. Returns None if the site cannot be located unambiguously.
+pub fn replace_version_formula(
+    source: &str,
+    rule: &str,
+    version_index: usize,
+    replacement: &str,
+) -> Option<String> {
+    let lines: Vec<&str> = source.lines().collect();
+    let rule_marker = format!("- name: {rule}");
+    let rule_start = lines
+        .iter()
+        .position(|line| line.trim_start().starts_with(&rule_marker))?;
+    let rule_indent = indent_of(lines[rule_start]);
+    let rule_end = (rule_start + 1..lines.len())
+        .find(|&i| {
+            let line = lines[i];
+            !line.trim().is_empty()
+                && indent_of(line) <= rule_indent
+                && line.trim_start().starts_with("- ")
+        })
+        .unwrap_or(lines.len());
+
+    // The index-th `- effective_from` item inside this rule's versions list.
+    let mut seen = 0usize;
+    let mut version_start = None;
+    for i in rule_start + 1..rule_end {
+        if lines[i].trim_start().starts_with("- effective_from") {
+            if seen == version_index {
+                version_start = Some(i);
+                break;
+            }
+            seen += 1;
+        }
+    }
+    let version_start = version_start?;
+    let version_indent = indent_of(lines[version_start]);
+    let version_end = (version_start + 1..rule_end)
+        .find(|&i| {
+            let line = lines[i];
+            !line.trim().is_empty() && indent_of(line) <= version_indent
+        })
+        .unwrap_or(rule_end);
+
+    let formula_line =
+        (version_start..version_end).find(|&i| lines[i].trim_start().starts_with("formula:"))?;
+    let key_indent = indent_of(lines[formula_line]);
+    let is_block = lines[formula_line].trim_end().ends_with("|-")
+        || lines[formula_line].trim_end().ends_with('|');
+    let block_end = if is_block {
+        (formula_line + 1..version_end)
+            .find(|&i| {
+                let line = lines[i];
+                !line.trim().is_empty() && indent_of(line) <= key_indent
+            })
+            .unwrap_or(version_end)
+    } else {
+        formula_line + 1
+    };
+
+    let mut out: Vec<String> = Vec::with_capacity(lines.len());
+    out.extend(lines[..formula_line].iter().map(|s| s.to_string()));
+    out.push(format!("{}formula: {replacement}", " ".repeat(key_indent)));
+    out.extend(lines[block_end..].iter().map(|s| s.to_string()));
+    let mut joined = out.join("\n");
+    if source.ends_with('\n') {
+        joined.push('\n');
+    }
+    Some(joined)
+}
+
+fn indent_of(line: &str) -> usize {
+    line.len() - line.trim_start().len()
+}
+
+/// Extract the formula source of `rule`'s `versions[index]` verbatim.
+pub fn extract_version_formula(source: &str, rule: &str, version_index: usize) -> Option<String> {
+    let lines: Vec<&str> = source.lines().collect();
+    let rule_marker = format!("- name: {rule}");
+    let rule_start = lines
+        .iter()
+        .position(|line| line.trim_start().starts_with(&rule_marker))?;
+    let rule_indent = indent_of(lines[rule_start]);
+    let rule_end = (rule_start + 1..lines.len())
+        .find(|&i| {
+            let line = lines[i];
+            !line.trim().is_empty()
+                && indent_of(line) <= rule_indent
+                && line.trim_start().starts_with("- ")
+        })
+        .unwrap_or(lines.len());
+    let mut seen = 0usize;
+    let mut version_start = None;
+    for i in rule_start + 1..rule_end {
+        if lines[i].trim_start().starts_with("- effective_from") {
+            if seen == version_index {
+                version_start = Some(i);
+                break;
+            }
+            seen += 1;
+        }
+    }
+    let version_start = version_start?;
+    let version_indent = indent_of(lines[version_start]);
+    let version_end = (version_start + 1..rule_end)
+        .find(|&i| {
+            let line = lines[i];
+            !line.trim().is_empty() && indent_of(line) <= version_indent
+        })
+        .unwrap_or(rule_end);
+    let formula_line =
+        (version_start..version_end).find(|&i| lines[i].trim_start().starts_with("formula:"))?;
+    let key_indent = indent_of(lines[formula_line]);
+    let trimmed = lines[formula_line].trim_start();
+    if trimmed.trim_end().ends_with("|-") || trimmed.trim_end().ends_with('|') {
+        let block_end = (formula_line + 1..version_end)
+            .find(|&i| {
+                let line = lines[i];
+                !line.trim().is_empty() && indent_of(line) <= key_indent
+            })
+            .unwrap_or(version_end);
+        let body: Vec<&str> = lines[formula_line + 1..block_end].iter().copied().collect();
+        let strip = body
+            .iter()
+            .filter(|line| !line.trim().is_empty())
+            .map(|line| indent_of(line))
+            .min()
+            .unwrap_or(0);
+        Some(
+            body.iter()
+                .map(|line| {
+                    if line.len() >= strip {
+                        &line[strip..]
+                    } else {
+                        line.trim_start()
+                    }
+                })
+                .collect::<Vec<_>>()
+                .join("\n"),
+        )
+    } else {
+        Some(
+            trimmed
+                .trim_start_matches("formula:")
+                .trim()
+                .trim_matches('"')
+                .to_string(),
+        )
+    }
+}
+
+/// Behavioral equivalence report for one rewrite.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct GateReport {
+    pub assignments: usize,
+    pub outcomes_match: bool,
+    pub rescan_clean: bool,
+}
+
+/// Prove old and new formulas agree by executing BOTH through the real
+/// engine over every Boolean assignment of the bases, then rescanning the
+/// rewritten form to confirm the pattern is gone. Read order (and so
+/// missing-input fault order) is preserved by construction: the replacement
+/// lists bases in detection order, which is leaf read order.
+pub fn gate_rewrite(
+    old_formula: &str,
+    replacement: &str,
+    bases: &[String],
+) -> Result<GateReport, String> {
+    use crate::api::{
+        ExecutionMode, ExecutionQuery, ExecutionRequest, OutputValue, execute_request,
+    };
+    use crate::spec::{
+        DatasetSpec, InputRecordSpec, IntervalSpec, PeriodKindSpec, PeriodSpec, ScalarValueSpec,
+    };
+    if bases.len() > 12 {
+        return Err(format!(
+            "gate refuses arity {} (>4096 assignments)",
+            bases.len()
+        ));
+    }
+    let period = PeriodSpec {
+        kind: PeriodKindSpec::Month,
+        start: chrono::NaiveDate::from_ymd_opt(2026, 1, 1).expect("valid date"),
+        end: chrono::NaiveDate::from_ymd_opt(2026, 1, 31).expect("valid date"),
+    };
+    let run = |formula: &str, mask: usize| -> Result<String, String> {
+        let program = lower_rulespec_str(&probe_module(formula))
+            .map_err(|error| format!("probe lowering failed: {error}"))?;
+        let dataset = DatasetSpec {
+            inputs: bases
+                .iter()
+                .enumerate()
+                .map(|(bit, name)| InputRecordSpec {
+                    name: name.clone(),
+                    entity: "Household".to_string(),
+                    entity_id: "probe-1".to_string(),
+                    interval: IntervalSpec {
+                        start: period.start,
+                        end: period.end,
+                    },
+                    value: ScalarValueSpec::Bool {
+                        value: mask & (1 << bit) != 0,
+                    },
+                })
+                .collect(),
+            relations: vec![],
+        };
+        let response = execute_request(ExecutionRequest {
+            mode: ExecutionMode::Explain,
+            program,
+            dataset,
+            queries: vec![ExecutionQuery {
+                assessment_date: None,
+                entity_id: "probe-1".to_string(),
+                period: period.clone(),
+                outputs: vec!["migration_probe".to_string()],
+            }],
+        })
+        .map_err(|error| format!("probe execution failed: {error}"))?;
+        match response.results[0].outputs.get("migration_probe") {
+            Some(OutputValue::Judgment { outcome, .. }) => Ok(format!("{outcome:?}")),
+            other => Err(format!("probe produced no judgment: {other:?}")),
+        }
+    };
+    let assignments = 1usize << bases.len();
+    for mask in 0..assignments {
+        // Outcome-or-error must agree on both sides: a replacement that
+        // stops referencing a base makes the engine reject that input, and
+        // that asymmetry is a gate failure, not a tool crash.
+        let old = run(old_formula, mask);
+        let new = run(replacement, mask);
+        let agree = match (&old, &new) {
+            (Ok(old), Ok(new)) => old == new,
+            (Err(old), Err(new)) => old == new,
+            _ => false,
+        };
+        if !agree {
+            return Ok(GateReport {
+                assignments,
+                outcomes_match: false,
+                rescan_clean: false,
+            });
+        }
+        if let (Err(error), Err(_)) = (&old, &new) {
+            return Err(format!("both probes fail identically: {error}"));
+        }
+    }
+    let rescan_clean = scan_source(&probe_module(replacement))
+        .map(|hits| hits.is_empty())
+        .unwrap_or(false);
+    Ok(GateReport {
+        assignments,
+        outcomes_match: true,
+        rescan_clean,
+    })
+}
+
+fn probe_module(formula: &str) -> String {
+    let body = formula
+        .lines()
+        .map(|line| format!("          {line}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    format!(
+        "format: rulespec/v1\nrules:\n  - name: migration_probe\n    kind: derived\n    \
+         entity: Household\n    dtype: Judgment\n    versions:\n      - effective_from: \
+         2026-01-01\n        formula: |-\n{body}\n"
+    )
+}

--- a/src/migrate.rs
+++ b/src/migrate.rs
@@ -391,7 +391,7 @@ pub fn replace_version_formula(
     let rule_marker = format!("- name: {rule}");
     let rule_start = lines
         .iter()
-        .position(|line| line.trim_start().starts_with(&rule_marker))?;
+        .position(|line| line.trim_start().trim_end() == rule_marker)?;
     let rule_indent = indent_of(lines[rule_start]);
     let rule_end = (rule_start + 1..lines.len())
         .find(|&i| {
@@ -460,7 +460,7 @@ pub fn extract_version_formula(source: &str, rule: &str, version_index: usize) -
     let rule_marker = format!("- name: {rule}");
     let rule_start = lines
         .iter()
-        .position(|line| line.trim_start().starts_with(&rule_marker))?;
+        .position(|line| line.trim_start().trim_end() == rule_marker)?;
     let rule_indent = indent_of(lines[rule_start]);
     let rule_end = (rule_start + 1..lines.len())
         .find(|&i| {

--- a/tests/migrate_scan.rs
+++ b/tests/migrate_scan.rs
@@ -318,3 +318,39 @@ rules:
         assert!(manual[0].reason.contains("not a bare fact reference"));
     }
 }
+
+#[test]
+fn text_surgery_never_anchors_on_a_longer_name_sharing_the_prefix() {
+    use axiom_rules_engine::migrate::{extract_version_formula, replace_version_formula};
+    // `gate_extra` precedes `gate`; a prefix-matched locator would anchor on
+    // the wrong rule. The gate would catch the mismatch loudly, but the
+    // locator must be exact in the first place.
+    let source = r#"
+format: rulespec/v1
+rules:
+  - name: gate_extra
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    versions:
+      - effective_from: 2026-01-01
+        formula: other_fact
+  - name: gate
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    versions:
+      - effective_from: 2026-01-01
+        formula: |-
+          (a and not b) or (not a and b)
+"#;
+    let extracted = extract_version_formula(source, "gate", 0).expect("locates the exact rule");
+    assert!(extracted.contains("(a and not b)"), "got: {extracted}");
+    let rewritten =
+        replace_version_formula(source, "gate", 0, "exactly_one(a, b)").expect("rewrites");
+    assert!(rewritten.contains("formula: exactly_one(a, b)"));
+    assert!(
+        rewritten.contains("formula: other_fact"),
+        "gate_extra untouched"
+    );
+}

--- a/tests/migrate_scan.rs
+++ b/tests/migrate_scan.rs
@@ -226,3 +226,95 @@ rules:
     let hits = scan_source(rulespec).expect("module lowers");
     assert!(hits.is_empty(), "extra conjuncts are not a gate: {hits:?}");
 }
+
+mod apply {
+    use axiom_rules_engine::migrate::{
+        extract_version_formula, gate_rewrite, plan_rewrites, replace_version_formula, scan_source,
+    };
+
+    #[test]
+    fn plans_gates_and_rewrites_the_hand_expanded_shape() {
+        let (plans, manual) = plan_rewrites(super::HAND_EXPANDED).expect("lowers");
+        assert!(manual.is_empty());
+        assert_eq!(plans.len(), 1);
+        let plan = &plans[0];
+        assert_eq!(
+            plan.replacement,
+            "exactly_one(status_single, status_married_separate, status_joint, status_head_of_household)"
+        );
+        let old = extract_version_formula(super::HAND_EXPANDED, &plan.rule, 0).expect("extracts");
+        let gate = gate_rewrite(&old, &plan.replacement, &plan.bases).expect("gates");
+        assert_eq!(gate.assignments, 16);
+        assert!(gate.outcomes_match && gate.rescan_clean);
+        let rewritten =
+            replace_version_formula(super::HAND_EXPANDED, &plan.rule, 0, &plan.replacement)
+                .expect("rewrites");
+        assert!(rewritten.contains("formula: exactly_one(status_single,"));
+        assert!(
+            scan_source(&rewritten)
+                .expect("rewritten lowers")
+                .is_empty()
+        );
+        let (again, _) = plan_rewrites(&rewritten).expect("rewritten plans");
+        assert!(again.is_empty(), "apply is idempotent");
+    }
+
+    #[test]
+    fn gates_and_rewrites_the_factored_pairwise_shape() {
+        let source = r#"
+format: rulespec/v1
+rules:
+  - name: filing_status_is_valid
+    kind: derived
+    entity: TaxUnit
+    dtype: Judgment
+    versions:
+      - effective_from: 2026-01-01
+        formula: |-
+          (a or b or c or d)
+          and not (a and (b or c or d))
+          and not (b and (c or d))
+          and not (c and d)
+"#;
+        let (plans, manual) = plan_rewrites(source).expect("lowers");
+        assert!(manual.is_empty());
+        assert_eq!(plans.len(), 1);
+        assert_eq!(plans[0].replacement, "exactly_one(a, b, c, d)");
+        let old = extract_version_formula(source, &plans[0].rule, 0).expect("extracts");
+        let gate = gate_rewrite(&old, &plans[0].replacement, &plans[0].bases).expect("gates");
+        assert!(gate.outcomes_match && gate.rescan_clean);
+        assert_eq!(gate.assignments, 16);
+    }
+
+    #[test]
+    fn a_wrong_replacement_fails_the_gate() {
+        // Deliberately drop a base: the behavioral gate must catch it.
+        let (plans, _) = plan_rewrites(super::HAND_EXPANDED).expect("lowers");
+        let plan = &plans[0];
+        let old = extract_version_formula(super::HAND_EXPANDED, &plan.rule, 0).expect("extracts");
+        let sabotaged = "exactly_one(status_single, status_married_separate, status_joint)";
+        let gate = gate_rewrite(&old, sabotaged, &plan.bases).expect("gate runs");
+        assert!(!gate.outcomes_match, "dropping a base must not pass");
+    }
+
+    #[test]
+    fn non_fact_bases_are_reported_for_hands() {
+        let source = r#"
+format: rulespec/v1
+rules:
+  - name: mixed_gate
+    kind: derived
+    entity: Household
+    dtype: Judgment
+    versions:
+      - effective_from: 2026-01-01
+        formula: |-
+          (monthly_income > 1000 and not is_exempt)
+          or (not (monthly_income > 1000) and is_exempt)
+"#;
+        let (plans, manual) = plan_rewrites(source).expect("lowers");
+        assert!(plans.is_empty());
+        assert_eq!(manual.len(), 1);
+        assert!(manual[0].reason.contains("not a bare fact reference"));
+    }
+}


### PR DESCRIPTION
The wave half of #152, Max-commissioned. `migrate apply [--json] [--write] <path>...` turns every detected hand-expanded exactly-one site into `exactly_one(base1, ..., basen)` — under a gate, never on faith:

- **Plan**: only sites whose bases are all bare fact references; anything richer (Hawaii's extra implication conjunct, comparison bases) is reported `manual` and left byte-identical.
- **Gate, per rewrite**: the original and replacement formulas run through the real engine over all 2^n base assignments; outcome-or-error must agree on both sides (a replacement that drops a base makes the engine reject the unused input — that asymmetry fails the gate instead of crashing the tool, pinned by a sabotage test). Then a rescan must prove the pattern gone. Read order — and therefore missing-input fault order — is preserved by construction: bases are listed in detection order, which is leaf read order.
- **Text surgery**: replaces exactly the version's `formula:` scalar; everything else byte-preserved. Idempotent (pinned by test).

Live proof in the PR run: the real ND filing-status rule (factored pairwise idiom) plans, gates **16/16 assignments**, rewrites, and rescans clean — that file lowers under main today, so it's the wave's first target the moment the lane wants it.

Tests: 13 in the migrate suite (4 new: hand-expanded round-trip incl. idempotence, factored-pairwise gate, sabotaged-replacement gate failure, non-fact-base manual reporting). Full suite 292 green with schema features; fmt clean.

Wave sequencing (unchanged, on #152): the other 12 sites live in the rulespec-us#1050-blocked cohort under a pre-exactly_one toolchain pin — metadata cleanup → deliberate pin-bump PR (full revalidation) → `migrate apply --write`, with manifests per the lane's regime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)