### PR TITLE
Load the artifacts the published contract says are loadable

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,26 @@ Run a compiled artifact:
 cargo run -- run-compiled --artifact /tmp/snap.compiled.json < request.json
 ```
 
+Before downloading or running an artifact, ask the binary what it can load.
+`artifact_format_version` is matched **exactly** at load and moves
+independently of the package version, so semver alone cannot answer the
+question:
+
+```bash
+axiom-rules-engine capabilities
+```
+
+```json
+{
+  "artifact_format_version": 2,
+  "engine_version": "0.2.0"
+}
+```
+
+Compare that number against the publisher's
+`programs[].compat.requires_engine.artifact_format_version` in the artifact
+manifest. If they differ the artifact will not load, whatever the versions say.
+
 `request.json` must key atomic inputs by one of the exact owners published in
 `metadata.input_catalog`. Synthesized composition inputs use the catalog's bare
 name. Queried atomic outputs and relations still use their legal RuleSpec IDs:

--- a/schemas/compiled-artifact.v2.schema.json
+++ b/schemas/compiled-artifact.v2.schema.json
@@ -66,6 +66,8 @@
           "$ref": "#/$defs/FastPathMetadata"
         },
         "input_catalog": {
+          "default": [],
+          "description": "Defaulted only so an artifact that predates the catalog can be read at\nall. Absence is filled from the embedded program in `from_json_source`;\na catalog that IS present is still checked against the program, so an\nexplicit `[]` remains a mismatch rather than a way to skip the check.",
           "items": {
             "$ref": "#/$defs/CompiledInputCatalogEntry"
           },
@@ -74,8 +76,7 @@
       },
       "required": [
         "evaluation_order",
-        "fast_path",
-        "input_catalog"
+        "fast_path"
       ],
       "type": "object"
     },

--- a/schemas/compiled-artifact.v2.schema.json
+++ b/schemas/compiled-artifact.v2.schema.json
@@ -809,13 +809,6 @@
               "corpus_citation_paths"
             ]
           }
-        },
-        {
-          "not": {
-            "required": [
-              "extends"
-            ]
-          }
         }
       ],
       "properties": {
@@ -825,6 +818,10 @@
             "$ref": "#/$defs/DerivedSpec"
           },
           "type": "array"
+        },
+        "extends": {
+          "description": "Removed composition directive; tolerated only as null. Compose before compilation — any non-null value is rejected at load.",
+          "type": "null"
         },
         "module": {
           "anyOf": [

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -269,6 +269,7 @@ impl CompiledProgramArtifact {
         mut self,
         path: &str,
         options: CompileOptions,
+        fill_absent_catalog: bool,
     ) -> Result<Self, CompileError> {
         if self.artifact_format_version != ARTIFACT_FORMAT_VERSION {
             return Err(CompileError::UnsupportedArtifactFormatVersion {
@@ -281,6 +282,14 @@ impl CompiledProgramArtifact {
         self.program.validate_rounding()?;
         self.program.validate_effective_ranges()?;
         self.diagnostics = normalize_parameter_duplicates(&mut self.program, path, options)?;
+        // Fill an absent catalog only now, from the NORMALIZED program:
+        // reconstruction runs `to_program()`, which rejects the compatible
+        // duplicates normalization just collapsed. Doing this earlier turned
+        // published artifacts carrying such duplicates (us-tn-snap) into load
+        // failures.
+        if fill_absent_catalog {
+            self.metadata.input_catalog = compiled_input_catalog(&self.program)?;
+        }
         // This is a derived-metadata consistency check: it proves the metadata
         // agrees with the embedded program, not that either payload is untampered.
         let expected_metadata = compiled_metadata(&self.program)?;
@@ -483,20 +492,21 @@ impl CompiledProgramArtifact {
         // catalog from an explicit `[]`, and the two must not be treated alike:
         // an artifact that never carried the field is readable, while one
         // asserting an empty catalog over a program with inputs is making a
-        // false claim the consistency check below has to catch.
+        // false claim the consistency check below has to catch. The fill
+        // itself happens inside `check_format_version`, AFTER duplicate
+        // normalization: reconstructing the catalog needs `to_program()`,
+        // which rejects the compatible duplicates normalization exists to
+        // collapse (published us-tn-snap carries them).
         let catalog_absent = value
             .get("metadata")
             .and_then(serde_json::Value::as_object)
             .is_some_and(|metadata| !metadata.contains_key("input_catalog"));
-        let mut artifact: Self =
+        let artifact: Self =
             serde_json::from_value(value).map_err(|error| CompileError::DeserializeArtifact {
                 path: path.to_string(),
                 error,
             })?;
-        if catalog_absent {
-            artifact.metadata.input_catalog = compiled_input_catalog(&artifact.program)?;
-        }
-        artifact.check_format_version(path, options)
+        artifact.check_format_version(path, options, catalog_absent)
     }
 
     /// Resolve each rule's and parameter's `corpus_citation_path` to a

--- a/src/compile.rs
+++ b/src/compile.rs
@@ -160,6 +160,11 @@ pub struct CompiledProgramArtifact {
 pub struct CompiledProgramMetadata {
     pub evaluation_order: Vec<String>,
     pub fast_path: FastPathMetadata,
+    /// Defaulted only so an artifact that predates the catalog can be read at
+    /// all. Absence is filled from the embedded program in `from_json_source`;
+    /// a catalog that IS present is still checked against the program, so an
+    /// explicit `[]` remains a mismatch rather than a way to skip the check.
+    #[serde(default)]
     pub input_catalog: Vec<CompiledInputCatalogEntry>,
 }
 
@@ -474,11 +479,23 @@ impl CompiledProgramArtifact {
             });
         }
         validate_raw_artifact_contract(&value, path)?;
-        let artifact: Self =
+        // Absence, not emptiness. `#[serde(default)]` cannot tell an omitted
+        // catalog from an explicit `[]`, and the two must not be treated alike:
+        // an artifact that never carried the field is readable, while one
+        // asserting an empty catalog over a program with inputs is making a
+        // false claim the consistency check below has to catch.
+        let catalog_absent = value
+            .get("metadata")
+            .and_then(serde_json::Value::as_object)
+            .is_some_and(|metadata| !metadata.contains_key("input_catalog"));
+        let mut artifact: Self =
             serde_json::from_value(value).map_err(|error| CompileError::DeserializeArtifact {
                 path: path.to_string(),
                 error,
             })?;
+        if catalog_absent {
+            artifact.metadata.input_catalog = compiled_input_catalog(&artifact.program)?;
+        }
         artifact.check_format_version(path, options)
     }
 
@@ -726,7 +743,17 @@ fn validate_raw_artifact_contract(
     path: &str,
 ) -> Result<(), CompileError> {
     if let Some(program) = value.get("program").and_then(serde_json::Value::as_object) {
-        if program.contains_key("extends") {
+        // `extends` carries unresolved inheritance, which is what the hard cut
+        // removed. A null is not inheritance: engines on the v0.1 maintenance
+        // line serialize the field unconditionally, so every artifact they built
+        // says `"extends": null` while being fully composed. Rejecting on the
+        // key rather than on a value locks out artifacts that satisfy the
+        // contract — which is why released v0.2.0 cannot load any published
+        // artifact today.
+        if program
+            .get("extends")
+            .is_some_and(|extends| !extends.is_null())
+        {
             return Err(invalid_artifact_contract(
                 path,
                 "program.extends was removed; compose before compilation",

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ use axiom_rules_engine::api::{
     CompiledExecutionRequest, ExecutionRequest, execute_compiled_request, execute_request,
 };
 use axiom_rules_engine::compile::{
-    CompiledProgramArtifact, CorpusProvisionIndex, compile_summary_lines,
+    ARTIFACT_FORMAT_VERSION, CompiledProgramArtifact, CorpusProvisionIndex, compile_summary_lines,
 };
 use axiom_rules_engine::rulespec::CanonicalRuleSpecRoots;
 
@@ -26,6 +26,19 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
                     return Err("`version` takes no arguments".into());
                 }
                 println!("{}", version_line());
+                return Ok(());
+            }
+            "capabilities" => {
+                if args.next().is_some() {
+                    return Err("`capabilities` takes no arguments".into());
+                }
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&serde_json::json!({
+                        "engine_version": env!("CARGO_PKG_VERSION"),
+                        "artifact_format_version": ARTIFACT_FORMAT_VERSION,
+                    }))?
+                );
                 return Ok(());
             }
             "--help" | "-h" | "help" => {
@@ -82,6 +95,7 @@ mod tests {
             "compile-composed",
             "run-compiled",
             "emit-schemas",
+            "capabilities",
             "version",
             "help",
         ] {
@@ -116,6 +130,9 @@ commands:
   emit-schemas      Write JSON Schemas for the wire types (schema feature only).
   migrate           Corpus-migration tooling; `migrate scan <path>...` inventories
                     hand-expanded exactly-one patterns (#152).
+  capabilities      Print, as JSON, the engine version and the artifact format
+                    version the loader enforces. Semver alone cannot answer
+                    whether an artifact will load; this can.
   version           Print the engine version.
   help              Print this message.
 

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -165,7 +165,22 @@ fn harden_compiled_artifact_schema(value: &mut Value) {
                     && properties.contains_key("parameters")
                     && properties.contains_key("derived")
                 {
-                    forbidden.push("extends");
+                    // The removed composition directive. The loader tolerates
+                    // exactly one shape — the key absent, or present as null
+                    // (v0.1-maintenance-line engines serialize it
+                    // unconditionally) — and the schema must say the same
+                    // thing: `not required` here would reject every published
+                    // artifact the engine accepts.
+                    properties.insert(
+                        "extends".to_string(),
+                        json!({
+                            "type": "null",
+                            "description": "Removed composition directive; \
+                             tolerated only as null. Compose before \
+                             compilation — any non-null value is rejected \
+                             at load."
+                        }),
+                    );
                 }
                 if let Some(Value::Object(version)) = properties.get_mut("artifact_format_version")
                 {

--- a/tests/artifact_version.rs
+++ b/tests/artifact_version.rs
@@ -362,3 +362,47 @@ fn an_absent_input_catalog_is_filled_but_an_empty_one_is_checked() {
         "unexpected error: {error}"
     );
 }
+
+/// Published us-tn-snap carries compatible duplicate parameters that load-time
+/// normalization collapses. Reconstructing an absent input catalog runs
+/// `to_program()`, which rejects those duplicates — so the fill must happen
+/// AFTER normalization. Doing it before turned that artifact into the only
+/// load failure in the release (33/34).
+#[test]
+fn absent_catalog_fill_happens_after_duplicate_normalization() {
+    let artifact = CompiledProgramArtifact::from_rulespec_str(SIMPLE_RULESPEC)
+        .expect("RuleSpec module compiles from YAML");
+    let mut value = serde_json::to_value(&artifact).expect("artifact serialises");
+    // Reshape to the v0.1-maintenance emission: null extends, no catalog, and
+    // the same parameter declared twice with compatible (mergeable) versions.
+    value["program"]["extends"] = serde_json::Value::Null;
+    value["metadata"]
+        .as_object_mut()
+        .expect("metadata is an object")
+        .remove("input_catalog");
+    let parameters = value["program"]["parameters"]
+        .as_array_mut()
+        .expect("parameters is an array");
+    // Clone the declaration and shift its version window so the two entries
+    // are compatible-mergeable rather than conflicting; reusing the serialized
+    // version shape keeps the fixture honest about what engines actually emit.
+    let mut duplicate = parameters[0].clone();
+    duplicate["versions"][0]["effective_from"] = serde_json::json!("2027-01-01");
+    duplicate["versions"][0]["effective_to"] = serde_json::json!("2027-12-31");
+    parameters.push(duplicate);
+
+    let loaded = CompiledProgramArtifact::from_json_str(&value.to_string())
+        .expect("duplicates must normalize before the catalog fill runs to_program()");
+    assert_eq!(
+        loaded.program.parameters.len(),
+        1,
+        "the compatible duplicates collapse into one declaration"
+    );
+    assert!(
+        loaded
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == "duplicate_parameter_name"),
+        "the merge is diagnosed, not silent"
+    );
+}

--- a/tests/artifact_version.rs
+++ b/tests/artifact_version.rs
@@ -302,3 +302,63 @@ fn direct_program_compile_rejects_invalid_carried_citation() {
     program.parameters[0].corpus_citation_path = Some("us/statute".to_string());
     assert!(CompiledProgramArtifact::compile(program).is_err());
 }
+
+/// Artifacts built on the v0.1 maintenance line serialize `extends`
+/// unconditionally, so every one of them says `"extends": null` while being
+/// fully composed. Released v0.2.0 rejects on the key's presence and therefore
+/// cannot load a single published artifact.
+#[test]
+fn a_null_extends_is_not_unresolved_inheritance() {
+    let artifact = CompiledProgramArtifact::from_rulespec_str(SIMPLE_RULESPEC)
+        .expect("RuleSpec module compiles from YAML");
+    let mut value = serde_json::to_value(&artifact).expect("artifact serialises");
+    value["program"]["extends"] = serde_json::Value::Null;
+
+    CompiledProgramArtifact::from_json_str(&value.to_string())
+        .expect("a null extends carries no inheritance and must load");
+
+    // A real inheritance reference is still refused.
+    value["program"]["extends"] = serde_json::json!("us:policies/base");
+    let error = CompiledProgramArtifact::from_json_str(&value.to_string())
+        .expect_err("a non-null extends must still be rejected");
+    assert!(
+        error.to_string().contains("compose before compilation"),
+        "unexpected error: {error}"
+    );
+}
+
+/// Absence and emptiness are different claims. An artifact predating the
+/// catalog omits the field and is readable; one asserting `[]` over a program
+/// that has inputs is stating something false and must not be waved through.
+#[test]
+fn an_absent_input_catalog_is_filled_but_an_empty_one_is_checked() {
+    let artifact = CompiledProgramArtifact::from_rulespec_str(SIMPLE_RULESPEC)
+        .expect("RuleSpec module compiles from YAML");
+    let expected = artifact.metadata.input_catalog.clone();
+    assert!(
+        !expected.is_empty(),
+        "this program must have inputs for the test to mean anything"
+    );
+    let mut value = serde_json::to_value(&artifact).expect("artifact serialises");
+
+    // Omitted entirely: readable, and the catalog is recomputed from the program.
+    value["metadata"]
+        .as_object_mut()
+        .expect("metadata is an object")
+        .remove("input_catalog");
+    let loaded = CompiledProgramArtifact::from_json_str(&value.to_string())
+        .expect("an artifact predating the catalog still loads");
+    assert_eq!(
+        loaded.metadata.input_catalog, expected,
+        "the filled catalog must match what the program actually declares"
+    );
+
+    // Explicitly empty: a false claim, and still a mismatch.
+    value["metadata"]["input_catalog"] = serde_json::json!([]);
+    let error = CompiledProgramArtifact::from_json_str(&value.to_string())
+        .expect_err("an explicitly empty catalog must not be accepted");
+    assert!(
+        error.to_string().contains("metadata does not match"),
+        "unexpected error: {error}"
+    );
+}

--- a/tests/schema_golden.rs
+++ b/tests/schema_golden.rs
@@ -276,3 +276,55 @@ fn v1_and_v2_artifact_schemas_reject_the_other_generation() {
     assert!(!v1_validator.is_valid(&v2_artifact));
     assert!(!v2_validator.is_valid(&v1_artifact));
 }
+
+/// The schema and the loader must agree on the v0.1-maintenance serialization.
+///
+/// Engines on that line write `"extends": null` unconditionally and predate
+/// `metadata.input_catalog`; every published artifact has this shape. The
+/// loader accepts it, so a schema-first consumer must reach the same verdict —
+/// a schema that forbids the `extends` KEY (rather than a non-null value)
+/// rejects every artifact the engine loads, which is the compat lie this
+/// change set exists to remove.
+#[test]
+fn artifact_schema_and_loader_agree_on_maintenance_line_artifacts() {
+    let fixture = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/rulespec/uksi/2013/376/rules.yaml");
+    let source = std::fs::read_to_string(&fixture).expect("fixture is readable");
+    let artifact = CompiledProgramArtifact::from_rulespec_str(&source)
+        .expect("fixture compiles to an artifact");
+    let mut value = serde_json::to_value(&artifact).expect("artifact serializes");
+    // Reshape to what a v0.1-maintenance engine emits.
+    value["program"]["extends"] = serde_json::Value::Null;
+    value["metadata"]
+        .as_object_mut()
+        .expect("metadata is an object")
+        .remove("input_catalog");
+
+    let schema_value = all_schemas()
+        .into_iter()
+        .find(|named| named.file_name == "compiled-artifact.v2.schema.json")
+        .expect("artifact schema is published")
+        .schema;
+    let validator = jsonschema::draft7::new(&schema_value).expect("artifact schema compiles");
+
+    let errors: Vec<String> = validator
+        .iter_errors(&value)
+        .map(|error| format!("{} at {}", error, error.instance_path()))
+        .collect();
+    assert!(
+        errors.is_empty(),
+        "schema rejects the maintenance-line shape the loader accepts:\n{}",
+        errors.join("\n")
+    );
+    CompiledProgramArtifact::from_json_str(&value.to_string())
+        .expect("the loader accepts the same shape the schema accepts");
+
+    // And both refuse a real (non-null) composition directive.
+    value["program"]["extends"] = serde_json::json!("us:policies/base");
+    assert!(
+        validator.iter_errors(&value).next().is_some(),
+        "schema must reject a non-null extends"
+    );
+    CompiledProgramArtifact::from_json_str(&value.to_string())
+        .expect_err("the loader must reject a non-null extends");
+}

--- a/tests/version_cli.rs
+++ b/tests/version_cli.rs
@@ -36,3 +36,31 @@ fn unknown_command_is_an_error() {
         .expect("run engine");
     assert!(!out.status.success());
 }
+
+/// A publisher stamping `requires_engine` and a consumer deciding whether an
+/// artifact will load both need the number the loader actually matches. Without
+/// this, the only way to discover incompatibility is to attempt a load — which
+/// is how v0.1.0 and format-2 artifacts both advertised "0.1.0" while every
+/// load failed.
+#[test]
+fn capabilities_report_the_artifact_format_version() {
+    let out = engine().arg("capabilities").output().expect("run engine");
+    assert!(out.status.success(), "capabilities should exit 0");
+    let value: serde_json::Value =
+        serde_json::from_slice(&out.stdout).expect("capabilities emits JSON");
+    assert_eq!(value["engine_version"], env!("CARGO_PKG_VERSION"));
+    assert_eq!(
+        value["artifact_format_version"],
+        serde_json::json!(axiom_rules_engine::compile::ARTIFACT_FORMAT_VERSION),
+        "capabilities must report the version the loader enforces"
+    );
+}
+
+#[test]
+fn capabilities_rejects_extra_arguments() {
+    let out = engine()
+        .args(["capabilities", "surprise"])
+        .output()
+        .expect("run engine");
+    assert!(!out.status.success(), "stray arg must be an error");
+}


### PR DESCRIPTION
## The problem

Released **v0.2.0 — currently marked Latest — cannot execute a single published rulespec-us artifact.**

```
$ axiom-rules-engine run-compiled --artifact us-co-snap.compiled.json < request.json
compiled artefact `us-co-snap.compiled.json` violates the v2 contract:
program.extends was removed; compose before compilation
```

Anyone following the quickstart takes Latest and it does not work. The BOM pins `v0.1.1` (the v0.1 maintenance line), so the launch path itself is fine — but the releases page disagrees with the BOM, and nothing in the published contract tells a reader which one to take.

## Two checks stricter than the invariants they defend

**`program.extends`** was removed because it carried unresolved inheritance. Engines on the v0.1 maintenance line serialize the field unconditionally, so artifacts they build carry `"extends": null` while being fully composed. Rejecting on the *key* rather than on a *non-null value* locks out artifacts that satisfy the contract. A real inheritance reference is still refused.

**`metadata.input_catalog`** postdates those artifacts, and a missing required field fails deserialization outright. It is now `#[serde(default)]`, and **absence** — read from the raw JSON, distinct from an explicit `[]` — is filled from the embedded program. An artifact asserting an empty catalog over a program that has inputs is making a false claim and still fails the existing metadata-consistency check.

That absence-vs-emptiness distinction is the subtle one: an earlier cut of this change keyed the allowance on `is_empty()` and silently accepted-and-overwrote a false `[]`. Both directions are now tested.

## `capabilities`

```
$ axiom-rules-engine capabilities
{ "artifact_format_version": 2, "engine_version": "0.2.0" }
```

Semver cannot express loadability. v0.1.0 and format-2 artifacts both advertised `"0.1.0"`, so a third party comparing `--version` against `requires_engine.min_version` concluded compatible and was wrong every time. A publisher stamping the compat contract and a consumer choosing a release both need the number the loader actually matches, without attempting a load.

Pairs with the rulespec-us change that makes `requires_engine` carry `artifact_format_version`; either is useful alone, both together close the false pass.

## Verification

Against the published `us-co-snap.compiled.json` (`program-artifacts-3373e8411f7e`, sha `96d99042…`):

| output | value |
|---|---|
| `snap_monthly_allotment` | **478** |
| `snap_maximum_allotment` | 546 |
| `snap_net_income` | 226 |

98-node explain trace. 283 tests pass.

`snap_allotment` is 0 and `snap_eligible` unresolved — the artifact's eligibility judgments are three-valued and need adjudication facts the golden household does not carry. Pre-existing and unrelated to this change; noted so the numbers above are not read as a full parity pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)