### PR TITLE
Cut the crate at 0.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "axiom-rules-engine"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "chrono",
  "jsonschema",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "axiom-rules-engine"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 license = "Apache-2.0"
 description = "Temporal-relational runtime for compiling and executing Axiom RuleSpec (experimental API)."

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ axiom-rules-engine capabilities
 ```json
 {
   "artifact_format_version": 2,
-  "engine_version": "0.2.0"
+  "engine_version": "0.2.1"
 }
 ```
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -82,7 +82,7 @@ mod tests {
 
     #[test]
     fn version_line_uses_package_version() {
-        assert_eq!(version_line(), "axiom-rules-engine 0.2.0");
+        assert_eq!(version_line(), "axiom-rules-engine 0.2.1");
     }
 
     /// Top-level help must name every command `run` dispatches on, so adding a command


### PR DESCRIPTION
Version bump only (Cargo.toml, Cargo.lock, the hardcoded version-line test) — the same three-file shape as the 0.2.0 cut (#149).

This becomes the first release whose loader accepts the published artifacts: v0.2.0, still marked Latest, rejects every one of them at load (#156 has the full story; the fixes are already on main). At this commit 34/34 artifacts in the current program-artifacts release load, and `capabilities` reports:

```json
{ "artifact_format_version": 2, "engine_version": "0.2.1" }
```

which makes the compat contract from rulespec-us#1233 checkable against this binary without attempting a load. Tagging `v0.2.1` after merge hands the rest to cargo-dist (4 targets, checksums, attestations), and Latest stops pointing at a binary that loads nothing.

299 tests pass with `--features schema`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)