### PR TITLE
Unit derivation stage 2: prototype behind an off-by-default feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,10 @@ fs = []
 # extension, wasm, finbot, microsim) lean. CI runs the schema tests with
 # `--features schema`; `cargo test --features schema` reproduces them locally.
 schema = ["dep:schemars"]
+# Stage-2 prototype for the ratified unit-derivation semantics. The runtime
+# configuration inside the module is independently disabled by default. This
+# feature does not extend artifact v2 or any publication/launch surface.
+unit-derivation = []
 
 [[bin]]
 name = "axiom-rules-engine"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,3 +14,5 @@ pub mod rulespec;
 pub mod schema;
 pub mod source;
 pub mod spec;
+#[cfg(feature = "unit-derivation")]
+pub mod unit_derivation;

--- a/src/unit_derivation/compile.rs
+++ b/src/unit_derivation/compile.rs
@@ -1,0 +1,747 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use super::types::*;
+
+#[derive(Clone, Debug)]
+pub struct CompiledConstitution {
+    pub(crate) plan: ConstitutionPlan,
+    pub(crate) semantics_digest: [u8; 32],
+    pub(crate) derived_bools: BTreeMap<String, DerivedBool>,
+    pub(crate) edges: BTreeMap<String, EdgeRule>,
+    pub(crate) cuts: BTreeMap<String, CutRule>,
+    pub(crate) attachments: BTreeMap<String, AttachmentRule>,
+    pub(crate) bars: BTreeMap<String, BarRule>,
+    pub(crate) statuses: BTreeMap<String, StatusRule>,
+}
+
+impl CompiledConstitution {
+    pub fn semantics_digest(&self) -> [u8; 32] {
+        self.semantics_digest
+    }
+}
+
+fn insert_unique<T>(
+    namespace: &'static str,
+    values: &mut BTreeMap<String, T>,
+    id: String,
+    value: T,
+) -> Result<(), UnitDerivationError> {
+    match values.entry(id.clone()) {
+        std::collections::btree_map::Entry::Vacant(entry) => {
+            entry.insert(value);
+            Ok(())
+        }
+        std::collections::btree_map::Entry::Occupied(_) => {
+            Err(UnitDerivationError::DuplicateNamespace { namespace, id })
+        }
+    }
+}
+
+pub fn compile(plan: ConstitutionPlan) -> Result<CompiledConstitution, UnitDerivationError> {
+    if plan.id.is_empty() || plan.entity_type.is_empty() || plan.roster_relation.is_empty() {
+        return Err(UnitDerivationError::InvalidPlan(
+            "constitution id, entity type, and roster relation must be non-empty".to_string(),
+        ));
+    }
+    if plan.relations.unit_constituent.is_empty()
+        || plan.relations.participating_member.is_empty()
+        || plan.relations.unit_constituent == plan.relations.participating_member
+    {
+        return Err(UnitDerivationError::InvalidPlan(
+            "the two compile-resolved projection relation ids must be non-empty and distinct"
+                .to_string(),
+        ));
+    }
+
+    let mut derived_bools = BTreeMap::new();
+    for derived in &plan.derived_bools {
+        insert_unique(
+            "derived constitution fact",
+            &mut derived_bools,
+            derived.id.clone(),
+            derived.clone(),
+        )?;
+    }
+
+    let mut edges = BTreeMap::new();
+    for edge in &plan.edges {
+        if edge.left == edge.right {
+            return Err(UnitDerivationError::InvalidPlan(format!(
+                "edge `{}` is a self-edge",
+                edge.id
+            )));
+        }
+        let mut defeaters = BTreeMap::new();
+        for defeater in &edge.defeaters {
+            insert_unique(
+                "edge defeater",
+                &mut defeaters,
+                defeater.id.clone(),
+                defeater,
+            )?;
+        }
+        insert_unique("edge rule", &mut edges, edge.id.clone(), edge.clone())?;
+    }
+
+    let mut cuts = BTreeMap::new();
+    for cut in &plan.cuts {
+        if cut.members.is_empty() {
+            return Err(UnitDerivationError::InvalidPlan(format!(
+                "cut `{}` has no members",
+                cut.id
+            )));
+        }
+        let mut edge_precedence = BTreeMap::new();
+        for precedence in &cut.edge_precedence {
+            insert_unique(
+                "cut-edge precedence",
+                &mut edge_precedence,
+                precedence.edge_rule.clone(),
+                precedence,
+            )?;
+        }
+        let mut cut_order = BTreeMap::new();
+        for order in &cut.precedes {
+            insert_unique(
+                "cut precedence",
+                &mut cut_order,
+                order.lower_priority_cut.clone(),
+                order,
+            )?;
+        }
+        insert_unique("cut rule", &mut cuts, cut.id.clone(), cut.clone())?;
+    }
+
+    let mut attachments = BTreeMap::new();
+    for attachment in &plan.attachments {
+        if attachment.members.is_empty()
+            || attachment.members.contains(&attachment.target_anchor)
+            || attachment.actor.is_empty()
+        {
+            return Err(UnitDerivationError::InvalidPlan(format!(
+                "attachment `{}` must have an actor and a non-empty source disjoint from its target anchor",
+                attachment.id
+            )));
+        }
+        if let Some(election) = &attachment.election
+            && attachment.actor != election.actor
+        {
+            return Err(UnitDerivationError::InvalidPlan(format!(
+                "attachment `{}` actor `{}` disagrees with election actor `{}`",
+                attachment.id, attachment.actor, election.actor
+            )));
+        }
+        insert_unique(
+            "attachment rule",
+            &mut attachments,
+            attachment.id.clone(),
+            attachment.clone(),
+        )?;
+    }
+
+    let mut bars = BTreeMap::new();
+    for bar in &plan.bars {
+        if bar.members.is_empty() {
+            return Err(UnitDerivationError::InvalidPlan(format!(
+                "bar `{}` has no members",
+                bar.id
+            )));
+        }
+        insert_unique("bar rule", &mut bars, bar.id.clone(), bar.clone())?;
+    }
+
+    let mut statuses = BTreeMap::new();
+    for status in &plan.statuses {
+        insert_unique(
+            "status rule",
+            &mut statuses,
+            status.id.clone(),
+            status.clone(),
+        )?;
+    }
+
+    validate_exprs(&plan, &derived_bools)?;
+    validate_elections(&plan, &derived_bools)?;
+    validate_precedence(&edges, &cuts)?;
+    validate_attachment_confluence(&attachments)?;
+
+    let semantics_digest = super::evaluate::sha256(&canonical_plan_encoding(&plan));
+
+    Ok(CompiledConstitution {
+        plan,
+        semantics_digest,
+        derived_bools,
+        edges,
+        cuts,
+        attachments,
+        bars,
+        statuses,
+    })
+}
+
+/// Normative stage-2 compiled-plan encoding. Every item is tag-delimited and
+/// length-prefixed; set-like operation collections are sorted by their stable
+/// ids before encoding, so caller record order cannot affect identity.
+fn canonical_plan_encoding(plan: &ConstitutionPlan) -> Vec<u8> {
+    let mut encoder = CanonicalEncoder::new(b"axiom.unit-derivation.semantics.stage2\0");
+    encoder.string(&plan.id);
+    encoder.string(&plan.entity_type);
+    encoder.string(&plan.roster_relation);
+    encoder.string(&plan.relations.unit_constituent);
+    encoder.string(&plan.relations.participating_member);
+
+    let mut derived = plan.derived_bools.iter().collect::<Vec<_>>();
+    derived.sort_by_key(|item| item.id.as_str());
+    encoder.count(derived.len());
+    for item in derived {
+        encoder.string(&item.id);
+        encoder.byte(match item.stratum {
+            Stratum::Person => 0,
+            Stratum::Candidate => 1,
+            Stratum::Unit => 2,
+        });
+        encoder.expr(&item.expr);
+    }
+
+    let mut edges = plan.edges.iter().collect::<Vec<_>>();
+    edges.sort_by_key(|item| item.id.as_str());
+    encoder.count(edges.len());
+    for item in edges {
+        encoder.string(&item.id);
+        encoder.byte(match item.kind {
+            EdgeKind::Base => 0,
+            EdgeKind::Combination => 1,
+        });
+        let (left, right) = if item.left <= item.right {
+            (&item.left, &item.right)
+        } else {
+            (&item.right, &item.left)
+        };
+        encoder.string(left);
+        encoder.string(right);
+        encoder.expr(&item.when);
+        encoder.citation(&item.citation);
+        let mut defeaters = item.defeaters.iter().collect::<Vec<_>>();
+        defeaters.sort_by_key(|defeater| defeater.id.as_str());
+        encoder.count(defeaters.len());
+        for defeater in defeaters {
+            encoder.string(&defeater.id);
+            encoder.expr(&defeater.when);
+            encoder.citation(&defeater.citation);
+        }
+    }
+
+    let mut cuts = plan.cuts.iter().collect::<Vec<_>>();
+    cuts.sort_by_key(|item| item.id.as_str());
+    encoder.count(cuts.len());
+    for item in cuts {
+        encoder.string(&item.id);
+        encoder.strings(item.members.iter());
+        encoder.expr(&item.when);
+        encoder.citation(&item.citation);
+        encoder.election(item.election.as_ref());
+        let mut precedence = item.edge_precedence.iter().collect::<Vec<_>>();
+        precedence.sort_by_key(|entry| entry.edge_rule.as_str());
+        encoder.count(precedence.len());
+        for entry in precedence {
+            encoder.string(&entry.edge_rule);
+            match &entry.decision {
+                CutEdgeDecision::Blocked { citation } => {
+                    encoder.byte(0);
+                    encoder.citation(citation);
+                }
+                CutEdgeDecision::Overrides { citation } => {
+                    encoder.byte(1);
+                    encoder.citation(citation);
+                }
+                CutEdgeDecision::Unresolved { issue } => {
+                    encoder.byte(2);
+                    encoder.string(issue);
+                }
+            }
+        }
+        let mut orders = item.precedes.iter().collect::<Vec<_>>();
+        orders.sort_by_key(|order| order.lower_priority_cut.as_str());
+        encoder.count(orders.len());
+        for order in orders {
+            encoder.string(&order.lower_priority_cut);
+            encoder.citation(&order.citation);
+        }
+    }
+
+    let mut attachments = plan.attachments.iter().collect::<Vec<_>>();
+    attachments.sort_by_key(|item| item.id.as_str());
+    encoder.count(attachments.len());
+    for item in attachments {
+        encoder.string(&item.id);
+        encoder.strings(item.members.iter());
+        encoder.string(&item.target_anchor);
+        encoder.expr(&item.when);
+        encoder.string(&item.actor);
+        encoder.election(item.election.as_ref());
+        encoder.citation(&item.citation);
+    }
+
+    let mut bars = plan.bars.iter().collect::<Vec<_>>();
+    bars.sort_by_key(|item| item.id.as_str());
+    encoder.count(bars.len());
+    for item in bars {
+        encoder.string(&item.id);
+        encoder.strings(item.members.iter());
+        encoder.expr(&item.when);
+        encoder.citation(&item.citation);
+    }
+
+    let mut statuses = plan.statuses.iter().collect::<Vec<_>>();
+    statuses.sort_by_key(|item| item.id.as_str());
+    encoder.count(statuses.len());
+    for item in statuses {
+        encoder.string(&item.id);
+        encoder.string(&item.person);
+        encoder.expr(&item.when);
+        encoder.citation(&item.citation);
+    }
+
+    match &plan.base_chain_policy {
+        Some(citation) => {
+            encoder.byte(1);
+            encoder.citation(citation);
+        }
+        None => encoder.byte(0),
+    }
+    encoder.finish()
+}
+
+struct CanonicalEncoder {
+    bytes: Vec<u8>,
+}
+
+impl CanonicalEncoder {
+    fn new(domain: &[u8]) -> Self {
+        Self {
+            bytes: domain.to_vec(),
+        }
+    }
+
+    fn finish(self) -> Vec<u8> {
+        self.bytes
+    }
+
+    fn byte(&mut self, value: u8) {
+        self.bytes.push(value);
+    }
+
+    fn count(&mut self, value: usize) {
+        self.bytes.extend_from_slice(&(value as u32).to_be_bytes());
+    }
+
+    fn string(&mut self, value: &str) {
+        self.count(value.len());
+        self.bytes.extend_from_slice(value.as_bytes());
+    }
+
+    fn strings<'a>(&mut self, values: impl Iterator<Item = &'a String>) {
+        let values = values.collect::<Vec<_>>();
+        self.count(values.len());
+        for value in values {
+            self.string(value);
+        }
+    }
+
+    fn citation(&mut self, citation: &Citation) {
+        self.string(&citation.provision);
+        self.string(&citation.authority);
+    }
+
+    fn election(&mut self, election: Option<&ElectionRequirement>) {
+        let Some(election) = election else {
+            self.byte(0);
+            return;
+        };
+        self.byte(1);
+        self.string(&election.fact);
+        self.string(&election.actor);
+        match &election.missing {
+            MissingElectionPolicy::Unknown => self.byte(0),
+            MissingElectionPolicy::AuthorityDefault { value, citation } => {
+                self.byte(1);
+                self.byte(u8::from(*value));
+                self.citation(citation);
+            }
+        }
+    }
+
+    fn expr(&mut self, expr: &BoolExpr) {
+        match expr {
+            BoolExpr::Literal(value) => {
+                self.byte(0);
+                self.byte(u8::from(*value));
+            }
+            BoolExpr::Fact(FactRef::Bool(name)) => {
+                self.byte(1);
+                self.string(name);
+            }
+            BoolExpr::Fact(FactRef::Relation { family, tuple }) => {
+                self.byte(2);
+                self.string(family);
+                self.strings(tuple.iter());
+            }
+            BoolExpr::Derived(name) => {
+                self.byte(3);
+                self.string(name);
+            }
+            BoolExpr::And(items) => {
+                self.byte(4);
+                self.count(items.len());
+                for item in items {
+                    self.expr(item);
+                }
+            }
+            BoolExpr::Or(items) => {
+                self.byte(5);
+                self.count(items.len());
+                for item in items {
+                    self.expr(item);
+                }
+            }
+            BoolExpr::Not(item) => {
+                self.byte(6);
+                self.expr(item);
+            }
+        }
+    }
+}
+
+fn validate_elections(
+    plan: &ConstitutionPlan,
+    derived: &BTreeMap<String, DerivedBool>,
+) -> Result<(), UnitDerivationError> {
+    let mut policies = BTreeMap::<String, (String, MissingElectionPolicy)>::new();
+    let requirements = plan
+        .cuts
+        .iter()
+        .filter_map(|rule| {
+            rule.election
+                .as_ref()
+                .map(|item| (&rule.id, &rule.when, item))
+        })
+        .chain(plan.attachments.iter().filter_map(|rule| {
+            rule.election
+                .as_ref()
+                .map(|item| (&rule.id, &rule.when, item))
+        }));
+    for (rule, when, election) in requirements {
+        if election.actor.is_empty() || election.fact.is_empty() {
+            return Err(UnitDerivationError::InvalidPlan(format!(
+                "election on `{rule}` must name its actor and fact"
+            )));
+        }
+        let fact = FactRef::Bool(election.fact.clone());
+        if !expr_fact_refs(when, derived).contains(&fact) {
+            return Err(UnitDerivationError::InvalidPlan(format!(
+                "election fact `{}` on `{rule}` is not consumed by its guard",
+                election.fact
+            )));
+        }
+        match policies.entry(election.fact.clone()) {
+            std::collections::btree_map::Entry::Vacant(slot) => {
+                slot.insert((election.actor.clone(), election.missing.clone()));
+            }
+            std::collections::btree_map::Entry::Occupied(slot)
+                if slot.get() != &(election.actor.clone(), election.missing.clone()) =>
+            {
+                return Err(UnitDerivationError::InvalidPlan(format!(
+                    "election fact `{}` has conflicting missing-evidence policies",
+                    election.fact
+                )));
+            }
+            std::collections::btree_map::Entry::Occupied(_) => {}
+        }
+    }
+    Ok(())
+}
+
+fn validate_exprs(
+    plan: &ConstitutionPlan,
+    derived: &BTreeMap<String, DerivedBool>,
+) -> Result<(), UnitDerivationError> {
+    let mut roots: Vec<(&str, &BoolExpr)> = Vec::new();
+    roots.extend(plan.edges.iter().map(|rule| (rule.id.as_str(), &rule.when)));
+    for rule in &plan.edges {
+        roots.extend(
+            rule.defeaters
+                .iter()
+                .map(|item| (item.id.as_str(), &item.when)),
+        );
+    }
+    roots.extend(plan.cuts.iter().map(|rule| (rule.id.as_str(), &rule.when)));
+    roots.extend(
+        plan.attachments
+            .iter()
+            .map(|rule| (rule.id.as_str(), &rule.when)),
+    );
+    roots.extend(plan.bars.iter().map(|rule| (rule.id.as_str(), &rule.when)));
+    roots.extend(
+        plan.statuses
+            .iter()
+            .map(|rule| (rule.id.as_str(), &rule.when)),
+    );
+
+    for (root, expr) in roots {
+        let mut visiting = Vec::new();
+        validate_expr(root, expr, derived, &mut visiting)?;
+    }
+    for rule in derived.values() {
+        let mut visiting = vec![rule.id.clone()];
+        validate_expr(&rule.id, &rule.expr, derived, &mut visiting)?;
+    }
+    Ok(())
+}
+
+fn validate_expr(
+    root: &str,
+    expr: &BoolExpr,
+    derived: &BTreeMap<String, DerivedBool>,
+    visiting: &mut Vec<String>,
+) -> Result<(), UnitDerivationError> {
+    match expr {
+        BoolExpr::Literal(_) | BoolExpr::Fact(_) => Ok(()),
+        BoolExpr::Derived(reference) => {
+            let rule =
+                derived
+                    .get(reference)
+                    .ok_or_else(|| UnitDerivationError::UnknownReference {
+                        from: root.to_string(),
+                        reference: reference.clone(),
+                    })?;
+            if let Some(position) = visiting.iter().position(|item| item == reference) {
+                let mut cycle = visiting[position..].to_vec();
+                cycle.push(reference.clone());
+                return Err(UnitDerivationError::CyclicDependency(cycle.join(" -> ")));
+            }
+            let mut path = visiting.clone();
+            path.push(reference.clone());
+            if rule.stratum == Stratum::Unit {
+                return Err(UnitDerivationError::UnitStratumDependency(
+                    path.join(" -> "),
+                ));
+            }
+            visiting.push(reference.clone());
+            validate_expr(root, &rule.expr, derived, visiting)?;
+            visiting.pop();
+            Ok(())
+        }
+        BoolExpr::And(items) | BoolExpr::Or(items) => {
+            for item in items {
+                validate_expr(root, item, derived, visiting)?;
+            }
+            Ok(())
+        }
+        BoolExpr::Not(item) => validate_expr(root, item, derived, visiting),
+    }
+}
+
+fn validate_precedence(
+    edges: &BTreeMap<String, EdgeRule>,
+    cuts: &BTreeMap<String, CutRule>,
+) -> Result<(), UnitDerivationError> {
+    for cut in cuts.values() {
+        let declarations = cut
+            .edge_precedence
+            .iter()
+            .map(|item| (item.edge_rule.as_str(), &item.decision))
+            .collect::<BTreeMap<_, _>>();
+        for edge in edges.values() {
+            if edge.kind != EdgeKind::Combination {
+                continue;
+            }
+            let crosses = cut.members.contains(&edge.left) != cut.members.contains(&edge.right);
+            if crosses && !declarations.contains_key(edge.id.as_str()) {
+                return Err(UnitDerivationError::InvalidPlan(format!(
+                    "cut `{}` can cross combination edge `{}` but declares no explicit block, override, or unresolved legal branch",
+                    cut.id, edge.id
+                )));
+            }
+        }
+        for declaration in &cut.edge_precedence {
+            let edge = edges.get(&declaration.edge_rule).ok_or_else(|| {
+                UnitDerivationError::UnknownReference {
+                    from: cut.id.clone(),
+                    reference: declaration.edge_rule.clone(),
+                }
+            })?;
+            if edge.kind != EdgeKind::Combination {
+                return Err(UnitDerivationError::InvalidPlan(format!(
+                    "cut `{}` declares blocking precedence against non-combination edge `{}`",
+                    cut.id, edge.id
+                )));
+            }
+        }
+        for order in &cut.precedes {
+            if !cuts.contains_key(&order.lower_priority_cut) {
+                return Err(UnitDerivationError::UnknownReference {
+                    from: cut.id.clone(),
+                    reference: order.lower_priority_cut.clone(),
+                });
+            }
+        }
+    }
+
+    let graph = cuts
+        .iter()
+        .map(|(id, cut)| {
+            (
+                id.clone(),
+                cut.precedes
+                    .iter()
+                    .map(|order| order.lower_priority_cut.clone())
+                    .collect::<BTreeSet<_>>(),
+            )
+        })
+        .collect::<BTreeMap<_, _>>();
+    for id in graph.keys() {
+        let mut visiting = Vec::new();
+        validate_order_dag(id, &graph, &mut visiting, &mut BTreeSet::new())?;
+    }
+
+    let rules = cuts.values().collect::<Vec<_>>();
+    for (index, left) in rules.iter().enumerate() {
+        for right in rules.iter().skip(index + 1) {
+            if left.members != right.members {
+                continue;
+            }
+            let ordered = order_reaches(&graph, &left.id, &right.id)
+                || order_reaches(&graph, &right.id, &left.id);
+            for edge in edges.values().filter(|edge| {
+                edge.kind == EdgeKind::Combination
+                    && (left.members.contains(&edge.left) != left.members.contains(&edge.right))
+            }) {
+                let left_decision = left
+                    .edge_precedence
+                    .iter()
+                    .find(|item| item.edge_rule == edge.id)
+                    .expect("crossing precedence validated");
+                let right_decision = right
+                    .edge_precedence
+                    .iter()
+                    .find(|item| item.edge_rule == edge.id)
+                    .expect("crossing precedence validated");
+                if cut_decision_class(&left_decision.decision)
+                    != cut_decision_class(&right_decision.decision)
+                    && !ordered
+                {
+                    return Err(UnitDerivationError::InvalidPlan(format!(
+                        "coalescible cuts `{}` and `{}` contradict each other for combination edge `{}` without explicit cut precedence",
+                        left.id, right.id, edge.id
+                    )));
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+fn cut_decision_class(decision: &CutEdgeDecision) -> u8 {
+    match decision {
+        CutEdgeDecision::Blocked { .. } => 0,
+        CutEdgeDecision::Overrides { .. } => 1,
+        CutEdgeDecision::Unresolved { .. } => 2,
+    }
+}
+
+fn order_reaches(graph: &BTreeMap<String, BTreeSet<String>>, from: &str, target: &str) -> bool {
+    let mut pending = vec![from.to_string()];
+    let mut visited = BTreeSet::new();
+    while let Some(id) = pending.pop() {
+        if !visited.insert(id.clone()) {
+            continue;
+        }
+        for next in graph.get(&id).into_iter().flatten() {
+            if next == target {
+                return true;
+            }
+            pending.push(next.clone());
+        }
+    }
+    false
+}
+
+fn validate_order_dag(
+    id: &str,
+    graph: &BTreeMap<String, BTreeSet<String>>,
+    visiting: &mut Vec<String>,
+    complete: &mut BTreeSet<String>,
+) -> Result<(), UnitDerivationError> {
+    if complete.contains(id) {
+        return Ok(());
+    }
+    if let Some(position) = visiting.iter().position(|item| item == id) {
+        let mut cycle = visiting[position..].to_vec();
+        cycle.push(id.to_string());
+        return Err(UnitDerivationError::CyclicDependency(cycle.join(" -> ")));
+    }
+    visiting.push(id.to_string());
+    for next in graph.get(id).into_iter().flatten() {
+        validate_order_dag(next, graph, visiting, complete)?;
+    }
+    visiting.pop();
+    complete.insert(id.to_string());
+    Ok(())
+}
+
+fn validate_attachment_confluence(
+    attachments: &BTreeMap<String, AttachmentRule>,
+) -> Result<(), UnitDerivationError> {
+    let rules = attachments.values().collect::<Vec<_>>();
+    for (index, left) in rules.iter().enumerate() {
+        for right in rules.iter().skip(index + 1) {
+            if !left.members.is_disjoint(&right.members)
+                || left.members.contains(&right.target_anchor)
+                || right.members.contains(&left.target_anchor)
+            {
+                return Err(UnitDerivationError::InvalidPlan(format!(
+                    "attachments `{}` and `{}` can disagree without declared ordering",
+                    left.id, right.id
+                )));
+            }
+        }
+    }
+    Ok(())
+}
+
+pub(crate) fn expr_fact_refs(
+    expr: &BoolExpr,
+    derived: &BTreeMap<String, DerivedBool>,
+) -> BTreeSet<FactRef> {
+    let mut facts = BTreeSet::new();
+    collect_expr_fact_refs(expr, derived, &mut facts, &mut BTreeSet::new());
+    facts
+}
+
+fn collect_expr_fact_refs(
+    expr: &BoolExpr,
+    derived: &BTreeMap<String, DerivedBool>,
+    facts: &mut BTreeSet<FactRef>,
+    visiting: &mut BTreeSet<String>,
+) {
+    match expr {
+        BoolExpr::Literal(_) => {}
+        BoolExpr::Fact(fact) => {
+            facts.insert(fact.clone());
+        }
+        BoolExpr::Derived(reference) => {
+            if visiting.insert(reference.clone()) {
+                if let Some(rule) = derived.get(reference) {
+                    collect_expr_fact_refs(&rule.expr, derived, facts, visiting);
+                }
+                visiting.remove(reference);
+            }
+        }
+        BoolExpr::And(items) | BoolExpr::Or(items) => {
+            for item in items {
+                collect_expr_fact_refs(item, derived, facts, visiting);
+            }
+        }
+        BoolExpr::Not(item) => collect_expr_fact_refs(item, derived, facts, visiting),
+    }
+}

--- a/src/unit_derivation/evaluate.rs
+++ b/src/unit_derivation/evaluate.rs
@@ -1,0 +1,1614 @@
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
+
+use super::compile::{CompiledConstitution, expr_fact_refs};
+use super::interface::EntityRegistry;
+use super::types::*;
+
+#[derive(Clone, Debug)]
+enum NormalizedBool {
+    Known(bool),
+    Unknown,
+    Conflict(BTreeSet<bool>),
+}
+
+#[derive(Clone, Debug)]
+struct BoundFacts {
+    values: BTreeMap<String, NormalizedBool>,
+    conflicts: BTreeSet<String>,
+    completeness_evidence: BTreeSet<String>,
+    election_defaults: BTreeMap<String, (String, bool, Citation)>,
+    request_evidence: BTreeMap<String, BTreeSet<String>>,
+}
+
+#[derive(Clone, Debug)]
+struct FrozenEdge {
+    id: String,
+    kind: EdgeKind,
+    left: String,
+    right: String,
+    citation: Citation,
+}
+
+#[derive(Clone, Debug)]
+struct WorldPerson {
+    block: Option<Vec<String>>,
+    role: Option<ProjectionRole>,
+    kind: Option<IndeterminateKind>,
+    citations: BTreeSet<Citation>,
+}
+
+#[derive(Clone, Debug)]
+struct WorldResult {
+    persons: BTreeMap<String, WorldPerson>,
+    events: BTreeSet<TraceEvent>,
+}
+
+#[derive(Clone, Debug)]
+struct ActiveCut {
+    ids: BTreeSet<String>,
+    members: BTreeSet<String>,
+    citations: BTreeSet<Citation>,
+}
+
+type WorldVariables = Vec<(String, Vec<bool>)>;
+
+pub fn derive_units(
+    compiled: &CompiledConstitution,
+    input: &ConstitutionInput,
+    config: &UnitDerivationConfig,
+) -> Result<UnitDerivationResult, UnitDerivationError> {
+    if !config.enabled {
+        return Err(UnitDerivationError::Disabled);
+    }
+    if config.semantics_version != super::EXPERIMENTAL_SEMANTICS_VERSION {
+        return Err(UnitDerivationError::UnsupportedExperimentalVersion(
+            config.semantics_version.clone(),
+        ));
+    }
+    if !input.segment_complete {
+        return Err(UnitDerivationError::RequiresSegmentation);
+    }
+    validate_roster(compiled, input)?;
+
+    let persons = input
+        .roster
+        .persons
+        .iter()
+        .cloned()
+        .collect::<BTreeSet<_>>();
+    if input.roster.completeness.is_none() {
+        return Ok(roster_incomplete_result(compiled, input, &persons));
+    }
+
+    let referenced_facts = all_fact_refs(compiled, input);
+    let bound = bind_facts(compiled, input, &referenced_facts)?;
+    let (mut variables, fixed) = world_variables(compiled, &bound);
+    variables.sort_by(|left, right| left.0.cmp(&right.0));
+
+    let worlds = variable_world_count(&variables)?;
+    if worlds > config.max_admissible_worlds {
+        return Err(UnitDerivationError::UncheckableWorldSpace {
+            worlds,
+            maximum: config.max_admissible_worlds,
+        });
+    }
+
+    let mut enumerated = Vec::with_capacity(worlds);
+    enumerate_worlds(&variables, 0, fixed, &mut enumerated);
+    let mut valuations = Vec::new();
+    for valuation in enumerated {
+        let mut admissible = true;
+        for constraint in &input.integrity_constraints {
+            if !eval_expr(
+                &constraint.expr,
+                &valuation,
+                &compiled.derived_bools,
+                &mut BTreeSet::new(),
+            )? {
+                admissible = false;
+                break;
+            }
+        }
+        if admissible {
+            valuations.push(valuation);
+        }
+    }
+
+    if valuations.is_empty() {
+        return Ok(inconsistent_result(compiled, input, &persons, &bound));
+    }
+
+    let influence = influence_sets(compiled, input, &bound);
+    let mut results = Vec::with_capacity(valuations.len());
+    for valuation in &valuations {
+        results.push(evaluate_world(
+            compiled, &persons, valuation, &influence, &bound,
+        )?);
+    }
+    assemble_result(compiled, input, &persons, &bound, &influence, results)
+}
+
+fn validate_roster(
+    compiled: &CompiledConstitution,
+    input: &ConstitutionInput,
+) -> Result<(), UnitDerivationError> {
+    if input.roster.relation != compiled.plan.roster_relation {
+        return Err(UnitDerivationError::InvalidPlan(format!(
+            "roster bound `{}` but compiled constitution requires `{}`",
+            input.roster.relation, compiled.plan.roster_relation
+        )));
+    }
+    if input.roster.scope.is_empty() || input.segment.is_empty() {
+        return Err(UnitDerivationError::InvalidPlan(
+            "roster scope and evaluation segment must be non-empty".to_string(),
+        ));
+    }
+    let roster = input
+        .roster
+        .persons
+        .iter()
+        .cloned()
+        .collect::<BTreeSet<_>>();
+    if roster.len() != input.roster.persons.len() {
+        return Err(UnitDerivationError::DuplicateNamespace {
+            namespace: "roster person",
+            id: input
+                .roster
+                .persons
+                .iter()
+                .find(|person| {
+                    input
+                        .roster
+                        .persons
+                        .iter()
+                        .filter(|candidate| *candidate == *person)
+                        .count()
+                        > 1
+                })
+                .cloned()
+                .unwrap_or_default(),
+        });
+    }
+    if roster.is_empty() {
+        return Err(UnitDerivationError::InvalidPlan(
+            "roster must contain at least one person".to_string(),
+        ));
+    }
+
+    let mut referenced = BTreeSet::new();
+    for edge in compiled.edges.values() {
+        referenced.insert(edge.left.clone());
+        referenced.insert(edge.right.clone());
+    }
+    for cut in compiled.cuts.values() {
+        referenced.extend(cut.members.iter().cloned());
+    }
+    for attachment in compiled.attachments.values() {
+        referenced.extend(attachment.members.iter().cloned());
+        referenced.insert(attachment.target_anchor.clone());
+    }
+    for bar in compiled.bars.values() {
+        referenced.extend(bar.members.iter().cloned());
+    }
+    for status in compiled.statuses.values() {
+        referenced.insert(status.person.clone());
+    }
+    if let Some(missing) = referenced.difference(&roster).next() {
+        return Err(UnitDerivationError::InvalidPlan(format!(
+            "operation names person `{missing}` outside the roster"
+        )));
+    }
+    Ok(())
+}
+
+fn all_fact_refs(compiled: &CompiledConstitution, input: &ConstitutionInput) -> BTreeSet<FactRef> {
+    let mut facts = BTreeSet::new();
+    for edge in compiled.edges.values() {
+        facts.extend(expr_fact_refs(&edge.when, &compiled.derived_bools));
+        for defeater in &edge.defeaters {
+            facts.extend(expr_fact_refs(&defeater.when, &compiled.derived_bools));
+        }
+    }
+    for cut in compiled.cuts.values() {
+        facts.extend(expr_fact_refs(&cut.when, &compiled.derived_bools));
+    }
+    for attachment in compiled.attachments.values() {
+        facts.extend(expr_fact_refs(&attachment.when, &compiled.derived_bools));
+    }
+    for bar in compiled.bars.values() {
+        facts.extend(expr_fact_refs(&bar.when, &compiled.derived_bools));
+    }
+    for status in compiled.statuses.values() {
+        facts.extend(expr_fact_refs(&status.when, &compiled.derived_bools));
+    }
+    for constraint in &input.integrity_constraints {
+        facts.extend(expr_fact_refs(&constraint.expr, &compiled.derived_bools));
+    }
+    facts
+}
+
+fn bind_facts(
+    compiled: &CompiledConstitution,
+    input: &ConstitutionInput,
+    referenced: &BTreeSet<FactRef>,
+) -> Result<BoundFacts, UnitDerivationError> {
+    let mut families = BTreeMap::new();
+    for family in &input.relation_families {
+        insert_unique_ref(
+            "relation family",
+            &mut families,
+            family.name.clone(),
+            family,
+        )?;
+    }
+    let mut bool_facts = BTreeMap::new();
+    for fact in &input.bool_facts {
+        if fact.explicit_unknown.is_some() && !fact.observations.is_empty() {
+            return Err(UnitDerivationError::InvalidPlan(format!(
+                "boolean fact `{}` supplies both explicit Unknown and observations",
+                fact.name
+            )));
+        }
+        insert_unique_ref("boolean fact", &mut bool_facts, fact.name.clone(), fact)?;
+    }
+
+    let request_evidence = bool_facts
+        .iter()
+        .map(|(name, fact)| {
+            let evidence = fact
+                .observations
+                .iter()
+                .map(|observation| observation.evidence.id.clone())
+                .chain(
+                    fact.explicit_unknown
+                        .iter()
+                        .map(|evidence| evidence.id.clone()),
+                )
+                .collect();
+            (name.clone(), evidence)
+        })
+        .collect();
+
+    let mut values = BTreeMap::new();
+    let mut conflicts = BTreeSet::new();
+    let mut completeness_evidence = BTreeSet::new();
+    let election_policies = election_policies(compiled);
+    let mut election_defaults = BTreeMap::new();
+    if let Some(evidence) = &input.roster.completeness {
+        completeness_evidence.insert(evidence.id.clone());
+    }
+
+    for fact in referenced {
+        let normalized = match fact {
+            FactRef::Bool(name) => match bool_facts.get(name) {
+                Some(input) if input.explicit_unknown.is_some() => NormalizedBool::Unknown,
+                Some(input) if !input.observations.is_empty() => {
+                    normalize_observations(&input.observations)
+                }
+                _ => match election_policies.get(name) {
+                    Some((actor, MissingElectionPolicy::AuthorityDefault { value, citation })) => {
+                        election_defaults
+                            .insert(name.clone(), (actor.clone(), *value, citation.clone()));
+                        NormalizedBool::Known(*value)
+                    }
+                    Some((_, MissingElectionPolicy::Unknown)) | None => NormalizedBool::Unknown,
+                },
+            },
+            FactRef::Relation { family, tuple } => {
+                let Some(family) = families.get(family) else {
+                    values.insert(fact.key(), NormalizedBool::Unknown);
+                    continue;
+                };
+                let observations = family
+                    .facts
+                    .iter()
+                    .filter(|record| &record.tuple == tuple)
+                    .map(|record| record.observation.clone())
+                    .collect::<Vec<_>>();
+                if observations.is_empty() {
+                    if family.scope == input.roster.scope {
+                        if let Some(evidence) = &family.completeness {
+                            completeness_evidence.insert(evidence.id.clone());
+                            NormalizedBool::Known(false)
+                        } else {
+                            NormalizedBool::Unknown
+                        }
+                    } else {
+                        NormalizedBool::Unknown
+                    }
+                } else if family.scope == input.roster.scope {
+                    if let Some(evidence) = &family.completeness {
+                        completeness_evidence.insert(evidence.id.clone());
+                    }
+                    normalize_observations(&observations)
+                } else {
+                    NormalizedBool::Unknown
+                }
+            }
+        };
+        if matches!(normalized, NormalizedBool::Conflict(_)) {
+            conflicts.insert(fact.key());
+        }
+        values.insert(fact.key(), normalized);
+    }
+    Ok(BoundFacts {
+        values,
+        conflicts,
+        completeness_evidence,
+        election_defaults,
+        request_evidence,
+    })
+}
+
+fn election_policies(
+    compiled: &CompiledConstitution,
+) -> BTreeMap<String, (String, MissingElectionPolicy)> {
+    let mut policies = BTreeMap::new();
+    for election in compiled
+        .cuts
+        .values()
+        .filter_map(|rule| rule.election.as_ref())
+        .chain(
+            compiled
+                .attachments
+                .values()
+                .filter_map(|rule| rule.election.as_ref()),
+        )
+    {
+        let value = (election.actor.clone(), election.missing.clone());
+        match policies.entry(election.fact.clone()) {
+            std::collections::btree_map::Entry::Vacant(slot) => {
+                slot.insert(value);
+            }
+            std::collections::btree_map::Entry::Occupied(slot) => {
+                debug_assert_eq!(slot.get(), &value, "compile validated election policies");
+            }
+        }
+    }
+    policies
+}
+
+fn insert_unique_ref<'a, T>(
+    namespace: &'static str,
+    values: &mut BTreeMap<String, &'a T>,
+    id: String,
+    value: &'a T,
+) -> Result<(), UnitDerivationError> {
+    match values.entry(id.clone()) {
+        std::collections::btree_map::Entry::Vacant(entry) => {
+            entry.insert(value);
+            Ok(())
+        }
+        std::collections::btree_map::Entry::Occupied(_) => {
+            Err(UnitDerivationError::DuplicateNamespace { namespace, id })
+        }
+    }
+}
+
+fn normalize_observations(observations: &[ObservedBool]) -> NormalizedBool {
+    let distinct = observations.iter().cloned().collect::<BTreeSet<_>>();
+    if distinct.is_empty() {
+        NormalizedBool::Unknown
+    } else if distinct.len() == 1 {
+        NormalizedBool::Known(distinct.iter().next().expect("one observation").value)
+    } else {
+        NormalizedBool::Conflict(distinct.iter().map(|item| item.value).collect())
+    }
+}
+
+fn world_variables(
+    compiled: &CompiledConstitution,
+    bound: &BoundFacts,
+) -> (WorldVariables, BTreeMap<String, bool>) {
+    let mut variables = Vec::new();
+    let mut fixed = BTreeMap::new();
+    for (key, value) in &bound.values {
+        match value {
+            NormalizedBool::Known(value) => {
+                fixed.insert(key.clone(), *value);
+            }
+            NormalizedBool::Unknown => variables.push((key.clone(), vec![false, true])),
+            NormalizedBool::Conflict(candidates) => {
+                variables.push((key.clone(), candidates.iter().copied().collect()));
+            }
+        }
+    }
+    for cut in compiled.cuts.values() {
+        for precedence in &cut.edge_precedence {
+            if matches!(precedence.decision, CutEdgeDecision::Unresolved { .. }) {
+                variables.push((
+                    legal_precedence_key(&cut.id, &precedence.edge_rule),
+                    vec![false, true],
+                ));
+            }
+        }
+    }
+    (variables, fixed)
+}
+
+fn variable_world_count(variables: &[(String, Vec<bool>)]) -> Result<usize, UnitDerivationError> {
+    variables.iter().try_fold(1usize, |count, (_, values)| {
+        count
+            .checked_mul(values.len())
+            .ok_or(UnitDerivationError::UncheckableWorldSpace {
+                worlds: usize::MAX,
+                maximum: usize::MAX,
+            })
+    })
+}
+
+fn enumerate_worlds(
+    variables: &[(String, Vec<bool>)],
+    index: usize,
+    valuation: BTreeMap<String, bool>,
+    worlds: &mut Vec<BTreeMap<String, bool>>,
+) {
+    if index == variables.len() {
+        worlds.push(valuation);
+        return;
+    }
+    let (key, values) = &variables[index];
+    for value in values {
+        let mut branch = valuation.clone();
+        branch.insert(key.clone(), *value);
+        enumerate_worlds(variables, index + 1, branch, worlds);
+    }
+}
+
+fn eval_expr(
+    expr: &BoolExpr,
+    valuation: &BTreeMap<String, bool>,
+    derived: &BTreeMap<String, DerivedBool>,
+    visiting: &mut BTreeSet<String>,
+) -> Result<bool, UnitDerivationError> {
+    match expr {
+        BoolExpr::Literal(value) => Ok(*value),
+        BoolExpr::Fact(fact) => valuation.get(&fact.key()).copied().ok_or_else(|| {
+            UnitDerivationError::UnknownReference {
+                from: "valuation".to_string(),
+                reference: fact.key(),
+            }
+        }),
+        BoolExpr::Derived(reference) => {
+            if !visiting.insert(reference.clone()) {
+                return Err(UnitDerivationError::CyclicDependency(reference.clone()));
+            }
+            let rule =
+                derived
+                    .get(reference)
+                    .ok_or_else(|| UnitDerivationError::UnknownReference {
+                        from: "constitution expression".to_string(),
+                        reference: reference.clone(),
+                    })?;
+            let result = eval_expr(&rule.expr, valuation, derived, visiting);
+            visiting.remove(reference);
+            result
+        }
+        BoolExpr::And(items) => {
+            for item in items {
+                if !eval_expr(item, valuation, derived, visiting)? {
+                    return Ok(false);
+                }
+            }
+            Ok(true)
+        }
+        BoolExpr::Or(items) => {
+            for item in items {
+                if eval_expr(item, valuation, derived, visiting)? {
+                    return Ok(true);
+                }
+            }
+            Ok(false)
+        }
+        BoolExpr::Not(item) => Ok(!eval_expr(item, valuation, derived, visiting)?),
+    }
+}
+
+fn evaluate_world(
+    compiled: &CompiledConstitution,
+    persons: &BTreeSet<String>,
+    valuation: &BTreeMap<String, bool>,
+    influence: &BTreeMap<String, BTreeSet<String>>,
+    bound: &BoundFacts,
+) -> Result<WorldResult, UnitDerivationError> {
+    let mut events = BTreeSet::new();
+    let mut frozen = Vec::new();
+    for edge in compiled.edges.values() {
+        let active = eval_expr(
+            &edge.when,
+            valuation,
+            &compiled.derived_bools,
+            &mut BTreeSet::new(),
+        )?;
+        let mut defeated = false;
+        for defeater in &edge.defeaters {
+            if eval_expr(
+                &defeater.when,
+                valuation,
+                &compiled.derived_bools,
+                &mut BTreeSet::new(),
+            )? {
+                defeated = true;
+                break;
+            }
+        }
+        if active && !defeated {
+            events.insert(TraceEvent::FrozenEdge {
+                rule: edge.id.clone(),
+                left: edge.left.clone(),
+                right: edge.right.clone(),
+            });
+            frozen.push(FrozenEdge {
+                id: edge.id.clone(),
+                kind: edge.kind,
+                left: edge.left.clone(),
+                right: edge.right.clone(),
+                citation: edge.citation.clone(),
+            });
+        }
+    }
+
+    let mut forced_indeterminate = BTreeMap::new();
+    if compiled.plan.base_chain_policy.is_none() {
+        for component in graph_components(
+            persons,
+            frozen.iter().filter(|edge| edge.kind == EdgeKind::Base),
+        ) {
+            if component.len() > 2 && !is_edge_clique(&component, &frozen, EdgeKind::Base) {
+                let mut listed = component.iter().cloned().collect::<Vec<_>>();
+                listed.sort();
+                events.insert(TraceEvent::DiscretionNotEncoded {
+                    persons: listed.clone(),
+                });
+                for person in influence_closure_from_seed(compiled, &component, influence) {
+                    forced_indeterminate.insert(person, IndeterminateKind::DiscretionNotEncoded);
+                }
+            }
+        }
+    }
+
+    let mut active_cuts = Vec::new();
+    for cut in compiled.cuts.values() {
+        if eval_expr(
+            &cut.when,
+            valuation,
+            &compiled.derived_bools,
+            &mut BTreeSet::new(),
+        )? {
+            active_cuts.push(ActiveCut {
+                ids: BTreeSet::from([cut.id.clone()]),
+                members: cut.members.clone(),
+                citations: BTreeSet::from([cut.citation.clone()]),
+            });
+        }
+    }
+    apply_cut_precedence(compiled, &mut active_cuts);
+    let mut coalesced = BTreeMap::<BTreeSet<String>, ActiveCut>::new();
+    for cut in active_cuts {
+        let entry = coalesced
+            .entry(cut.members.clone())
+            .or_insert_with(|| ActiveCut {
+                ids: BTreeSet::new(),
+                members: cut.members.clone(),
+                citations: BTreeSet::new(),
+            });
+        entry.ids.extend(cut.ids);
+        entry.citations.extend(cut.citations);
+    }
+    let mut active_cuts = coalesced.into_values().collect::<Vec<_>>();
+
+    let mut rejected = BTreeSet::new();
+    for left_index in 0..active_cuts.len() {
+        for right_index in (left_index + 1)..active_cuts.len() {
+            let left = &active_cuts[left_index];
+            let right = &active_cuts[right_index];
+            if !left.members.is_disjoint(&right.members) {
+                let left_id = left.ids.iter().next().expect("active cut id").clone();
+                let right_id = right.ids.iter().next().expect("active cut id").clone();
+                events.insert(TraceEvent::CutOverlapConflict {
+                    left: left_id,
+                    right: right_id,
+                });
+                let seed = left
+                    .members
+                    .union(&right.members)
+                    .cloned()
+                    .collect::<BTreeSet<_>>();
+                for person in influence_closure_from_seed(compiled, &seed, influence) {
+                    forced_indeterminate
+                        .insert(person, IndeterminateKind::ConstitutionOverlapConflict);
+                }
+                rejected.insert(left_index);
+                rejected.insert(right_index);
+            }
+        }
+    }
+    active_cuts = active_cuts
+        .into_iter()
+        .enumerate()
+        .filter_map(|(index, cut)| (!rejected.contains(&index)).then_some(cut))
+        .collect();
+
+    let mut applied = Vec::new();
+    for cut in active_cuts {
+        let mut blocked = false;
+        for edge in frozen
+            .iter()
+            .filter(|edge| edge.kind == EdgeKind::Combination)
+        {
+            if cut.members.contains(&edge.left) == cut.members.contains(&edge.right) {
+                continue;
+            }
+            for cut_id in &cut.ids {
+                let rule = &compiled.cuts[cut_id];
+                let precedence = rule
+                    .edge_precedence
+                    .iter()
+                    .find(|item| item.edge_rule == edge.id)
+                    .expect("compile requires crossing precedence");
+                let edge_blocks = match &precedence.decision {
+                    CutEdgeDecision::Blocked { .. } => true,
+                    CutEdgeDecision::Overrides { .. } => false,
+                    CutEdgeDecision::Unresolved { .. } => {
+                        !valuation[&legal_precedence_key(&rule.id, &precedence.edge_rule)]
+                    }
+                };
+                if edge_blocks {
+                    blocked = true;
+                    events.insert(TraceEvent::CutBlocked {
+                        cut: rule.id.clone(),
+                        edge_rule: edge.id.clone(),
+                        actor: rule
+                            .election
+                            .as_ref()
+                            .map(|election| election.actor.clone()),
+                        request_evidence: rule
+                            .election
+                            .as_ref()
+                            .and_then(|election| bound.request_evidence.get(&election.fact))
+                            .cloned()
+                            .unwrap_or_default(),
+                    });
+                }
+            }
+        }
+        if !blocked {
+            for id in &cut.ids {
+                let rule = &compiled.cuts[id];
+                events.insert(TraceEvent::CutApplied {
+                    rule: id.clone(),
+                    actor: rule
+                        .election
+                        .as_ref()
+                        .map(|election| election.actor.clone()),
+                    request_evidence: rule
+                        .election
+                        .as_ref()
+                        .and_then(|election| bound.request_evidence.get(&election.fact))
+                        .cloned()
+                        .unwrap_or_default(),
+                });
+            }
+            applied.push(cut);
+        }
+    }
+
+    let excluded = forced_indeterminate
+        .keys()
+        .cloned()
+        .collect::<BTreeSet<_>>();
+    let mut cut_members = BTreeSet::new();
+    let mut blocks = Vec::<BTreeSet<String>>::new();
+    for cut in &applied {
+        let members = cut
+            .members
+            .difference(&excluded)
+            .cloned()
+            .collect::<BTreeSet<_>>();
+        cut_members.extend(members.iter().cloned());
+        if !members.is_empty() {
+            blocks.push(members);
+        }
+    }
+    let residue = persons
+        .difference(&excluded)
+        .filter(|person| !cut_members.contains(*person))
+        .cloned()
+        .collect::<BTreeSet<_>>();
+    blocks.extend(graph_components(
+        &residue,
+        frozen
+            .iter()
+            .filter(|edge| residue.contains(&edge.left) && residue.contains(&edge.right)),
+    ));
+
+    let mut attached = BTreeSet::new();
+    for attachment in compiled.attachments.values() {
+        if !eval_expr(
+            &attachment.when,
+            valuation,
+            &compiled.derived_bools,
+            &mut BTreeSet::new(),
+        )? {
+            continue;
+        }
+        let Some(target_index) = blocks
+            .iter()
+            .position(|block| block.contains(&attachment.target_anchor))
+        else {
+            continue;
+        };
+        let moving = attachment
+            .members
+            .difference(&excluded)
+            .cloned()
+            .collect::<BTreeSet<_>>();
+        for block in &mut blocks {
+            block.retain(|person| !moving.contains(person));
+        }
+        blocks[target_index].extend(moving.iter().cloned());
+        blocks.retain(|block| !block.is_empty());
+        attached.extend(moving);
+        events.insert(TraceEvent::Attachment {
+            rule: attachment.id.clone(),
+            target_anchor: attachment.target_anchor.clone(),
+            actor: attachment.actor.clone(),
+            request_evidence: attachment
+                .election
+                .as_ref()
+                .and_then(|election| bound.request_evidence.get(&election.fact))
+                .cloned()
+                .unwrap_or_default(),
+        });
+    }
+    canonicalize_blocks(&mut blocks);
+
+    let mut roles = persons
+        .iter()
+        .map(|person| (person.clone(), ProjectionRole::Member))
+        .collect::<BTreeMap<_, _>>();
+    for bar in compiled.bars.values() {
+        if eval_expr(
+            &bar.when,
+            valuation,
+            &compiled.derived_bools,
+            &mut BTreeSet::new(),
+        )? && !bar.members.is_subset(&attached)
+        {
+            for person in &bar.members {
+                roles.insert(person.clone(), ProjectionRole::BarredIndependent);
+            }
+            events.insert(TraceEvent::IndependentBar {
+                rule: bar.id.clone(),
+            });
+        }
+    }
+    for status in compiled.statuses.values() {
+        if eval_expr(
+            &status.when,
+            valuation,
+            &compiled.derived_bools,
+            &mut BTreeSet::new(),
+        )? {
+            roles.insert(status.person.clone(), ProjectionRole::Excluded);
+            events.insert(TraceEvent::StatusExcluded {
+                rule: status.id.clone(),
+                person: status.person.clone(),
+            });
+        }
+    }
+
+    let mut world_persons = BTreeMap::new();
+    for person in persons {
+        if let Some(kind) = forced_indeterminate.get(person) {
+            world_persons.insert(
+                person.clone(),
+                WorldPerson {
+                    block: None,
+                    role: None,
+                    kind: Some(kind.clone()),
+                    citations: BTreeSet::new(),
+                },
+            );
+            continue;
+        }
+        let block = blocks
+            .iter()
+            .find(|block| block.contains(person))
+            .expect("every determined roster person is partitioned");
+        let block_vec = block.iter().cloned().collect::<Vec<_>>();
+        let mut citations = BTreeSet::new();
+        for edge in &frozen {
+            if block.contains(&edge.left) && block.contains(&edge.right) {
+                citations.insert(edge.citation.clone());
+            }
+        }
+        for cut in &applied {
+            let residual_of_cut = frozen.iter().any(|edge| {
+                (block.contains(&edge.left) && cut.members.contains(&edge.right))
+                    || (block.contains(&edge.right) && cut.members.contains(&edge.left))
+            });
+            if cut.members.contains(person) || residual_of_cut {
+                citations.extend(cut.citations.iter().cloned());
+            }
+        }
+        for attachment in compiled.attachments.values() {
+            if block.contains(&attachment.target_anchor)
+                && attachment
+                    .members
+                    .iter()
+                    .any(|member| block.contains(member))
+            {
+                citations.insert(attachment.citation.clone());
+            }
+        }
+        for bar in compiled.bars.values() {
+            if roles.get(person) == Some(&ProjectionRole::BarredIndependent)
+                && bar.members.contains(person)
+            {
+                citations.insert(bar.citation.clone());
+            }
+        }
+        for status in compiled.statuses.values() {
+            if roles.get(person) == Some(&ProjectionRole::Excluded) && status.person == *person {
+                citations.insert(status.citation.clone());
+            }
+        }
+        world_persons.insert(
+            person.clone(),
+            WorldPerson {
+                block: Some(block_vec),
+                role: roles.get(person).copied(),
+                kind: None,
+                citations,
+            },
+        );
+    }
+    Ok(WorldResult {
+        persons: world_persons,
+        events,
+    })
+}
+
+fn graph_components<'a>(
+    vertices: &BTreeSet<String>,
+    edges: impl Iterator<Item = &'a FrozenEdge>,
+) -> Vec<BTreeSet<String>> {
+    let mut adjacency = vertices
+        .iter()
+        .map(|person| (person.clone(), BTreeSet::new()))
+        .collect::<BTreeMap<_, _>>();
+    for edge in edges {
+        if vertices.contains(&edge.left) && vertices.contains(&edge.right) {
+            adjacency
+                .get_mut(&edge.left)
+                .expect("edge endpoint in vertices")
+                .insert(edge.right.clone());
+            adjacency
+                .get_mut(&edge.right)
+                .expect("edge endpoint in vertices")
+                .insert(edge.left.clone());
+        }
+    }
+    let mut remaining = vertices.clone();
+    let mut components = Vec::new();
+    while let Some(seed) = remaining.iter().next().cloned() {
+        let mut component = BTreeSet::new();
+        let mut queue = VecDeque::from([seed]);
+        while let Some(person) = queue.pop_front() {
+            if !remaining.remove(&person) {
+                continue;
+            }
+            component.insert(person.clone());
+            queue.extend(adjacency[&person].iter().cloned());
+        }
+        components.push(component);
+    }
+    canonicalize_blocks(&mut components);
+    components
+}
+
+fn canonicalize_blocks(blocks: &mut Vec<BTreeSet<String>>) {
+    blocks.sort_by(|left, right| left.iter().cmp(right.iter()));
+    blocks.dedup();
+}
+
+fn is_edge_clique(component: &BTreeSet<String>, edges: &[FrozenEdge], kind: EdgeKind) -> bool {
+    let members = component.iter().collect::<Vec<_>>();
+    for (index, left) in members.iter().enumerate() {
+        for right in members.iter().skip(index + 1) {
+            if !edges.iter().any(|edge| {
+                edge.kind == kind
+                    && ((&edge.left == *left && &edge.right == *right)
+                        || (&edge.left == *right && &edge.right == *left))
+            }) {
+                return false;
+            }
+        }
+    }
+    true
+}
+
+fn apply_cut_precedence(compiled: &CompiledConstitution, cuts: &mut Vec<ActiveCut>) {
+    let mut rejected = BTreeSet::new();
+    for left_index in 0..cuts.len() {
+        for right_index in (left_index + 1)..cuts.len() {
+            if cuts[left_index]
+                .members
+                .is_disjoint(&cuts[right_index].members)
+            {
+                continue;
+            }
+            let left_precedes =
+                cut_set_precedes(compiled, &cuts[left_index].ids, &cuts[right_index].ids);
+            let right_precedes =
+                cut_set_precedes(compiled, &cuts[right_index].ids, &cuts[left_index].ids);
+            match (left_precedes, right_precedes) {
+                (true, false) => {
+                    rejected.insert(right_index);
+                }
+                (false, true) => {
+                    rejected.insert(left_index);
+                }
+                _ => {}
+            }
+        }
+    }
+    *cuts = cuts
+        .drain(..)
+        .enumerate()
+        .filter_map(|(index, cut)| (!rejected.contains(&index)).then_some(cut))
+        .collect();
+}
+
+fn cut_set_precedes(
+    compiled: &CompiledConstitution,
+    higher: &BTreeSet<String>,
+    lower: &BTreeSet<String>,
+) -> bool {
+    let mut pending = higher.iter().cloned().collect::<Vec<_>>();
+    let mut visited = BTreeSet::new();
+    while let Some(id) = pending.pop() {
+        if !visited.insert(id.clone()) {
+            continue;
+        }
+        for order in &compiled.cuts[&id].precedes {
+            if lower.contains(&order.lower_priority_cut) {
+                return true;
+            }
+            pending.push(order.lower_priority_cut.clone());
+        }
+    }
+    false
+}
+
+fn influence_sets(
+    compiled: &CompiledConstitution,
+    input: &ConstitutionInput,
+    bound: &BoundFacts,
+) -> BTreeMap<String, BTreeSet<String>> {
+    let roster = input
+        .roster
+        .persons
+        .iter()
+        .cloned()
+        .collect::<BTreeSet<_>>();
+    let unresolved = bound
+        .values
+        .iter()
+        .filter_map(|(key, value)| {
+            (!matches!(value, NormalizedBool::Known(_))).then_some(key.clone())
+        })
+        .chain(compiled.cuts.values().flat_map(|cut| {
+            cut.edge_precedence
+                .iter()
+                .filter(|precedence| {
+                    matches!(precedence.decision, CutEdgeDecision::Unresolved { .. })
+                })
+                .map(|precedence| legal_precedence_key(&cut.id, &precedence.edge_rule))
+        }))
+        .collect::<BTreeSet<_>>();
+    let facts_by_key = all_fact_refs(compiled, input)
+        .into_iter()
+        .map(|fact| (fact.key(), fact))
+        .collect::<BTreeMap<_, _>>();
+    let constraint_facts = input
+        .integrity_constraints
+        .iter()
+        .flat_map(|constraint| expr_fact_refs(&constraint.expr, &compiled.derived_bools))
+        .map(|fact| fact.key())
+        .collect::<BTreeSet<_>>();
+
+    let mut result = BTreeMap::new();
+    for key in unresolved {
+        let mut closure = facts_by_key
+            .get(&key)
+            .map_or_else(BTreeSet::new, |fact| fact.named_persons());
+        if constraint_facts.contains(&key) {
+            closure.extend(roster.iter().cloned());
+        }
+        for edge in compiled.edges.values() {
+            if expression_uses_key(&edge.when, key.as_str(), compiled)
+                || edge
+                    .defeaters
+                    .iter()
+                    .any(|item| expression_uses_key(&item.when, key.as_str(), compiled))
+            {
+                closure.insert(edge.left.clone());
+                closure.insert(edge.right.clone());
+            }
+        }
+        for cut in compiled.cuts.values() {
+            if expression_uses_key(&cut.when, key.as_str(), compiled)
+                || cut
+                    .edge_precedence
+                    .iter()
+                    .any(|precedence| legal_precedence_key(&cut.id, &precedence.edge_rule) == key)
+            {
+                closure.extend(cut.members.iter().cloned());
+                for precedence in &cut.edge_precedence {
+                    if legal_precedence_key(&cut.id, &precedence.edge_rule) == key {
+                        let edge = &compiled.edges[&precedence.edge_rule];
+                        closure.insert(edge.left.clone());
+                        closure.insert(edge.right.clone());
+                    }
+                }
+            }
+        }
+        for attachment in compiled.attachments.values() {
+            if expression_uses_key(&attachment.when, key.as_str(), compiled) {
+                closure.extend(attachment.members.iter().cloned());
+                closure.insert(attachment.target_anchor.clone());
+            }
+        }
+        for bar in compiled.bars.values() {
+            if expression_uses_key(&bar.when, key.as_str(), compiled) {
+                closure.extend(bar.members.iter().cloned());
+            }
+        }
+        for status in compiled.statuses.values() {
+            if expression_uses_key(&status.when, key.as_str(), compiled) {
+                closure.insert(status.person.clone());
+            }
+        }
+        close_potential_influence(compiled, &mut closure);
+        result.insert(key, closure);
+    }
+    result
+}
+
+fn expression_uses_key(expr: &BoolExpr, key: &str, compiled: &CompiledConstitution) -> bool {
+    expr_fact_refs(expr, &compiled.derived_bools)
+        .iter()
+        .any(|fact| fact.key() == key)
+}
+
+fn close_potential_influence(compiled: &CompiledConstitution, closure: &mut BTreeSet<String>) {
+    loop {
+        let before = closure.len();
+        for edge in compiled.edges.values() {
+            if closure.contains(&edge.left) || closure.contains(&edge.right) {
+                closure.insert(edge.left.clone());
+                closure.insert(edge.right.clone());
+            }
+        }
+        for cut in compiled.cuts.values() {
+            if !closure.is_disjoint(&cut.members) {
+                closure.extend(cut.members.iter().cloned());
+            }
+        }
+        for attachment in compiled.attachments.values() {
+            let touches = closure.contains(&attachment.target_anchor)
+                || !closure.is_disjoint(&attachment.members);
+            if touches {
+                closure.extend(attachment.members.iter().cloned());
+                closure.insert(attachment.target_anchor.clone());
+            }
+        }
+        for bar in compiled.bars.values() {
+            if !closure.is_disjoint(&bar.members) {
+                closure.extend(bar.members.iter().cloned());
+            }
+        }
+        if closure.len() == before {
+            break;
+        }
+    }
+}
+
+fn influence_closure_from_seed(
+    compiled: &CompiledConstitution,
+    seed: &BTreeSet<String>,
+    influence: &BTreeMap<String, BTreeSet<String>>,
+) -> BTreeSet<String> {
+    let mut closure = seed.clone();
+    loop {
+        let before = closure.len();
+        for affected in influence.values() {
+            if !closure.is_disjoint(affected) {
+                closure.extend(affected.iter().cloned());
+            }
+        }
+        if closure.len() == before {
+            close_potential_influence(compiled, &mut closure);
+            return closure;
+        }
+    }
+}
+
+fn assemble_result(
+    compiled: &CompiledConstitution,
+    input: &ConstitutionInput,
+    persons: &BTreeSet<String>,
+    bound: &BoundFacts,
+    influence: &BTreeMap<String, BTreeSet<String>>,
+    worlds: Vec<WorldResult>,
+) -> Result<UnitDerivationResult, UnitDerivationError> {
+    let mut events = BTreeSet::new();
+    for world in &worlds {
+        events.extend(world.events.iter().cloned());
+    }
+    events.extend(
+        bound
+            .election_defaults
+            .iter()
+            .map(
+                |(fact, (actor, value, citation))| TraceEvent::ElectionDefault {
+                    fact: fact.clone(),
+                    actor: actor.clone(),
+                    value: *value,
+                    citation: citation.clone(),
+                },
+            ),
+    );
+    let trace_root = trace_root(compiled, input, worlds.len(), &events);
+    let provenance = Provenance::Derived {
+        constitution: compiled.plan.id.clone(),
+        trace_root: trace_root.clone(),
+    };
+
+    let mut determined_blocks = BTreeMap::<String, Vec<String>>::new();
+    let mut determined_roles = BTreeMap::<String, ProjectionRole>::new();
+    let mut indeterminate = Vec::new();
+    let mut citations_by_person = BTreeMap::<String, BTreeSet<Citation>>::new();
+
+    for person in persons {
+        let states = worlds
+            .iter()
+            .map(|world| &world.persons[person])
+            .collect::<Vec<_>>();
+        let first_block = states[0].block.clone();
+        let block_invariant =
+            first_block.is_some() && states.iter().all(|state| state.block == first_block);
+        if block_invariant {
+            determined_blocks.insert(person.clone(), first_block.expect("checked Some"));
+            let role = states[0].role;
+            if let Some(role) = role
+                && states.iter().all(|state| state.role == Some(role))
+            {
+                determined_roles.insert(person.clone(), role);
+            } else {
+                indeterminate.push(IndeterminatePerson {
+                    person: person.clone(),
+                    kind: IndeterminateKind::Role(Projection::ParticipatingMember),
+                    unresolved_facts: unresolved_for_person(person, influence),
+                });
+            }
+        } else {
+            let kind = states
+                .iter()
+                .find_map(|state| state.kind.clone())
+                .unwrap_or(IndeterminateKind::Membership);
+            indeterminate.push(IndeterminatePerson {
+                person: person.clone(),
+                kind,
+                unresolved_facts: unresolved_for_person(person, influence),
+            });
+        }
+        let citations = citations_by_person.entry(person.clone()).or_default();
+        for state in states {
+            citations.extend(state.citations.iter().cloned());
+        }
+    }
+
+    let invariant_blocks = determined_blocks
+        .values()
+        .filter(|block| {
+            block.iter().all(|member| {
+                determined_blocks
+                    .get(member)
+                    .is_some_and(|candidate| candidate == *block)
+            })
+        })
+        .cloned()
+        .collect::<BTreeSet<_>>();
+
+    let mut registry = EntityRegistry::default();
+    for entity in &input.supplied_entities {
+        registry.bind_supplied(
+            entity.entity_type.clone(),
+            entity.id.clone(),
+            entity.evidence.id.clone(),
+        )?;
+    }
+    let roster_evidence = input
+        .roster
+        .completeness
+        .as_ref()
+        .expect("incomplete roster returned before assembly")
+        .id
+        .clone();
+    for person in persons {
+        registry.bind_supplied("person", person.clone(), roster_evidence.clone())?;
+    }
+
+    let mut units = Vec::new();
+    let mut ids_by_block = BTreeMap::new();
+    for block in invariant_blocks {
+        let digest_id = unit_id(
+            compiled.semantics_digest,
+            &compiled.plan.relations.unit_constituent,
+            &input.roster.scope,
+            &input.segment,
+            &block,
+        );
+        let id = format!("{}:{digest_id}", compiled.plan.entity_type);
+        ids_by_block.insert(block.clone(), id.clone());
+        let unit = DerivedUnit {
+            entity_type: compiled.plan.entity_type.clone(),
+            id,
+            members: block,
+            provenance: provenance.clone(),
+        };
+        registry.insert_derived(&unit)?;
+        units.push(unit);
+    }
+    units.sort_by(|left, right| left.id.cmp(&right.id));
+
+    let mut memberships = Vec::new();
+    for (person, block) in &determined_blocks {
+        let Some(unit) = ids_by_block.get(block) else {
+            continue;
+        };
+        memberships.push(MembershipTuple {
+            relation: compiled.plan.relations.unit_constituent.clone(),
+            unit: unit.clone(),
+            person: person.clone(),
+            projection: Projection::UnitConstituent,
+            role: ProjectionRole::Member,
+            citations: citations_by_person[person].clone(),
+            provenance: provenance.clone(),
+        });
+        if let Some(role) = determined_roles.get(person) {
+            memberships.push(MembershipTuple {
+                relation: compiled.plan.relations.participating_member.clone(),
+                unit: unit.clone(),
+                person: person.clone(),
+                projection: Projection::ParticipatingMember,
+                role: *role,
+                citations: citations_by_person[person].clone(),
+                provenance: provenance.clone(),
+            });
+        }
+    }
+    memberships.sort_by(|left, right| {
+        (
+            left.relation.as_str(),
+            left.unit.as_str(),
+            left.person.as_str(),
+            left.projection,
+            left.role,
+        )
+            .cmp(&(
+                right.relation.as_str(),
+                right.unit.as_str(),
+                right.person.as_str(),
+                right.projection,
+                right.role,
+            ))
+    });
+    memberships.dedup();
+    indeterminate.sort_by(|left, right| {
+        (left.person.as_str(), format!("{:?}", left.kind))
+            .cmp(&(right.person.as_str(), format!("{:?}", right.kind)))
+    });
+    indeterminate.dedup();
+
+    let input_conflict_impacts = conflict_impacts(compiled, input, bound, influence);
+
+    Ok(UnitDerivationResult {
+        relations: compiled.plan.relations.clone(),
+        units,
+        memberships,
+        indeterminate,
+        trace: DerivationTrace {
+            root: trace_root,
+            worlds_evaluated: worlds.len(),
+            events,
+            completeness_evidence: bound.completeness_evidence.clone(),
+            input_conflicts: bound.conflicts.clone(),
+            input_conflict_impacts,
+        },
+    })
+}
+
+fn unresolved_for_person(
+    person: &str,
+    influence: &BTreeMap<String, BTreeSet<String>>,
+) -> BTreeSet<String> {
+    influence
+        .iter()
+        .filter_map(|(fact, persons)| persons.contains(person).then_some(fact.clone()))
+        .collect()
+}
+
+fn roster_incomplete_result(
+    compiled: &CompiledConstitution,
+    input: &ConstitutionInput,
+    persons: &BTreeSet<String>,
+) -> UnitDerivationResult {
+    UnitDerivationResult {
+        relations: compiled.plan.relations.clone(),
+        units: Vec::new(),
+        memberships: Vec::new(),
+        indeterminate: persons
+            .iter()
+            .map(|person| IndeterminatePerson {
+                person: person.clone(),
+                kind: IndeterminateKind::RosterNotAssertedComplete,
+                unresolved_facts: BTreeSet::from(["roster_not_asserted_complete".to_string()]),
+            })
+            .collect(),
+        trace: DerivationTrace {
+            root: trace_root(compiled, input, 0, &BTreeSet::new()),
+            worlds_evaluated: 0,
+            events: BTreeSet::new(),
+            completeness_evidence: BTreeSet::new(),
+            input_conflicts: BTreeSet::new(),
+            input_conflict_impacts: BTreeSet::new(),
+        },
+    }
+}
+
+fn inconsistent_result(
+    compiled: &CompiledConstitution,
+    input: &ConstitutionInput,
+    persons: &BTreeSet<String>,
+    bound: &BoundFacts,
+) -> UnitDerivationResult {
+    UnitDerivationResult {
+        relations: compiled.plan.relations.clone(),
+        units: Vec::new(),
+        memberships: Vec::new(),
+        indeterminate: persons
+            .iter()
+            .map(|person| IndeterminatePerson {
+                person: person.clone(),
+                kind: IndeterminateKind::InconsistentInputs,
+                unresolved_facts: bound.values.keys().cloned().collect(),
+            })
+            .collect(),
+        trace: DerivationTrace {
+            root: trace_root(compiled, input, 0, &BTreeSet::new()),
+            worlds_evaluated: 0,
+            events: BTreeSet::new(),
+            completeness_evidence: bound.completeness_evidence.clone(),
+            input_conflicts: bound.conflicts.clone(),
+            input_conflict_impacts: BTreeSet::new(),
+        },
+    }
+}
+
+fn conflict_impacts(
+    compiled: &CompiledConstitution,
+    input: &ConstitutionInput,
+    bound: &BoundFacts,
+    influence: &BTreeMap<String, BTreeSet<String>>,
+) -> BTreeSet<InputConflictImpact> {
+    let constraint_keys = input
+        .integrity_constraints
+        .iter()
+        .flat_map(|constraint| expr_fact_refs(&constraint.expr, &compiled.derived_bools))
+        .map(|fact| fact.key())
+        .collect::<BTreeSet<_>>();
+    bound
+        .conflicts
+        .iter()
+        .map(|fact| {
+            let affects_composition = compiled.edges.values().any(|rule| {
+                expression_uses_key(&rule.when, fact, compiled)
+                    || rule
+                        .defeaters
+                        .iter()
+                        .any(|item| expression_uses_key(&item.when, fact, compiled))
+            }) || compiled
+                .cuts
+                .values()
+                .any(|rule| expression_uses_key(&rule.when, fact, compiled))
+                || compiled
+                    .attachments
+                    .values()
+                    .any(|rule| expression_uses_key(&rule.when, fact, compiled))
+                || constraint_keys.contains(fact);
+            let affects_participation = affects_composition
+                || compiled
+                    .bars
+                    .values()
+                    .any(|rule| expression_uses_key(&rule.when, fact, compiled))
+                || compiled
+                    .statuses
+                    .values()
+                    .any(|rule| expression_uses_key(&rule.when, fact, compiled));
+            let mut projections = BTreeSet::new();
+            if affects_composition {
+                projections.insert(Projection::UnitConstituent);
+            }
+            if affects_participation {
+                projections.insert(Projection::ParticipatingMember);
+            }
+            InputConflictImpact {
+                fact: fact.clone(),
+                persons: influence.get(fact).cloned().unwrap_or_default(),
+                projections,
+            }
+        })
+        .collect()
+}
+
+fn trace_root(
+    compiled: &CompiledConstitution,
+    input: &ConstitutionInput,
+    worlds: usize,
+    events: &BTreeSet<TraceEvent>,
+) -> String {
+    let mut preimage = b"axiom.unit-derivation.trace.stage2\0".to_vec();
+    push_len_prefixed(&mut preimage, compiled.plan.id.as_bytes());
+    push_len_prefixed(&mut preimage, input.roster.scope.as_bytes());
+    push_len_prefixed(&mut preimage, input.segment.as_bytes());
+    preimage.extend_from_slice(&(worlds as u64).to_be_bytes());
+    for event in events {
+        push_len_prefixed(&mut preimage, format!("{event:?}").as_bytes());
+    }
+    format!("sha256:{}", hex(&sha256(&preimage)))
+}
+
+/// Content-derived identity from the fixed stage-2 preimage:
+///
+/// `domain_tag || semantics_digest || LP(relation) || LP(scope) ||
+/// LP(segment) || member_count(u32-be) || LP(sorted canonical member id)*`.
+///
+/// `LP` is a four-byte big-endian byte length followed by UTF-8 bytes. The
+/// returned value is the digest portion (`sha256:...`); emission prefixes the
+/// declared entity type. Record order, evidence, shadow tuples, and labels are
+/// absent from the preimage.
+pub fn unit_id(
+    semantics_digest: [u8; 32],
+    canonical_relation_id: &str,
+    roster_scope: &str,
+    segment: &str,
+    members: &[String],
+) -> String {
+    let mut canonical_members = members.to_vec();
+    canonical_members.sort();
+    canonical_members.dedup();
+    let mut preimage = b"axiom.unit-derivation.stage2\0".to_vec();
+    preimage.extend_from_slice(&semantics_digest);
+    push_len_prefixed(&mut preimage, canonical_relation_id.as_bytes());
+    push_len_prefixed(&mut preimage, roster_scope.as_bytes());
+    push_len_prefixed(&mut preimage, segment.as_bytes());
+    preimage.extend_from_slice(&(canonical_members.len() as u32).to_be_bytes());
+    for member in canonical_members {
+        push_len_prefixed(&mut preimage, member.as_bytes());
+    }
+    format!("sha256:{}", hex(&sha256(&preimage)))
+}
+
+fn push_len_prefixed(preimage: &mut Vec<u8>, bytes: &[u8]) {
+    preimage.extend_from_slice(&(bytes.len() as u32).to_be_bytes());
+    preimage.extend_from_slice(bytes);
+}
+
+fn hex(bytes: &[u8]) -> String {
+    const DIGITS: &[u8; 16] = b"0123456789abcdef";
+    let mut output = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        output.push(DIGITS[(byte >> 4) as usize] as char);
+        output.push(DIGITS[(byte & 0x0f) as usize] as char);
+    }
+    output
+}
+
+fn legal_precedence_key(cut: &str, edge: &str) -> String {
+    format!("legal-precedence:{cut}:{edge}")
+}
+
+// Small, dependency-free SHA-256 implementation for the experimental identity
+// preimage. Keeping it local avoids changing the default dependency surface.
+pub(crate) fn sha256(input: &[u8]) -> [u8; 32] {
+    const INITIAL: [u32; 8] = [
+        0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f, 0x9b05688c, 0x1f83d9ab,
+        0x5be0cd19,
+    ];
+    const ROUND: [u32; 64] = [
+        0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4,
+        0xab1c5ed5, 0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe,
+        0x9bdc06a7, 0xc19bf174, 0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f,
+        0x4a7484aa, 0x5cb0a9dc, 0x76f988da, 0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7,
+        0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967, 0x27b70a85, 0x2e1b2138, 0x4d2c6dfc,
+        0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85, 0xa2bfe8a1, 0xa81a664b,
+        0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070, 0x19a4c116,
+        0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+        0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7,
+        0xc67178f2,
+    ];
+
+    let bit_len = (input.len() as u64).wrapping_mul(8);
+    let mut padded = input.to_vec();
+    padded.push(0x80);
+    while padded.len() % 64 != 56 {
+        padded.push(0);
+    }
+    padded.extend_from_slice(&bit_len.to_be_bytes());
+
+    let mut state = INITIAL;
+    for chunk in padded.chunks_exact(64) {
+        let mut words = [0u32; 64];
+        for (index, word) in words.iter_mut().take(16).enumerate() {
+            let offset = index * 4;
+            *word = u32::from_be_bytes([
+                chunk[offset],
+                chunk[offset + 1],
+                chunk[offset + 2],
+                chunk[offset + 3],
+            ]);
+        }
+        for index in 16..64 {
+            let s0 = words[index - 15].rotate_right(7)
+                ^ words[index - 15].rotate_right(18)
+                ^ (words[index - 15] >> 3);
+            let s1 = words[index - 2].rotate_right(17)
+                ^ words[index - 2].rotate_right(19)
+                ^ (words[index - 2] >> 10);
+            words[index] = words[index - 16]
+                .wrapping_add(s0)
+                .wrapping_add(words[index - 7])
+                .wrapping_add(s1);
+        }
+
+        let [mut a, mut b, mut c, mut d, mut e, mut f, mut g, mut h] = state;
+        for index in 0..64 {
+            let big1 = e.rotate_right(6) ^ e.rotate_right(11) ^ e.rotate_right(25);
+            let choose = (e & f) ^ ((!e) & g);
+            let temp1 = h
+                .wrapping_add(big1)
+                .wrapping_add(choose)
+                .wrapping_add(ROUND[index])
+                .wrapping_add(words[index]);
+            let big0 = a.rotate_right(2) ^ a.rotate_right(13) ^ a.rotate_right(22);
+            let majority = (a & b) ^ (a & c) ^ (b & c);
+            let temp2 = big0.wrapping_add(majority);
+            h = g;
+            g = f;
+            f = e;
+            e = d.wrapping_add(temp1);
+            d = c;
+            c = b;
+            b = a;
+            a = temp1.wrapping_add(temp2);
+        }
+        state[0] = state[0].wrapping_add(a);
+        state[1] = state[1].wrapping_add(b);
+        state[2] = state[2].wrapping_add(c);
+        state[3] = state[3].wrapping_add(d);
+        state[4] = state[4].wrapping_add(e);
+        state[5] = state[5].wrapping_add(f);
+        state[6] = state[6].wrapping_add(g);
+        state[7] = state[7].wrapping_add(h);
+    }
+
+    let mut output = [0u8; 32];
+    for (index, word) in state.into_iter().enumerate() {
+        output[index * 4..index * 4 + 4].copy_from_slice(&word.to_be_bytes());
+    }
+    output
+}

--- a/src/unit_derivation/interface.rs
+++ b/src/unit_derivation/interface.rs
@@ -1,0 +1,881 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use super::compile::CompiledConstitution;
+use super::evaluate::derive_units;
+use super::types::*;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RegistryEntry {
+    pub entity_type: String,
+    pub id: String,
+    pub provenance: Provenance,
+}
+
+/// Typed runtime entity-instance registry. The key is the instance id rather
+/// than `(type, id)`, so a cross-type collision cannot pass unnoticed.
+#[derive(Clone, Debug, Default)]
+pub struct EntityRegistry {
+    entries: BTreeMap<String, RegistryEntry>,
+}
+
+impl EntityRegistry {
+    pub fn bind_supplied(
+        &mut self,
+        entity_type: impl Into<String>,
+        id: impl Into<String>,
+        evidence_id: impl Into<String>,
+    ) -> Result<(), UnitDerivationError> {
+        let entity_type = entity_type.into();
+        let id = id.into();
+        self.insert_unique(RegistryEntry {
+            entity_type,
+            id,
+            provenance: Provenance::Supplied {
+                evidence_id: evidence_id.into(),
+            },
+        })
+    }
+
+    pub fn insert_derived(&mut self, unit: &DerivedUnit) -> Result<(), UnitDerivationError> {
+        self.insert_unique(RegistryEntry {
+            entity_type: unit.entity_type.clone(),
+            id: unit.id.clone(),
+            provenance: unit.provenance.clone(),
+        })
+    }
+
+    pub fn get(&self, id: &str) -> Option<&RegistryEntry> {
+        self.entries.get(id)
+    }
+
+    fn insert_unique(&mut self, entry: RegistryEntry) -> Result<(), UnitDerivationError> {
+        match self.entries.entry(entry.id.clone()) {
+            std::collections::btree_map::Entry::Vacant(slot) => {
+                slot.insert(entry);
+                Ok(())
+            }
+            std::collections::btree_map::Entry::Occupied(existing) => {
+                if existing.get().entity_type == entry.entity_type
+                    && matches!(existing.get().provenance, Provenance::Supplied { .. })
+                    && matches!(entry.provenance, Provenance::Supplied { .. })
+                {
+                    return Ok(());
+                }
+                Err(UnitDerivationError::EntityCollision {
+                    id: entry.id,
+                    existing_type: existing.get().entity_type.clone(),
+                    incoming_type: entry.entity_type,
+                })
+            }
+        }
+    }
+}
+
+/// The barrier-owned phase-2 dataset and its Knowledge-aware relation index.
+/// The typed registry is retained with the materialization so callers cannot
+/// accidentally separate the checked entity universe from the indexed data.
+#[derive(Clone, Debug)]
+pub struct PhaseTwoDataSet {
+    dataset: crate::model::DataSet,
+    relation_knowledge: Vec<RelationKnowledgeRecord>,
+    registry: EntityRegistry,
+}
+
+/// Feature-gated phase-2 evaluator pairing the unchanged v2 engine with the
+/// barrier's unresolved relation candidates. Complete reductions are
+/// Knowledge-valued; determined execution delegates to the ordinary engine.
+pub struct PhaseTwoEngine<'a> {
+    ordinary: crate::engine::Engine<'a>,
+    program: &'a crate::model::Program,
+    relation_knowledge: &'a [RelationKnowledgeRecord],
+}
+
+impl<'a> PhaseTwoEngine<'a> {
+    pub fn evaluate_scalar(
+        &mut self,
+        derived_name: &str,
+        entity_id: &str,
+        period: &crate::model::Period,
+    ) -> Result<CompleteReduction<crate::model::ScalarValue>, crate::engine::EvalError> {
+        let mut reasons = BTreeSet::new();
+        self.collect_derived_reduction_reasons(
+            derived_name,
+            entity_id,
+            period,
+            &mut BTreeSet::new(),
+            &mut reasons,
+        );
+        if !reasons.is_empty() {
+            return Ok(CompleteReduction::Indeterminate { reasons });
+        }
+        self.ordinary
+            .evaluate_scalar(derived_name, entity_id, period)
+            .map(CompleteReduction::Determined)
+    }
+
+    fn collect_derived_reduction_reasons(
+        &self,
+        name: &str,
+        entity_id: &str,
+        period: &crate::model::Period,
+        visiting: &mut BTreeSet<String>,
+        reasons: &mut BTreeSet<String>,
+    ) {
+        if !visiting.insert(name.to_string()) {
+            return;
+        }
+        if let Some(derived) = self.program.derived.get(name)
+            && let Some(semantics) = derived.semantics_at(period)
+        {
+            match semantics {
+                crate::model::DerivedSemantics::Scalar(expr) => self
+                    .collect_scalar_reduction_reasons(expr, entity_id, period, visiting, reasons),
+                crate::model::DerivedSemantics::Judgment(expr) => self
+                    .collect_judgment_reduction_reasons(expr, entity_id, period, visiting, reasons),
+            }
+        }
+        visiting.remove(name);
+    }
+
+    fn collect_scalar_reduction_reasons(
+        &self,
+        expr: &crate::model::ScalarExpr,
+        entity_id: &str,
+        period: &crate::model::Period,
+        visiting: &mut BTreeSet<String>,
+        reasons: &mut BTreeSet<String>,
+    ) {
+        use crate::model::ScalarExpr;
+        match expr {
+            ScalarExpr::Derived(name) => {
+                self.collect_derived_reduction_reasons(name, entity_id, period, visiting, reasons)
+            }
+            ScalarExpr::ParameterLookup { index, .. }
+            | ScalarExpr::Ceil(index)
+            | ScalarExpr::Floor(index) => {
+                self.collect_scalar_reduction_reasons(index, entity_id, period, visiting, reasons)
+            }
+            ScalarExpr::Add(items) | ScalarExpr::Max(items) | ScalarExpr::Min(items) => {
+                for item in items {
+                    self.collect_scalar_reduction_reasons(
+                        item, entity_id, period, visiting, reasons,
+                    );
+                }
+            }
+            ScalarExpr::Sub(left, right)
+            | ScalarExpr::Mul(left, right)
+            | ScalarExpr::Div(left, right)
+            | ScalarExpr::DaysBetween {
+                from: left,
+                to: right,
+            }
+            | ScalarExpr::DateAddDays {
+                date: left,
+                days: right,
+            } => {
+                self.collect_scalar_reduction_reasons(left, entity_id, period, visiting, reasons);
+                self.collect_scalar_reduction_reasons(right, entity_id, period, visiting, reasons);
+            }
+            ScalarExpr::CountRelated {
+                relation,
+                current_slot,
+                where_clause,
+                ..
+            }
+            | ScalarExpr::SumRelated {
+                relation,
+                current_slot,
+                where_clause,
+                ..
+            } => {
+                self.collect_relation_reasons(
+                    relation,
+                    *current_slot,
+                    entity_id,
+                    period,
+                    &mut BTreeSet::new(),
+                    reasons,
+                );
+                if let Some(predicate) = where_clause {
+                    self.collect_judgment_reduction_reasons(
+                        predicate, entity_id, period, visiting, reasons,
+                    );
+                }
+            }
+            ScalarExpr::If {
+                condition,
+                then_expr,
+                else_expr,
+            } => {
+                self.collect_judgment_reduction_reasons(
+                    condition, entity_id, period, visiting, reasons,
+                );
+                self.collect_scalar_reduction_reasons(
+                    then_expr, entity_id, period, visiting, reasons,
+                );
+                self.collect_scalar_reduction_reasons(
+                    else_expr, entity_id, period, visiting, reasons,
+                );
+            }
+            ScalarExpr::OverPeriods { value, n, .. } => {
+                self.collect_scalar_reduction_reasons(value, entity_id, period, visiting, reasons);
+                if let Some(n) = n {
+                    self.collect_scalar_reduction_reasons(n, entity_id, period, visiting, reasons);
+                }
+            }
+            ScalarExpr::Literal(_)
+            | ScalarExpr::Input(_)
+            | ScalarExpr::InputOrElse { .. }
+            | ScalarExpr::PeriodStart
+            | ScalarExpr::PeriodEnd => {}
+        }
+    }
+
+    fn collect_judgment_reduction_reasons(
+        &self,
+        expr: &crate::model::JudgmentExpr,
+        entity_id: &str,
+        period: &crate::model::Period,
+        visiting: &mut BTreeSet<String>,
+        reasons: &mut BTreeSet<String>,
+    ) {
+        use crate::model::JudgmentExpr;
+        match expr {
+            JudgmentExpr::Comparison { left, right, .. } => {
+                self.collect_scalar_reduction_reasons(left, entity_id, period, visiting, reasons);
+                self.collect_scalar_reduction_reasons(right, entity_id, period, visiting, reasons);
+            }
+            JudgmentExpr::Derived(name) => {
+                self.collect_derived_reduction_reasons(name, entity_id, period, visiting, reasons)
+            }
+            JudgmentExpr::And(items) | JudgmentExpr::Or(items) => {
+                for item in items {
+                    self.collect_judgment_reduction_reasons(
+                        item, entity_id, period, visiting, reasons,
+                    );
+                }
+            }
+            JudgmentExpr::Not(item) => {
+                self.collect_judgment_reduction_reasons(item, entity_id, period, visiting, reasons)
+            }
+            JudgmentExpr::RelationMember { .. } => {}
+        }
+    }
+
+    fn collect_relation_reasons(
+        &self,
+        relation: &str,
+        current_slot: usize,
+        entity_id: &str,
+        period: &crate::model::Period,
+        visiting: &mut BTreeSet<String>,
+        reasons: &mut BTreeSet<String>,
+    ) {
+        if !visiting.insert(relation.to_string()) {
+            return;
+        }
+        for record in self.relation_knowledge.iter().filter(|record| {
+            record.name == relation
+                && record.interval.contains_period(period)
+                && record
+                    .tuple
+                    .get(current_slot)
+                    .is_some_and(|id| id == entity_id)
+        }) {
+            match &record.truth {
+                LiftedTruth::Unknown {
+                    reasons: unresolved,
+                }
+                | LiftedTruth::Conflict {
+                    reasons: unresolved,
+                } => reasons.extend(unresolved.iter().cloned()),
+                LiftedTruth::Holds | LiftedTruth::DoesNotHold => {}
+            }
+        }
+        if let Some(derivation) = self
+            .program
+            .relations
+            .get(relation)
+            .and_then(|schema| schema.derivation.as_ref())
+        {
+            self.collect_relation_reasons(
+                &derivation.source_relation,
+                derivation.current_slot,
+                entity_id,
+                period,
+                visiting,
+                reasons,
+            );
+        }
+        visiting.remove(relation);
+    }
+}
+
+impl PhaseTwoDataSet {
+    pub fn dataset(&self) -> &crate::model::DataSet {
+        &self.dataset
+    }
+
+    pub fn relation_knowledge(&self) -> &[RelationKnowledgeRecord] {
+        &self.relation_knowledge
+    }
+
+    pub fn registry(&self) -> &EntityRegistry {
+        &self.registry
+    }
+
+    pub fn engine<'a>(&'a self, program: &'a crate::model::Program) -> PhaseTwoEngine<'a> {
+        PhaseTwoEngine {
+            ordinary: crate::engine::Engine::new(program, &self.dataset),
+            program,
+            relation_knowledge: &self.relation_knowledge,
+        }
+    }
+}
+
+/// Immutable-by-construction expected-behavior ledger. There are no mutation
+/// methods, so a Prototype must receive its ledger before any result exists.
+#[derive(Clone, Debug)]
+pub struct FrozenLedger {
+    entries: BTreeMap<(String, Projection), LedgerEntry>,
+}
+
+impl FrozenLedger {
+    pub fn new(entries: Vec<LedgerEntry>) -> Result<Self, UnitDerivationError> {
+        let mut frozen = BTreeMap::new();
+        for entry in entries {
+            let key = (entry.fixture.clone(), entry.projection);
+            match frozen.entry(key) {
+                std::collections::btree_map::Entry::Vacant(slot) => {
+                    slot.insert(entry);
+                }
+                std::collections::btree_map::Entry::Occupied(existing) => {
+                    return Err(UnitDerivationError::DuplicateNamespace {
+                        namespace: "frozen comparison ledger",
+                        id: format!("{}:{:?}", existing.key().0, existing.key().1),
+                    });
+                }
+            }
+        }
+        Ok(Self { entries: frozen })
+    }
+
+    fn get(&self, fixture: &str, projection: Projection) -> Option<&LedgerEntry> {
+        self.entries.get(&(fixture.to_string(), projection))
+    }
+}
+
+/// Supplied membership held outside all evaluable indexes. Its records are
+/// private and can only be consumed by the partition-normalized comparator.
+#[derive(Clone, Debug)]
+pub struct ShadowChannel {
+    fixture: String,
+    records: Vec<SuppliedMembershipTuple>,
+}
+
+#[derive(Clone, Debug)]
+pub struct Prototype {
+    compiled: CompiledConstitution,
+    config: UnitDerivationConfig,
+    ledger: FrozenLedger,
+}
+
+impl Prototype {
+    pub fn new(
+        compiled: CompiledConstitution,
+        config: UnitDerivationConfig,
+        ledger: FrozenLedger,
+    ) -> Self {
+        Self {
+            compiled,
+            config,
+            ledger,
+        }
+    }
+
+    /// Checked comparison binder. It accepts only the two compile-resolved
+    /// canonical relation ids and stores them in the non-evaluable channel.
+    pub fn bind_shadow(
+        &self,
+        fixture: impl Into<String>,
+        mut records: Vec<SuppliedMembershipTuple>,
+    ) -> Result<ShadowChannel, UnitDerivationError> {
+        for record in &records {
+            let expected = match record.projection {
+                Projection::UnitConstituent => &self.compiled.plan.relations.unit_constituent,
+                Projection::ParticipatingMember => {
+                    &self.compiled.plan.relations.participating_member
+                }
+            };
+            if &record.relation != expected {
+                return Err(UnitDerivationError::InvalidPlan(format!(
+                    "shadow tuple relation `{}` is not the compile-resolved id `{expected}` for {:?}",
+                    record.relation, record.projection
+                )));
+            }
+        }
+        records.sort_by(|left, right| {
+            (
+                left.projection,
+                left.unit.as_str(),
+                left.person.as_str(),
+                left.relation.as_str(),
+            )
+                .cmp(&(
+                    right.projection,
+                    right.unit.as_str(),
+                    right.person.as_str(),
+                    right.relation.as_str(),
+                ))
+        });
+        records.dedup();
+        Ok(ShadowChannel {
+            fixture: fixture.into(),
+            records,
+        })
+    }
+
+    pub fn run(
+        &self,
+        input: &ConstitutionInput,
+        directly_supplied_membership: &[SuppliedMembershipTuple],
+        shadow: Option<&ShadowChannel>,
+    ) -> Result<PrototypeRun, UnitDerivationError> {
+        if let Some(record) = directly_supplied_membership.iter().find(|record| {
+            record.relation == self.compiled.plan.relations.unit_constituent
+                || record.relation == self.compiled.plan.relations.participating_member
+        }) {
+            return Err(UnitDerivationError::SuppliedAndDerivedMembership(
+                record.relation.clone(),
+            ));
+        }
+        let derivation = derive_units(&self.compiled, input, &self.config)?;
+        let comparisons = shadow.map_or(Ok(Vec::new()), |shadow| {
+            self.compare_shadow(&derivation, shadow)
+        })?;
+        Ok(PrototypeRun {
+            derivation,
+            comparisons,
+        })
+    }
+
+    fn compare_shadow(
+        &self,
+        derivation: &UnitDerivationResult,
+        shadow: &ShadowChannel,
+    ) -> Result<Vec<ComparisonResult>, UnitDerivationError> {
+        let mut comparisons = Vec::new();
+        for projection in [Projection::UnitConstituent, Projection::ParticipatingMember] {
+            let ledger = self
+                .ledger
+                .get(&shadow.fixture, projection)
+                .ok_or_else(|| UnitDerivationError::MissingLedgerEntry {
+                    fixture: shadow.fixture.clone(),
+                    projection,
+                })?;
+            let observed = if matches!(ledger.expectation, LedgerExpectation::OutOfPilot { .. }) {
+                ObservedComparison::OutOfPilot
+            } else if derivation
+                .trace
+                .input_conflict_impacts
+                .iter()
+                .any(|impact| impact.projections.contains(&projection))
+                || derivation
+                    .indeterminate
+                    .iter()
+                    .any(|item| matches!(item.kind, IndeterminateKind::ConstitutionOverlapConflict))
+            {
+                ObservedComparison::Conflict
+            } else if projection_indeterminate(derivation, projection) {
+                ObservedComparison::Indeterminate
+            } else {
+                let derived = normalize_derived_partition(derivation, projection);
+                let supplied = normalize_supplied_partition(shadow, projection);
+                if derived == supplied {
+                    ObservedComparison::Equal
+                } else {
+                    ObservedComparison::Different
+                }
+            };
+            let conforms_to_ledger = matches!(
+                (&observed, &ledger.expectation),
+                (ObservedComparison::Equal, LedgerExpectation::Equal)
+                    | (ObservedComparison::Different, LedgerExpectation::Different)
+                    | (
+                        ObservedComparison::Indeterminate,
+                        LedgerExpectation::Indeterminate
+                    )
+                    | (ObservedComparison::Conflict, LedgerExpectation::Conflict)
+                    | (
+                        ObservedComparison::OutOfPilot,
+                        LedgerExpectation::OutOfPilot { .. }
+                    )
+            );
+            comparisons.push(ComparisonResult {
+                fixture: shadow.fixture.clone(),
+                projection,
+                observed,
+                expected: ledger.expectation.clone(),
+                conforms_to_ledger,
+            });
+        }
+        Ok(comparisons)
+    }
+}
+
+fn projection_indeterminate(result: &UnitDerivationResult, projection: Projection) -> bool {
+    result
+        .indeterminate
+        .iter()
+        .any(|item| match (&item.kind, projection) {
+            (IndeterminateKind::Role(affected), projection) => *affected == projection,
+            (IndeterminateKind::Membership, _)
+            | (IndeterminateKind::DiscretionNotEncoded, _)
+            | (IndeterminateKind::RosterNotAssertedComplete, _)
+            | (IndeterminateKind::InconsistentInputs, _) => true,
+            (IndeterminateKind::ConstitutionOverlapConflict, _) => false,
+        })
+}
+
+fn normalize_derived_partition(
+    result: &UnitDerivationResult,
+    projection: Projection,
+) -> Vec<Vec<String>> {
+    let mut by_unit = BTreeMap::<String, BTreeSet<String>>::new();
+    for tuple in &result.memberships {
+        if tuple.projection == projection && tuple.role == ProjectionRole::Member {
+            by_unit
+                .entry(tuple.unit.clone())
+                .or_default()
+                .insert(tuple.person.clone());
+        }
+    }
+    let mut blocks = by_unit
+        .into_values()
+        .filter(|block| !block.is_empty())
+        .map(|block| block.into_iter().collect::<Vec<_>>())
+        .collect::<Vec<_>>();
+    blocks.sort();
+    blocks
+}
+
+fn normalize_supplied_partition(
+    shadow: &ShadowChannel,
+    projection: Projection,
+) -> Vec<Vec<String>> {
+    let mut by_unit = BTreeMap::<String, BTreeSet<String>>::new();
+    for tuple in &shadow.records {
+        if tuple.projection == projection {
+            by_unit
+                .entry(tuple.unit.clone())
+                .or_default()
+                .insert(tuple.person.clone());
+        }
+    }
+    let mut blocks = by_unit
+        .into_values()
+        .filter(|block| !block.is_empty())
+        .map(|block| block.into_iter().collect::<Vec<_>>())
+        .collect::<Vec<_>>();
+    blocks.sort();
+    blocks
+}
+
+/// Knowledge-lifted `derived_relation` filter. Unknown and Conflict candidates
+/// are retained as unresolved rather than silently dropped.
+pub fn lift_derived_relation(mut candidates: Vec<LiftedCandidate>) -> LiftedRelation {
+    candidates.sort_by(|left, right| left.id.cmp(&right.id));
+    let mut members = Vec::new();
+    let mut unresolved = BTreeMap::new();
+    for candidate in candidates {
+        match candidate.predicate {
+            LiftedTruth::Holds => members.push(candidate.id),
+            LiftedTruth::DoesNotHold => {}
+            predicate @ (LiftedTruth::Unknown { .. } | LiftedTruth::Conflict { .. }) => {
+                unresolved.insert(candidate.id, predicate);
+            }
+        }
+    }
+    members.sort();
+    members.dedup();
+    LiftedRelation {
+        members,
+        unresolved,
+    }
+}
+
+/// Canonical result-only serialization for the named experimental channel.
+/// This is deliberately not `CompiledProgramArtifact` v2 and cannot be given a
+/// release-line format identity by the caller.
+pub fn serialize_experimental_run(run: &PrototypeRun) -> Result<Vec<u8>, serde_json::Error> {
+    let units = run
+        .derivation
+        .units
+        .iter()
+        .map(|unit| {
+            serde_json::json!({
+                "entity_type": unit.entity_type,
+                "id": unit.id,
+                "members": unit.members,
+                "provenance": provenance_json(&unit.provenance),
+            })
+        })
+        .collect::<Vec<_>>();
+    let memberships = run
+        .derivation
+        .memberships
+        .iter()
+        .map(|tuple| {
+            serde_json::json!({
+                "relation": tuple.relation,
+                "unit": tuple.unit,
+                "person": tuple.person,
+                "projection": projection_name(tuple.projection),
+                "role": role_name(tuple.role),
+                "citations": tuple.citations.iter().map(citation_json).collect::<Vec<_>>(),
+                "provenance": provenance_json(&tuple.provenance),
+            })
+        })
+        .collect::<Vec<_>>();
+    let indeterminate = run
+        .derivation
+        .indeterminate
+        .iter()
+        .map(|item| {
+            serde_json::json!({
+                "person": item.person,
+                "kind": format!("{:?}", item.kind),
+                "unresolved_facts": item.unresolved_facts,
+            })
+        })
+        .collect::<Vec<_>>();
+    let comparisons = run
+        .comparisons
+        .iter()
+        .map(|item| {
+            serde_json::json!({
+                "fixture": item.fixture,
+                "projection": projection_name(item.projection),
+                "observed": format!("{:?}", item.observed),
+                "expected": format!("{:?}", item.expected),
+                "conforms_to_ledger": item.conforms_to_ledger,
+            })
+        })
+        .collect::<Vec<_>>();
+    serde_json::to_vec(&serde_json::json!({
+        "experimental_semantics_version": super::EXPERIMENTAL_SEMANTICS_VERSION,
+        "derivation": {
+            "units": units,
+            "memberships": memberships,
+            "indeterminate": indeterminate,
+            "trace": {
+                "root": run.derivation.trace.root,
+                "worlds_evaluated": run.derivation.trace.worlds_evaluated,
+                "events": run.derivation.trace.events.iter().map(|event| format!("{event:?}")).collect::<Vec<_>>(),
+                "completeness_evidence": run.derivation.trace.completeness_evidence,
+                "input_conflicts": run.derivation.trace.input_conflicts,
+                "input_conflict_impacts": run.derivation.trace.input_conflict_impacts.iter().map(|impact| serde_json::json!({
+                    "fact": impact.fact,
+                    "persons": impact.persons,
+                    "projections": impact.projections.iter().map(|projection| projection_name(*projection)).collect::<Vec<_>>(),
+                })).collect::<Vec<_>>(),
+            }
+        },
+        "comparisons": comparisons,
+    }))
+}
+
+/// Materialization barrier into the ordinary evaluator's relation dataset.
+/// Only Determined derived tuples with `Member` role enter evaluable indexes;
+/// excluded/barred role records stay in the audited prototype result, and the
+/// private shadow channel is structurally unavailable here.
+pub fn materialize_phase_two_dataset(
+    base: &crate::model::DataSet,
+    phase_two_program: &crate::model::Program,
+    input: &ConstitutionInput,
+    run: &PrototypeRun,
+    interval: crate::model::Interval,
+) -> Result<PhaseTwoDataSet, UnitDerivationError> {
+    let derived_relations = BTreeSet::from([
+        run.derivation.relations.unit_constituent.as_str(),
+        run.derivation.relations.participating_member.as_str(),
+    ]);
+    if let Some(conflict) = base
+        .relations
+        .iter()
+        .find(|record| derived_relations.contains(record.name.as_str()))
+    {
+        return Err(UnitDerivationError::SuppliedAndDerivedMembership(
+            conflict.name.clone(),
+        ));
+    }
+
+    // Reconstruct the complete typed supplied registry before cloning or
+    // extending relation storage. A collision therefore fails atomically at
+    // the barrier, before any phase-2 index can be built.
+    let mut registry = EntityRegistry::default();
+    for supplied in &input.supplied_entities {
+        registry.bind_supplied(
+            supplied.entity_type.clone(),
+            supplied.id.clone(),
+            supplied.evidence.id.clone(),
+        )?;
+    }
+    let roster_evidence = input
+        .roster
+        .completeness
+        .as_ref()
+        .map_or("roster-without-completeness", |evidence| {
+            evidence.id.as_str()
+        });
+    for person in &input.roster.persons {
+        registry.bind_supplied("person", person.clone(), roster_evidence)?;
+    }
+    for record in &base.inputs {
+        registry.bind_supplied(
+            record.entity.clone(),
+            record.entity_id.clone(),
+            format!("dataset-input:{}", record.name),
+        )?;
+    }
+    for record in &base.relations {
+        let schema = phase_two_program
+            .relations
+            .get(&record.name)
+            .ok_or_else(|| {
+                UnitDerivationError::InvalidPlan(format!(
+                    "base relation `{}` has no typed phase-2 schema",
+                    record.name
+                ))
+            })?;
+        if record.tuple.len() != schema.arity || schema.slot_entities.len() != schema.arity {
+            return Err(UnitDerivationError::InvalidPlan(format!(
+                "base relation `{}` cannot bind every tuple slot to a declared entity type",
+                record.name
+            )));
+        }
+        for (slot, id) in record.tuple.iter().enumerate() {
+            registry.bind_supplied(
+                schema.slot_entities[slot].clone(),
+                id.clone(),
+                format!("dataset-relation:{}:{slot}", record.name),
+            )?;
+        }
+    }
+    for unit in &run.derivation.units {
+        registry.insert_derived(unit)?;
+    }
+
+    let mut materialized = base.clone();
+    let records = run
+        .derivation
+        .memberships
+        .iter()
+        .filter(|tuple| tuple.role == ProjectionRole::Member)
+        .map(|tuple| {
+            (
+                tuple.relation.clone(),
+                vec![tuple.unit.clone(), tuple.person.clone()],
+            )
+        })
+        .collect::<BTreeSet<_>>();
+    materialized
+        .relations
+        .extend(
+            records
+                .into_iter()
+                .map(|(name, tuple)| crate::model::RelationRecord {
+                    name,
+                    tuple,
+                    interval: interval.clone(),
+                }),
+        );
+
+    let constituent_unit_by_person = run
+        .derivation
+        .memberships
+        .iter()
+        .filter(|tuple| tuple.projection == Projection::UnitConstituent)
+        .map(|tuple| (tuple.person.clone(), tuple.unit.clone()))
+        .collect::<BTreeMap<_, _>>();
+    let mut relation_knowledge = run
+        .derivation
+        .indeterminate
+        .iter()
+        .filter_map(|item| {
+            if item.kind != IndeterminateKind::Role(Projection::ParticipatingMember) {
+                return None;
+            }
+            let unit = constituent_unit_by_person.get(&item.person)?;
+            let conflict = item
+                .unresolved_facts
+                .iter()
+                .any(|fact| run.derivation.trace.input_conflicts.contains(fact));
+            let truth = if conflict {
+                LiftedTruth::Conflict {
+                    reasons: item.unresolved_facts.clone(),
+                }
+            } else {
+                LiftedTruth::Unknown {
+                    reasons: item.unresolved_facts.clone(),
+                }
+            };
+            Some(RelationKnowledgeRecord {
+                name: run.derivation.relations.participating_member.clone(),
+                tuple: vec![unit.clone(), item.person.clone()],
+                interval: interval.clone(),
+                truth,
+            })
+        })
+        .collect::<Vec<_>>();
+    relation_knowledge.sort_by(|left, right| {
+        (left.name.as_str(), left.tuple.as_slice())
+            .cmp(&(right.name.as_str(), right.tuple.as_slice()))
+    });
+    relation_knowledge.dedup();
+
+    Ok(PhaseTwoDataSet {
+        dataset: materialized,
+        relation_knowledge,
+        registry,
+    })
+}
+
+fn projection_name(projection: Projection) -> &'static str {
+    match projection {
+        Projection::UnitConstituent => "unit_constituent",
+        Projection::ParticipatingMember => "participating_member",
+    }
+}
+
+fn role_name(role: ProjectionRole) -> &'static str {
+    match role {
+        ProjectionRole::Member => "member",
+        ProjectionRole::Excluded => "excluded",
+        ProjectionRole::BarredIndependent => "barred_independent",
+    }
+}
+
+fn citation_json(citation: &Citation) -> serde_json::Value {
+    serde_json::json!({
+        "provision": citation.provision,
+        "authority": citation.authority,
+    })
+}
+
+fn provenance_json(provenance: &Provenance) -> serde_json::Value {
+    match provenance {
+        Provenance::Supplied { evidence_id } => serde_json::json!({
+            "kind": "supplied",
+            "evidence_id": evidence_id,
+        }),
+        Provenance::Derived {
+            constitution,
+            trace_root,
+        } => serde_json::json!({
+            "kind": "derived",
+            "constitution": constitution,
+            "trace_root": trace_root,
+        }),
+    }
+}

--- a/src/unit_derivation/mod.rs
+++ b/src/unit_derivation/mod.rs
@@ -1,0 +1,25 @@
+//! Experimental stage-2 prototype of the ratified unit-derivation contract.
+//!
+//! This module is compiled only with the off-by-default `unit-derivation`
+//! Cargo feature. Its runtime configuration is also disabled by default. It
+//! deliberately does not change RuleSpec, artifact v2, the ordinary engine,
+//! or any release/launch surface.
+
+mod compile;
+mod evaluate;
+mod interface;
+#[cfg(test)]
+mod tests;
+mod types;
+
+pub use compile::{CompiledConstitution, compile};
+pub use evaluate::{derive_units, unit_id};
+pub use interface::{
+    EntityRegistry, FrozenLedger, PhaseTwoDataSet, PhaseTwoEngine, Prototype, ShadowChannel,
+    lift_derived_relation, materialize_phase_two_dataset, serialize_experimental_run,
+};
+pub use types::*;
+
+/// Experimental identity required by the prototype interface. This value is
+/// intentionally not an artifact-format or release-line version.
+pub const EXPERIMENTAL_SEMANTICS_VERSION: &str = "unit-derivation-stage2/1";

--- a/src/unit_derivation/tests.rs
+++ b/src/unit_derivation/tests.rs
@@ -1,0 +1,1416 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use serde::Deserialize;
+
+use super::*;
+
+fn citation(provision: &str) -> Citation {
+    Citation::new(provision, "synthetic fixture authority")
+}
+
+fn evidence(id: &str) -> Evidence {
+    Evidence {
+        id: id.to_string(),
+        citation: citation("fixture:evidence"),
+    }
+}
+
+fn observed(value: bool, id: &str) -> ObservedBool {
+    ObservedBool {
+        value,
+        evidence: evidence(id),
+    }
+}
+
+fn set(items: &[&str]) -> BTreeSet<String> {
+    items.iter().map(|item| (*item).to_string()).collect()
+}
+
+fn base_plan(persons: &[&str]) -> ConstitutionPlan {
+    let _ = persons;
+    ConstitutionPlan {
+        id: "us:7-cfr-273-1:snap-household".to_string(),
+        entity_type: "snap_household".to_string(),
+        roster_relation: "us:test#dwelling_resident".to_string(),
+        relations: EmissionRelations {
+            unit_constituent: "us:test#member_of_household".to_string(),
+            participating_member: "us:test#snap_unit_member".to_string(),
+        },
+        derived_bools: Vec::new(),
+        edges: Vec::new(),
+        cuts: Vec::new(),
+        attachments: Vec::new(),
+        bars: Vec::new(),
+        statuses: Vec::new(),
+        base_chain_policy: None,
+    }
+}
+
+fn complete_input(persons: &[&str]) -> ConstitutionInput {
+    ConstitutionInput {
+        roster: RosterInput {
+            relation: "us:test#dwelling_resident".to_string(),
+            scope: "dwelling:test".to_string(),
+            persons: persons.iter().map(|person| (*person).to_string()).collect(),
+            completeness: Some(evidence("complete-roster")),
+        },
+        segment: "2026-07-01/2026-07-31".to_string(),
+        segment_complete: true,
+        relation_families: Vec::new(),
+        bool_facts: Vec::new(),
+        supplied_entities: Vec::new(),
+        integrity_constraints: Vec::new(),
+    }
+}
+
+fn enabled() -> UnitDerivationConfig {
+    UnitDerivationConfig {
+        enabled: true,
+        ..UnitDerivationConfig::default()
+    }
+}
+
+fn edge(id: &str, kind: EdgeKind, left: &str, right: &str, when: BoolExpr) -> EdgeRule {
+    EdgeRule {
+        id: id.to_string(),
+        kind,
+        left: left.to_string(),
+        right: right.to_string(),
+        when,
+        citation: citation(id),
+        defeaters: Vec::new(),
+    }
+}
+
+fn relation_expr(family: &str, left: &str, right: &str) -> BoolExpr {
+    BoolExpr::fact(FactRef::Relation {
+        family: family.to_string(),
+        tuple: vec![left.to_string(), right.to_string()],
+    })
+}
+
+fn partition(result: &UnitDerivationResult, projection: Projection) -> Vec<Vec<String>> {
+    let mut by_unit = BTreeMap::<String, BTreeSet<String>>::new();
+    for tuple in &result.memberships {
+        if tuple.projection == projection && tuple.role == ProjectionRole::Member {
+            by_unit
+                .entry(tuple.unit.clone())
+                .or_default()
+                .insert(tuple.person.clone());
+        }
+    }
+    let mut blocks = by_unit
+        .into_values()
+        .map(|block| block.into_iter().collect::<Vec<_>>())
+        .collect::<Vec<_>>();
+    blocks.sort();
+    blocks
+}
+
+fn participant_count_program() -> crate::model::Program {
+    let mut phase_two = crate::model::Program::default();
+    phase_two
+        .add_relation_schema(crate::model::RelationSchema {
+            name: "us:test#snap_unit_member".to_string(),
+            arity: 2,
+            slot_entities: vec!["snap_household".to_string(), "person".to_string()],
+            derivation: None,
+        })
+        .unwrap();
+    phase_two
+        .add_derived(crate::model::Derived {
+            id: None,
+            name: "participant_count".to_string(),
+            entity: "snap_household".to_string(),
+            dtype: crate::model::DType::Integer,
+            unit: None,
+            rounding: None,
+            source: None,
+            source_url: None,
+            corpus_citation_path: None,
+            semantics: crate::model::DerivedSemantics::Scalar(
+                crate::model::ScalarExpr::CountRelated {
+                    relation: "us:test#snap_unit_member".to_string(),
+                    current_slot: 0,
+                    related_slot: 1,
+                    where_clause: None,
+                },
+            ),
+            versions: Vec::new(),
+        })
+        .unwrap();
+    phase_two
+}
+
+#[test]
+fn runtime_flag_is_independently_off_by_default() {
+    let compiled = compile(base_plan(&["a"])).unwrap();
+    let error = derive_units(&compiled, &complete_input(&["a"]), &Default::default())
+        .expect_err("runtime default must stay disabled");
+    assert_eq!(error, UnitDerivationError::Disabled);
+}
+
+#[test]
+fn scoped_family_completeness_and_locality_prevent_unknown_as_absence() {
+    let mut plan = base_plan(&["a", "b", "c"]);
+    plan.edges.push(edge(
+        "pap-a-b",
+        EdgeKind::Base,
+        "a",
+        "b",
+        relation_expr("purchase_and_prepare", "a", "b"),
+    ));
+    let compiled = compile(plan).unwrap();
+    let mut input = complete_input(&["a", "b", "c"]);
+    input.relation_families.push(RelationFamilyInput {
+        name: "purchase_and_prepare".to_string(),
+        scope: input.roster.scope.clone(),
+        completeness: None,
+        facts: Vec::new(),
+    });
+
+    let unresolved = derive_units(&compiled, &input, &enabled()).unwrap();
+    assert!(
+        unresolved
+            .indeterminate
+            .iter()
+            .any(|item| item.person == "a" && item.kind == IndeterminateKind::Membership)
+    );
+    assert!(
+        unresolved
+            .indeterminate
+            .iter()
+            .any(|item| item.person == "b" && item.kind == IndeterminateKind::Membership)
+    );
+    assert!(
+        !unresolved
+            .indeterminate
+            .iter()
+            .any(|item| item.person == "c")
+    );
+    assert!(partition(&unresolved, Projection::UnitConstituent).contains(&vec!["c".to_string()]));
+
+    input.relation_families[0].completeness = Some(evidence("complete-pap"));
+    let complete = derive_units(&compiled, &input, &enabled()).unwrap();
+    assert!(complete.indeterminate.is_empty());
+    assert_eq!(
+        partition(&complete, Projection::UnitConstituent),
+        vec![
+            vec!["a".to_string()],
+            vec!["b".to_string()],
+            vec!["c".to_string()]
+        ]
+    );
+}
+
+#[test]
+fn incomplete_roster_mints_nothing() {
+    let compiled = compile(base_plan(&["a", "b"])).unwrap();
+    let mut input = complete_input(&["a", "b"]);
+    input.roster.completeness = None;
+    let result = derive_units(&compiled, &input, &enabled()).unwrap();
+    assert!(result.units.is_empty());
+    assert_eq!(result.indeterminate.len(), 2);
+    assert!(
+        result
+            .indeterminate
+            .iter()
+            .all(|item| { item.kind == IndeterminateKind::RosterNotAssertedComplete })
+    );
+}
+
+#[test]
+fn composition_can_be_determined_while_participation_is_unknown() {
+    let mut plan = base_plan(&["claimant", "excluded"]);
+    plan.edges.push(edge(
+        "pap",
+        EdgeKind::Base,
+        "claimant",
+        "excluded",
+        BoolExpr::Literal(true),
+    ));
+    plan.statuses.push(StatusRule {
+        id: "ssn-noncooperation".to_string(),
+        person: "excluded".to_string(),
+        when: BoolExpr::fact(FactRef::Bool("ssn_noncooperation".to_string())),
+        citation: citation("7-cfr-273.1(b)(7)(iv)"),
+    });
+    let compiled = compile(plan).unwrap();
+    let result = derive_units(
+        &compiled,
+        &complete_input(&["claimant", "excluded"]),
+        &enabled(),
+    )
+    .unwrap();
+    assert_eq!(
+        partition(&result, Projection::UnitConstituent),
+        vec![vec!["claimant".to_string(), "excluded".to_string()]]
+    );
+    assert!(result.indeterminate.iter().any(|item| {
+        item.person == "excluded"
+            && item.kind == IndeterminateKind::Role(Projection::ParticipatingMember)
+    }));
+    assert!(
+        !result
+            .indeterminate
+            .iter()
+            .any(|item| item.person == "claimant")
+    );
+
+    let mut known_input = complete_input(&["claimant", "excluded"]);
+    known_input.bool_facts.push(BoolFactInput {
+        name: "ssn_noncooperation".to_string(),
+        observations: vec![observed(true, "known-ssn-noncooperation")],
+        explicit_unknown: None,
+    });
+    let known = derive_units(&compiled, &known_input, &enabled()).unwrap();
+    let run = PrototypeRun {
+        derivation: known,
+        comparisons: Vec::new(),
+    };
+    let period = crate::model::Period::month(2026, 7);
+    let phase_two = participant_count_program();
+    let dataset = materialize_phase_two_dataset(
+        &crate::model::DataSet::default(),
+        &phase_two,
+        &known_input,
+        &run,
+        crate::model::Interval::covering(&period),
+    )
+    .unwrap();
+    let mut engine = dataset.engine(&phase_two);
+    assert_eq!(
+        engine
+            .evaluate_scalar("participant_count", &run.derivation.units[0].id, &period)
+            .unwrap(),
+        CompleteReduction::Determined(crate::model::ScalarValue::Integer(1))
+    );
+}
+
+#[test]
+fn unknown_status_survives_materialization_and_indeterminates_phase_two_count() {
+    let mut plan = base_plan(&["a", "b"]);
+    plan.edges.push(edge(
+        "pap",
+        EdgeKind::Base,
+        "a",
+        "b",
+        BoolExpr::Literal(true),
+    ));
+    plan.statuses.push(StatusRule {
+        id: "unknown-status-for-b".to_string(),
+        person: "b".to_string(),
+        when: BoolExpr::fact(FactRef::Bool("status_b".to_string())),
+        citation: citation("review:S1-adversarial-status"),
+    });
+    let input = complete_input(&["a", "b"]);
+    let derivation = derive_units(&compile(plan).unwrap(), &input, &enabled()).unwrap();
+    assert!(derivation.indeterminate.iter().any(|item| {
+        item.person == "b" && item.kind == IndeterminateKind::Role(Projection::ParticipatingMember)
+    }));
+
+    let run = PrototypeRun {
+        derivation,
+        comparisons: Vec::new(),
+    };
+    let period = crate::model::Period::month(2026, 7);
+    let phase_two = participant_count_program();
+    let materialized = materialize_phase_two_dataset(
+        &crate::model::DataSet::default(),
+        &phase_two,
+        &input,
+        &run,
+        crate::model::Interval::covering(&period),
+    )
+    .unwrap();
+    assert_eq!(materialized.relation_knowledge().len(), 1);
+    let mut engine = materialized.engine(&phase_two);
+    let reduction = engine
+        .evaluate_scalar("participant_count", &run.derivation.units[0].id, &period)
+        .unwrap();
+    assert!(matches!(
+        reduction,
+        CompleteReduction::Indeterminate { ref reasons }
+            if reasons == &set(&["bool:status_b"])
+    ));
+}
+
+fn simultaneous_cut_plan(decision: CutEdgeDecision) -> ConstitutionPlan {
+    let mut plan = base_plan(&["a", "b", "c", "d", "e"]);
+    for (id, left, right) in [
+        ("base-ab", "a", "b"),
+        ("base-ac", "a", "c"),
+        ("base-bc", "b", "c"),
+        ("base-de", "d", "e"),
+    ] {
+        plan.edges.push(edge(
+            id,
+            EdgeKind::Base,
+            left,
+            right,
+            BoolExpr::Literal(true),
+        ));
+    }
+    for (id, left, right) in [("under22-a-c", "a", "c"), ("under22-b-c", "b", "c")] {
+        plan.edges.push(edge(
+            id,
+            EdgeKind::Combination,
+            left,
+            right,
+            BoolExpr::Literal(true),
+        ));
+    }
+    plan.cuts.push(CutRule {
+        id: "elderly-disabled".to_string(),
+        members: set(&["a", "b"]),
+        when: BoolExpr::Literal(true),
+        citation: citation("7-cfr-273.1(b)(2)"),
+        election: None,
+        edge_precedence: vec![
+            CutEdgePrecedence {
+                edge_rule: "under22-a-c".to_string(),
+                decision: decision.clone(),
+            },
+            CutEdgePrecedence {
+                edge_rule: "under22-b-c".to_string(),
+                decision,
+            },
+        ],
+        precedes: Vec::new(),
+    });
+    plan
+}
+
+#[test]
+fn snap_elderly_disabled_precedence_is_shown_both_ways_and_can_remain_unresolved() {
+    let input = complete_input(&["a", "b", "c", "d", "e"]);
+    let blocked = derive_units(
+        &compile(simultaneous_cut_plan(CutEdgeDecision::Blocked {
+            citation: citation("reviewed-block-reading"),
+        }))
+        .unwrap(),
+        &input,
+        &enabled(),
+    )
+    .unwrap();
+    assert_eq!(
+        partition(&blocked, Projection::UnitConstituent),
+        vec![
+            vec!["a".to_string(), "b".to_string(), "c".to_string()],
+            vec!["d".to_string(), "e".to_string()],
+        ]
+    );
+
+    let overrides = derive_units(
+        &compile(simultaneous_cut_plan(CutEdgeDecision::Overrides {
+            citation: citation("reviewed-override-reading"),
+        }))
+        .unwrap(),
+        &input,
+        &enabled(),
+    )
+    .unwrap();
+    assert_eq!(
+        partition(&overrides, Projection::UnitConstituent),
+        vec![
+            vec!["a".to_string(), "b".to_string()],
+            vec!["c".to_string()],
+            vec!["d".to_string(), "e".to_string()],
+        ]
+    );
+
+    let unresolved = derive_units(
+        &compile(simultaneous_cut_plan(CutEdgeDecision::Unresolved {
+            issue: "tier-b:b1-b2-precedence".to_string(),
+        }))
+        .unwrap(),
+        &input,
+        &enabled(),
+    )
+    .unwrap();
+    assert!(["a", "b", "c"].iter().all(|person| {
+        unresolved
+            .indeterminate
+            .iter()
+            .any(|item| &item.person == person)
+    }));
+    assert!(["d", "e"].iter().all(|person| {
+        !unresolved
+            .indeterminate
+            .iter()
+            .any(|item| &item.person == person)
+    }));
+    assert_eq!(
+        partition(&unresolved, Projection::UnitConstituent),
+        vec![vec!["d".to_string(), "e".to_string()]]
+    );
+}
+
+#[test]
+fn disjoint_cuts_are_all_blocked_against_one_frozen_edge_set() {
+    let mut plan = base_plan(&["a", "b", "c", "d"]);
+    for (id, kind, left, right) in [
+        ("base-ab", EdgeKind::Base, "a", "b"),
+        ("base-cd", EdgeKind::Base, "c", "d"),
+        ("combo-ac", EdgeKind::Combination, "a", "c"),
+        ("combo-bd", EdgeKind::Combination, "b", "d"),
+    ] {
+        plan.edges
+            .push(edge(id, kind, left, right, BoolExpr::Literal(true)));
+    }
+    for (id, members) in [
+        ("left-cut", set(&["a", "b"])),
+        ("right-cut", set(&["c", "d"])),
+    ] {
+        plan.cuts.push(CutRule {
+            id: id.to_string(),
+            members,
+            when: BoolExpr::Literal(true),
+            citation: citation(id),
+            election: None,
+            edge_precedence: ["combo-ac", "combo-bd"]
+                .into_iter()
+                .map(|edge_rule| CutEdgePrecedence {
+                    edge_rule: edge_rule.to_string(),
+                    decision: CutEdgeDecision::Blocked {
+                        citation: citation("combination-blocks"),
+                    },
+                })
+                .collect(),
+            precedes: Vec::new(),
+        });
+    }
+    let result = derive_units(
+        &compile(plan).unwrap(),
+        &complete_input(&["a", "b", "c", "d"]),
+        &enabled(),
+    )
+    .unwrap();
+    let blocked = result
+        .trace
+        .events
+        .iter()
+        .filter(|event| matches!(event, TraceEvent::CutBlocked { .. }))
+        .count();
+    assert_eq!(blocked, 4);
+    assert_eq!(
+        partition(&result, Projection::UnitConstituent),
+        vec![vec![
+            "a".to_string(),
+            "b".to_string(),
+            "c".to_string(),
+            "d".to_string(),
+        ]]
+    );
+}
+
+#[test]
+fn undeclared_overlap_conflicts_while_identical_cuts_coalesce() {
+    let mut overlap = base_plan(&["a", "b", "c", "d"]);
+    for (id, members) in [("ab", set(&["a", "b"])), ("bc", set(&["b", "c"]))] {
+        overlap.cuts.push(CutRule {
+            id: id.to_string(),
+            members,
+            when: BoolExpr::Literal(true),
+            citation: citation(id),
+            election: None,
+            edge_precedence: Vec::new(),
+            precedes: Vec::new(),
+        });
+    }
+    let result = derive_units(
+        &compile(overlap).unwrap(),
+        &complete_input(&["a", "b", "c", "d"]),
+        &enabled(),
+    )
+    .unwrap();
+    assert!(["a", "b", "c"].iter().all(|person| {
+        result.indeterminate.iter().any(|item| {
+            item.person == *person && item.kind == IndeterminateKind::ConstitutionOverlapConflict
+        })
+    }));
+    assert!(!result.indeterminate.iter().any(|item| item.person == "d"));
+
+    let mut identical = base_plan(&["a", "b", "c"]);
+    for id in ["same-one", "same-two"] {
+        identical.cuts.push(CutRule {
+            id: id.to_string(),
+            members: set(&["a", "b"]),
+            when: BoolExpr::Literal(true),
+            citation: citation(id),
+            election: None,
+            edge_precedence: Vec::new(),
+            precedes: Vec::new(),
+        });
+    }
+    let coalesced = derive_units(
+        &compile(identical).unwrap(),
+        &complete_input(&["a", "b", "c"]),
+        &enabled(),
+    )
+    .unwrap();
+    assert!(coalesced.indeterminate.is_empty());
+    assert_eq!(
+        partition(&coalesced, Projection::UnitConstituent),
+        vec![
+            vec!["a".to_string(), "b".to_string()],
+            vec!["c".to_string()]
+        ]
+    );
+}
+
+#[test]
+fn identical_cuts_with_contradictory_legal_decisions_fail_compilation() {
+    let mut plan = base_plan(&["a", "b", "c"]);
+    plan.edges.push(edge(
+        "combination-b-c",
+        EdgeKind::Combination,
+        "b",
+        "c",
+        BoolExpr::Literal(true),
+    ));
+    for (id, decision) in [
+        (
+            "same-blocked",
+            CutEdgeDecision::Blocked {
+                citation: citation("blocked-reading"),
+            },
+        ),
+        (
+            "same-overrides",
+            CutEdgeDecision::Overrides {
+                citation: citation("override-reading"),
+            },
+        ),
+    ] {
+        plan.cuts.push(CutRule {
+            id: id.to_string(),
+            members: set(&["a", "b"]),
+            when: BoolExpr::Literal(true),
+            citation: citation(id),
+            election: None,
+            edge_precedence: vec![CutEdgePrecedence {
+                edge_rule: "combination-b-c".to_string(),
+                decision,
+            }],
+            precedes: Vec::new(),
+        });
+    }
+
+    let error = compile(plan).expect_err("contradictory coalesced cuts need explicit precedence");
+    assert!(matches!(
+        error,
+        UnitDerivationError::InvalidPlan(message)
+            if message.contains("coalescible cuts") && message.contains("without explicit cut precedence")
+    ));
+}
+
+fn boarder_plan(request: BoolExpr) -> ConstitutionPlan {
+    let mut plan = base_plan(&["provider", "provider_spouse", "boarder", "boarder_spouse"]);
+    let election = match &request {
+        BoolExpr::Fact(FactRef::Bool(fact)) if fact == "provider_request" => {
+            Some(ElectionRequirement {
+                fact: fact.clone(),
+                actor: "provider candidate".to_string(),
+                missing: MissingElectionPolicy::Unknown,
+            })
+        }
+        _ => None,
+    };
+    plan.edges.push(edge(
+        "provider-group",
+        EdgeKind::Base,
+        "provider",
+        "provider_spouse",
+        BoolExpr::Literal(true),
+    ));
+    plan.edges.push(edge(
+        "boarder-spouse",
+        EdgeKind::Combination,
+        "boarder",
+        "boarder_spouse",
+        BoolExpr::Literal(true),
+    ));
+    plan.attachments.push(AttachmentRule {
+        id: "provider-request-attachment".to_string(),
+        members: set(&["boarder", "boarder_spouse"]),
+        target_anchor: "provider".to_string(),
+        when: request,
+        actor: "provider candidate".to_string(),
+        election,
+        citation: citation("7-cfr-273.1(b)(3)"),
+    });
+    plan.bars.push(BarRule {
+        id: "independent-participation-bar".to_string(),
+        members: set(&["boarder", "boarder_spouse"]),
+        when: BoolExpr::Literal(true),
+        citation: citation("7-cfr-273.1(b)(3)"),
+    });
+    plan
+}
+
+#[test]
+fn attachment_and_independent_bar_are_distinct_and_requests_have_no_default() {
+    let input = complete_input(&["provider", "provider_spouse", "boarder", "boarder_spouse"]);
+    let unattached = derive_units(
+        &compile(boarder_plan(BoolExpr::Literal(false))).unwrap(),
+        &input,
+        &enabled(),
+    )
+    .unwrap();
+    assert_eq!(unattached.units.len(), 2);
+    assert!(unattached.memberships.iter().any(|tuple| {
+        tuple.person == "boarder" && tuple.role == ProjectionRole::BarredIndependent
+    }));
+
+    let attached = derive_units(
+        &compile(boarder_plan(BoolExpr::Literal(true))).unwrap(),
+        &input,
+        &enabled(),
+    )
+    .unwrap();
+    assert_eq!(attached.units.len(), 1);
+    assert!(attached.memberships.iter().all(|tuple| {
+        tuple.projection != Projection::ParticipatingMember || tuple.role == ProjectionRole::Member
+    }));
+
+    let unresolved = derive_units(
+        &compile(boarder_plan(BoolExpr::fact(FactRef::Bool(
+            "provider_request".to_string(),
+        ))))
+        .unwrap(),
+        &input,
+        &enabled(),
+    )
+    .unwrap();
+    assert_eq!(unresolved.indeterminate.len(), 4);
+    assert!(unresolved.units.is_empty());
+
+    let mut defaulted_plan = boarder_plan(BoolExpr::fact(FactRef::Bool(
+        "provider_request".to_string(),
+    )));
+    defaulted_plan.attachments[0].election = Some(ElectionRequirement {
+        fact: "provider_request".to_string(),
+        actor: "provider candidate".to_string(),
+        missing: MissingElectionPolicy::AuthorityDefault {
+            value: false,
+            citation: citation("cited-administrative-default"),
+        },
+    });
+    let defaulted = derive_units(
+        &compile(defaulted_plan.clone()).unwrap(),
+        &input,
+        &enabled(),
+    )
+    .unwrap();
+    assert_eq!(defaulted.units.len(), 2);
+    assert!(defaulted.trace.events.iter().any(|event| {
+        matches!(
+            event,
+            TraceEvent::ElectionDefault {
+                fact,
+                actor,
+                value: false,
+                ..
+            } if fact == "provider_request" && actor == "provider candidate"
+        )
+    }));
+
+    let mut explicitly_unknown_input = input;
+    explicitly_unknown_input.bool_facts.push(BoolFactInput {
+        name: "provider_request".to_string(),
+        observations: Vec::new(),
+        explicit_unknown: Some(evidence("explicit-unknown-request")),
+    });
+    let explicitly_unknown = derive_units(
+        &compile(defaulted_plan).unwrap(),
+        &explicitly_unknown_input,
+        &enabled(),
+    )
+    .unwrap();
+    assert_eq!(explicitly_unknown.indeterminate.len(), 4);
+    assert!(
+        !explicitly_unknown
+            .trace
+            .events
+            .iter()
+            .any(|event| { matches!(event, TraceEvent::ElectionDefault { .. }) })
+    );
+}
+
+#[test]
+fn explicit_unknown_marker_cannot_be_overridden_by_observations() {
+    let mut plan = base_plan(&["provider", "boarder"]);
+    plan.attachments.push(AttachmentRule {
+        id: "request-attachment".to_string(),
+        members: set(&["boarder"]),
+        target_anchor: "provider".to_string(),
+        when: BoolExpr::fact(FactRef::Bool("provider_request".to_string())),
+        actor: "provider candidate".to_string(),
+        election: Some(ElectionRequirement {
+            fact: "provider_request".to_string(),
+            actor: "provider candidate".to_string(),
+            missing: MissingElectionPolicy::Unknown,
+        }),
+        citation: citation("request-authority"),
+    });
+    let mut input = complete_input(&["provider", "boarder"]);
+    input.bool_facts.push(BoolFactInput {
+        name: "provider_request".to_string(),
+        observations: vec![observed(true, "observed-true")],
+        explicit_unknown: Some(evidence("explicitly-unknown")),
+    });
+
+    let error = derive_units(&compile(plan).unwrap(), &input, &enabled())
+        .expect_err("explicit Unknown plus observations is structurally inconsistent");
+    assert!(matches!(
+        error,
+        UnitDerivationError::InvalidPlan(message)
+            if message.contains("both explicit Unknown and observations")
+    ));
+}
+
+#[test]
+fn actors_are_authoritative_and_request_evidence_is_traced_for_cuts_and_attachments() {
+    let mut plan = base_plan(&["provider", "boarder"]);
+    plan.cuts.push(CutRule {
+        id: "requested-cut".to_string(),
+        members: set(&["boarder"]),
+        when: BoolExpr::fact(FactRef::Bool("cut_request".to_string())),
+        citation: citation("cut-authority"),
+        election: Some(ElectionRequirement {
+            fact: "cut_request".to_string(),
+            actor: "boarder".to_string(),
+            missing: MissingElectionPolicy::Unknown,
+        }),
+        edge_precedence: Vec::new(),
+        precedes: Vec::new(),
+    });
+    plan.attachments.push(AttachmentRule {
+        id: "provider-attachment".to_string(),
+        members: set(&["boarder"]),
+        target_anchor: "provider".to_string(),
+        when: BoolExpr::fact(FactRef::Bool("provider_request".to_string())),
+        actor: "provider candidate".to_string(),
+        election: Some(ElectionRequirement {
+            fact: "provider_request".to_string(),
+            actor: "provider candidate".to_string(),
+            missing: MissingElectionPolicy::Unknown,
+        }),
+        citation: citation("attachment-authority"),
+    });
+
+    let mut mismatch = plan.clone();
+    mismatch.attachments[0].actor = "different actor".to_string();
+    assert!(matches!(
+        compile(mismatch).unwrap_err(),
+        UnitDerivationError::InvalidPlan(message) if message.contains("disagrees with election actor")
+    ));
+
+    let mut input = complete_input(&["provider", "boarder"]);
+    input.bool_facts.extend([
+        BoolFactInput {
+            name: "cut_request".to_string(),
+            observations: vec![observed(true, "cut-request-evidence")],
+            explicit_unknown: None,
+        },
+        BoolFactInput {
+            name: "provider_request".to_string(),
+            observations: vec![observed(true, "attachment-request-evidence")],
+            explicit_unknown: None,
+        },
+    ]);
+    let result = derive_units(&compile(plan).unwrap(), &input, &enabled()).unwrap();
+    assert!(result.trace.events.iter().any(|event| matches!(
+        event,
+        TraceEvent::CutApplied { rule, actor: Some(actor), request_evidence }
+            if rule == "requested-cut"
+                && actor == "boarder"
+                && request_evidence == &set(&["cut-request-evidence"])
+    )));
+    assert!(result.trace.events.iter().any(|event| matches!(
+        event,
+        TraceEvent::Attachment { rule, actor, request_evidence, .. }
+            if rule == "provider-attachment"
+                && actor == "provider candidate"
+                && request_evidence == &set(&["attachment-request-evidence"])
+    )));
+}
+
+#[test]
+fn dependency_check_uses_the_full_transitive_closure() {
+    let mut plan = base_plan(&["a", "b"]);
+    plan.derived_bools.push(DerivedBool {
+        id: "unit-scoped".to_string(),
+        stratum: Stratum::Unit,
+        expr: BoolExpr::Literal(true),
+    });
+    plan.derived_bools.push(DerivedBool {
+        id: "mislabelled-person".to_string(),
+        stratum: Stratum::Person,
+        expr: BoolExpr::Derived("unit-scoped".to_string()),
+    });
+    plan.edges.push(edge(
+        "bad-edge",
+        EdgeKind::Base,
+        "a",
+        "b",
+        BoolExpr::Derived("mislabelled-person".to_string()),
+    ));
+    let error = compile(plan).expect_err("transitive unit dependency must fail");
+    assert!(matches!(
+        error,
+        UnitDerivationError::UnitStratumDependency(_)
+    ));
+}
+
+#[test]
+fn tier_c_base_chain_has_no_engine_default() {
+    let mut plan = base_plan(&["a", "b", "c"]);
+    plan.edges.push(edge(
+        "ab",
+        EdgeKind::Base,
+        "a",
+        "b",
+        BoolExpr::Literal(true),
+    ));
+    plan.edges.push(edge(
+        "bc",
+        EdgeKind::Base,
+        "b",
+        "c",
+        BoolExpr::Literal(true),
+    ));
+    let input = complete_input(&["a", "b", "c"]);
+    let no_policy = derive_units(&compile(plan.clone()).unwrap(), &input, &enabled()).unwrap();
+    assert!(no_policy.units.is_empty());
+    assert!(
+        no_policy
+            .indeterminate
+            .iter()
+            .all(|item| { item.kind == IndeterminateKind::DiscretionNotEncoded })
+    );
+
+    plan.base_chain_policy = Some(citation("named-state-273.1(c)-policy"));
+    let explicit = derive_units(&compile(plan).unwrap(), &input, &enabled()).unwrap();
+    assert_eq!(explicit.units.len(), 1);
+}
+
+#[test]
+fn lifted_derived_relation_never_drops_unknown_or_conflict() {
+    let relation = lift_derived_relation(vec![
+        LiftedCandidate {
+            id: "kept".to_string(),
+            predicate: LiftedTruth::Holds,
+        },
+        LiftedCandidate {
+            id: "dropped".to_string(),
+            predicate: LiftedTruth::DoesNotHold,
+        },
+        LiftedCandidate {
+            id: "unknown".to_string(),
+            predicate: LiftedTruth::Unknown {
+                reasons: set(&["missing-ssn-fact"]),
+            },
+        },
+        LiftedCandidate {
+            id: "conflict".to_string(),
+            predicate: LiftedTruth::Conflict {
+                reasons: set(&["conflicting-status-records"]),
+            },
+        },
+    ]);
+    assert_eq!(relation.members, vec!["kept"]);
+    assert_eq!(relation.unresolved.len(), 2);
+    assert!(matches!(
+        relation.count_complete(),
+        CompleteReduction::Indeterminate { .. }
+    ));
+}
+
+#[test]
+fn runtime_entity_registry_rejects_supplied_and_derived_collisions() {
+    let mut registry = EntityRegistry::default();
+    registry.bind_supplied("person", "same-id", "e1").unwrap();
+    let collision = registry
+        .bind_supplied("household", "same-id", "e2")
+        .expect_err("all runtime instance collisions fail");
+    assert!(matches!(
+        collision,
+        UnitDerivationError::EntityCollision { .. }
+    ));
+
+    let compiled = compile(base_plan(&["a"])).unwrap();
+    let input = complete_input(&["a"]);
+    let first = derive_units(&compiled, &input, &enabled()).unwrap();
+    let mut colliding = input;
+    colliding.supplied_entities.push(SuppliedEntity {
+        entity_type: "supplied_household".to_string(),
+        id: first.units[0].id.clone(),
+        evidence: evidence("supplied-unit"),
+    });
+    let error = derive_units(&compiled, &colliding, &enabled())
+        .expect_err("emission must insert through the registry");
+    assert!(matches!(error, UnitDerivationError::EntityCollision { .. }));
+}
+
+#[test]
+fn materialization_rebuilds_complete_registry_and_rejects_base_dataset_collision() {
+    let compiled = compile(base_plan(&["a"])).unwrap();
+    let input = complete_input(&["a"]);
+    let derivation = derive_units(&compiled, &input, &enabled()).unwrap();
+    let derived_unit_id = derivation.units[0].id.clone();
+    let run = PrototypeRun {
+        derivation,
+        comparisons: Vec::new(),
+    };
+    let period = crate::model::Period::month(2026, 7);
+    let interval = crate::model::Interval::covering(&period);
+    let phase_two = participant_count_program();
+
+    let mut noncolliding = crate::model::DataSet::default();
+    noncolliding.add_input(
+        "age",
+        "person",
+        "base-only-person",
+        interval.clone(),
+        crate::model::ScalarValue::Integer(40),
+    );
+    let materialized =
+        materialize_phase_two_dataset(&noncolliding, &phase_two, &input, &run, interval.clone())
+            .unwrap();
+    assert_eq!(
+        materialized
+            .registry()
+            .get("base-only-person")
+            .map(|entry| entry.entity_type.as_str()),
+        Some("person")
+    );
+    assert!(materialized.registry().get("a").is_some());
+    assert!(materialized.registry().get(&derived_unit_id).is_some());
+
+    let mut colliding = crate::model::DataSet::default();
+    colliding.add_input(
+        "adversarial",
+        "some_other_entity_type",
+        derived_unit_id,
+        interval.clone(),
+        crate::model::ScalarValue::Bool(true),
+    );
+    let error = materialize_phase_two_dataset(&colliding, &phase_two, &input, &run, interval)
+        .expect_err("complete base dataset must bind before derived units");
+    assert!(matches!(error, UnitDerivationError::EntityCollision { .. }));
+}
+
+#[test]
+fn shadow_channel_is_checked_non_evaluable_and_partition_normalized() {
+    let mut plan = base_plan(&["a", "b"]);
+    plan.edges.push(edge(
+        "group",
+        EdgeKind::Base,
+        "a",
+        "b",
+        BoolExpr::Literal(true),
+    ));
+    let compiled = compile(plan).unwrap();
+    let entries = [Projection::UnitConstituent, Projection::ParticipatingMember]
+        .into_iter()
+        .map(|projection| LedgerEntry {
+            fixture: "shadow-case".to_string(),
+            projection,
+            expectation: LedgerExpectation::Equal,
+            statutory_basis: citation("frozen-before-run"),
+        })
+        .collect();
+    let prototype = Prototype::new(compiled, enabled(), FrozenLedger::new(entries).unwrap());
+    let supplied = [Projection::UnitConstituent, Projection::ParticipatingMember]
+        .into_iter()
+        .flat_map(|projection| {
+            ["a", "b"]
+                .into_iter()
+                .map(move |person| SuppliedMembershipTuple {
+                    relation: match projection {
+                        Projection::UnitConstituent => "us:test#member_of_household",
+                        Projection::ParticipatingMember => "us:test#snap_unit_member",
+                    }
+                    .to_string(),
+                    unit: "caller-unit-id-is-ignored".to_string(),
+                    person: person.to_string(),
+                    projection,
+                })
+        })
+        .collect::<Vec<_>>();
+
+    let direct_error = prototype
+        .run(&complete_input(&["a", "b"]), &supplied, None)
+        .expect_err("direct supplied and derived membership must conflict");
+    assert!(matches!(
+        direct_error,
+        UnitDerivationError::SuppliedAndDerivedMembership(_)
+    ));
+
+    let shadow = prototype.bind_shadow("shadow-case", supplied).unwrap();
+    let run = prototype
+        .run(&complete_input(&["a", "b"]), &[], Some(&shadow))
+        .unwrap();
+    assert_eq!(run.comparisons.len(), 2);
+    assert!(
+        run.comparisons
+            .iter()
+            .all(|item| { item.observed == ObservedComparison::Equal && item.conforms_to_ledger })
+    );
+    assert!(
+        run.derivation
+            .memberships
+            .iter()
+            .all(|tuple| { tuple.unit != "caller-unit-id-is-ignored" })
+    );
+    let first_bytes = serialize_experimental_run(&run).unwrap();
+    let second_bytes = serialize_experimental_run(&run).unwrap();
+    assert_eq!(first_bytes, second_bytes);
+    let envelope: serde_json::Value = serde_json::from_slice(&first_bytes).unwrap();
+    assert_eq!(
+        envelope["experimental_semantics_version"],
+        EXPERIMENTAL_SEMANTICS_VERSION
+    );
+    assert!(envelope.get("artifact_format_version").is_none());
+}
+
+#[test]
+fn invariant_normalized_input_conflict_is_classified_per_affected_projection() {
+    let mut plan = base_plan(&["a", "b"]);
+    plan.edges.push(edge(
+        "group",
+        EdgeKind::Base,
+        "a",
+        "b",
+        BoolExpr::Literal(true),
+    ));
+    plan.statuses.push(StatusRule {
+        id: "status-b".to_string(),
+        person: "b".to_string(),
+        when: BoolExpr::fact(FactRef::Bool("conflicted_status".to_string())),
+        citation: citation("status-authority"),
+    });
+    let compiled = compile(plan).unwrap();
+    let ledger = FrozenLedger::new(vec![
+        LedgerEntry {
+            fixture: "conflict-case".to_string(),
+            projection: Projection::UnitConstituent,
+            expectation: LedgerExpectation::Equal,
+            statutory_basis: citation("frozen-constituent"),
+        },
+        LedgerEntry {
+            fixture: "conflict-case".to_string(),
+            projection: Projection::ParticipatingMember,
+            expectation: LedgerExpectation::Conflict,
+            statutory_basis: citation("frozen-participating"),
+        },
+    ])
+    .unwrap();
+    let prototype = Prototype::new(compiled, enabled(), ledger);
+    let supplied = vec![
+        SuppliedMembershipTuple {
+            relation: "us:test#member_of_household".to_string(),
+            unit: "shadow".to_string(),
+            person: "a".to_string(),
+            projection: Projection::UnitConstituent,
+        },
+        SuppliedMembershipTuple {
+            relation: "us:test#member_of_household".to_string(),
+            unit: "shadow".to_string(),
+            person: "b".to_string(),
+            projection: Projection::UnitConstituent,
+        },
+        SuppliedMembershipTuple {
+            relation: "us:test#snap_unit_member".to_string(),
+            unit: "shadow".to_string(),
+            person: "a".to_string(),
+            projection: Projection::ParticipatingMember,
+        },
+    ];
+    let shadow = prototype.bind_shadow("conflict-case", supplied).unwrap();
+    let mut input = complete_input(&["a", "b"]);
+    input.bool_facts.push(BoolFactInput {
+        name: "conflicted_status".to_string(),
+        observations: vec![observed(true, "source-one"), observed(true, "source-two")],
+        explicit_unknown: None,
+    });
+    let run = prototype.run(&input, &[], Some(&shadow)).unwrap();
+    assert!(run.derivation.indeterminate.is_empty());
+    assert_eq!(run.derivation.trace.input_conflict_impacts.len(), 1);
+    assert_eq!(run.comparisons[0].observed, ObservedComparison::Equal);
+    assert_eq!(run.comparisons[1].observed, ObservedComparison::Conflict);
+    assert!(
+        run.comparisons
+            .iter()
+            .all(|comparison| comparison.conforms_to_ledger)
+    );
+}
+
+#[test]
+fn identity_preimage_is_order_invariant_and_matches_the_frozen_vector() {
+    let first = unit_id(
+        [0x5a; 32],
+        "us:test#member_of_household",
+        "dwelling:test",
+        "2026-07-01/2026-07-31",
+        &["person:b".to_string(), "person:a".to_string()],
+    );
+    let second = unit_id(
+        [0x5a; 32],
+        "us:test#member_of_household",
+        "dwelling:test",
+        "2026-07-01/2026-07-31",
+        &["person:a".to_string(), "person:b".to_string()],
+    );
+    assert_eq!(first, second);
+    assert_eq!(
+        first,
+        "sha256:bfd22d31b021e9ba47db44115094f66f5f70884490349b30fe396e747649beb4"
+    );
+}
+
+#[test]
+fn compiled_semantics_digest_is_independently_recomputed_and_churns_on_semantic_edits() {
+    let minimal = base_plan(&["a"]);
+    let compiled = compile(minimal.clone()).unwrap();
+    let mut encoding = b"axiom.unit-derivation.semantics.stage2\0".to_vec();
+    for value in [
+        minimal.id.as_str(),
+        minimal.entity_type.as_str(),
+        minimal.roster_relation.as_str(),
+        minimal.relations.unit_constituent.as_str(),
+        minimal.relations.participating_member.as_str(),
+    ] {
+        independent_lp(&mut encoding, value.as_bytes());
+    }
+    // Empty derived-bool, edge, cut, attachment, bar, and status collections.
+    for _ in 0..6 {
+        encoding.extend_from_slice(&0_u32.to_be_bytes());
+    }
+    // No base-chain policy.
+    encoding.push(0);
+    assert_eq!(compiled.semantics_digest(), independent_sha256(&encoding));
+
+    let mut formula_edit = minimal.clone();
+    formula_edit.edges.push(edge(
+        "semantic-edge",
+        EdgeKind::Base,
+        "a",
+        "b",
+        BoolExpr::Literal(true),
+    ));
+    let mut citation_edit = formula_edit.clone();
+    citation_edit.edges[0].citation = citation("different-authority");
+    assert_ne!(
+        compile(formula_edit).unwrap().semantics_digest(),
+        compile(citation_edit).unwrap().semantics_digest(),
+        "citation edits must churn the internally computed semantics digest"
+    );
+}
+
+fn independent_lp(output: &mut Vec<u8>, value: &[u8]) {
+    output.extend_from_slice(&(value.len() as u32).to_be_bytes());
+    output.extend_from_slice(value);
+}
+
+// Test-only SHA-256 recomputation kept independent of the prototype's hash
+// routine so the digest assertion does not merely call production twice.
+fn independent_sha256(input: &[u8]) -> [u8; 32] {
+    const K: [u32; 64] = [
+        0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4,
+        0xab1c5ed5, 0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe,
+        0x9bdc06a7, 0xc19bf174, 0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f,
+        0x4a7484aa, 0x5cb0a9dc, 0x76f988da, 0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7,
+        0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967, 0x27b70a85, 0x2e1b2138, 0x4d2c6dfc,
+        0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85, 0xa2bfe8a1, 0xa81a664b,
+        0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070, 0x19a4c116,
+        0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+        0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7,
+        0xc67178f2,
+    ];
+    let mut padded = input.to_vec();
+    let bit_len = (padded.len() as u64) * 8;
+    padded.push(0x80);
+    while padded.len() % 64 != 56 {
+        padded.push(0);
+    }
+    padded.extend_from_slice(&bit_len.to_be_bytes());
+    let mut state = [
+        0x6a09e667_u32,
+        0xbb67ae85,
+        0x3c6ef372,
+        0xa54ff53a,
+        0x510e527f,
+        0x9b05688c,
+        0x1f83d9ab,
+        0x5be0cd19,
+    ];
+    for chunk in padded.chunks_exact(64) {
+        let mut words = [0_u32; 64];
+        for (index, word) in words.iter_mut().take(16).enumerate() {
+            let offset = index * 4;
+            *word = u32::from_be_bytes(chunk[offset..offset + 4].try_into().unwrap());
+        }
+        for index in 16..64 {
+            let a = words[index - 15].rotate_right(7)
+                ^ words[index - 15].rotate_right(18)
+                ^ (words[index - 15] >> 3);
+            let b = words[index - 2].rotate_right(17)
+                ^ words[index - 2].rotate_right(19)
+                ^ (words[index - 2] >> 10);
+            words[index] = words[index - 16]
+                .wrapping_add(a)
+                .wrapping_add(words[index - 7])
+                .wrapping_add(b);
+        }
+        let [mut a, mut b, mut c, mut d, mut e, mut f, mut g, mut h] = state;
+        for index in 0..64 {
+            let choose = (e & f) ^ ((!e) & g);
+            let majority = (a & b) ^ (a & c) ^ (b & c);
+            let first = h
+                .wrapping_add(e.rotate_right(6) ^ e.rotate_right(11) ^ e.rotate_right(25))
+                .wrapping_add(choose)
+                .wrapping_add(K[index])
+                .wrapping_add(words[index]);
+            let second = (a.rotate_right(2) ^ a.rotate_right(13) ^ a.rotate_right(22))
+                .wrapping_add(majority);
+            h = g;
+            g = f;
+            f = e;
+            e = d.wrapping_add(first);
+            d = c;
+            c = b;
+            b = a;
+            a = first.wrapping_add(second);
+        }
+        for (slot, value) in state.iter_mut().zip([a, b, c, d, e, f, g, h].into_iter()) {
+            *slot = slot.wrapping_add(value);
+        }
+    }
+    let mut output = [0_u8; 32];
+    for (index, word) in state.into_iter().enumerate() {
+        output[index * 4..index * 4 + 4].copy_from_slice(&word.to_be_bytes());
+    }
+    output
+}
+
+#[test]
+fn strict_segmentation_precedes_selection() {
+    let compiled = compile(base_plan(&["a"])).unwrap();
+    let mut input = complete_input(&["a"]);
+    input.segment_complete = false;
+    assert_eq!(
+        derive_units(&compiled, &input, &enabled()).unwrap_err(),
+        UnitDerivationError::RequiresSegmentation
+    );
+}
+
+#[derive(Debug, Deserialize)]
+struct SnapFixtureFile {
+    cases: Vec<SnapFixture>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SnapFixture {
+    id: String,
+    roster: Vec<String>,
+    base_groups: Vec<Vec<String>>,
+    combination_edges: Vec<[String; 2]>,
+    status_excluded: Vec<String>,
+    expected_constituent: Vec<Vec<String>>,
+    expected_participating: Vec<Vec<String>>,
+}
+
+#[test]
+fn synthetic_snap_pilot_shape_fixtures_match_7_cfr_projection_shapes() {
+    let fixture: SnapFixtureFile = serde_yaml::from_str(include_str!(
+        "../../tests/fixtures/unit_derivation/snap_household_shapes.yaml"
+    ))
+    .unwrap();
+    for case in fixture.cases {
+        let roster_refs = case.roster.iter().map(String::as_str).collect::<Vec<_>>();
+        let mut plan = base_plan(&roster_refs);
+        let mut pap_facts = Vec::new();
+        for (group_index, group) in case.base_groups.iter().enumerate() {
+            for left_index in 0..group.len() {
+                for right_index in (left_index + 1)..group.len() {
+                    let left = &group[left_index];
+                    let right = &group[right_index];
+                    plan.edges.push(edge(
+                        &format!("pap-{group_index}-{left}-{right}"),
+                        EdgeKind::Base,
+                        left,
+                        right,
+                        relation_expr("purchase_and_prepare", left, right),
+                    ));
+                    pap_facts.push(RelationFact {
+                        tuple: vec![left.clone(), right.clone()],
+                        observation: observed(true, &format!("pap:{left}:{right}")),
+                    });
+                }
+            }
+        }
+        let mut combination_facts = Vec::new();
+        for [left, right] in &case.combination_edges {
+            plan.edges.push(edge(
+                &format!("mandatory-{left}-{right}"),
+                EdgeKind::Combination,
+                left,
+                right,
+                relation_expr("mandatory_combination", left, right),
+            ));
+            combination_facts.push(RelationFact {
+                tuple: vec![left.clone(), right.clone()],
+                observation: observed(true, &format!("combination:{left}:{right}")),
+            });
+        }
+        for person in &case.status_excluded {
+            plan.statuses.push(StatusRule {
+                id: format!("excluded-{person}"),
+                person: person.clone(),
+                when: BoolExpr::Literal(true),
+                citation: citation("7-cfr-273.1(b)(7)/273.11(c)"),
+            });
+        }
+        let mut input = complete_input(&roster_refs);
+        input.relation_families = vec![
+            RelationFamilyInput {
+                name: "purchase_and_prepare".to_string(),
+                scope: input.roster.scope.clone(),
+                completeness: Some(evidence(&format!("{}:complete-pap", case.id))),
+                facts: pap_facts,
+            },
+            RelationFamilyInput {
+                name: "mandatory_combination".to_string(),
+                scope: input.roster.scope.clone(),
+                completeness: Some(evidence(&format!("{}:complete-combination", case.id))),
+                facts: combination_facts,
+            },
+        ];
+        let result = derive_units(&compile(plan).unwrap(), &input, &enabled()).unwrap();
+        let mut expected_constituent = case.expected_constituent;
+        let mut expected_participating = case.expected_participating;
+        expected_constituent
+            .iter_mut()
+            .for_each(|block| block.sort());
+        expected_participating
+            .iter_mut()
+            .for_each(|block| block.sort());
+        expected_constituent.sort();
+        expected_participating.sort();
+        assert_eq!(
+            partition(&result, Projection::UnitConstituent),
+            expected_constituent,
+            "fixture {} constituent projection",
+            case.id
+        );
+        assert_eq!(
+            partition(&result, Projection::ParticipatingMember),
+            expected_participating,
+            "fixture {} participation projection",
+            case.id
+        );
+    }
+}

--- a/src/unit_derivation/types.rs
+++ b/src/unit_derivation/types.rs
@@ -1,0 +1,570 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use thiserror::Error;
+
+pub type PersonId = String;
+pub type UnitId = String;
+pub type FactId = String;
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Citation {
+    pub provision: String,
+    pub authority: String,
+}
+
+impl Citation {
+    pub fn new(provision: impl Into<String>, authority: impl Into<String>) -> Self {
+        Self {
+            provision: provision.into(),
+            authority: authority.into(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Evidence {
+    pub id: String,
+    pub citation: Citation,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct ObservedBool {
+    pub value: bool,
+    pub evidence: Evidence,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RelationFact {
+    pub tuple: Vec<String>,
+    pub observation: ObservedBool,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RelationFamilyInput {
+    pub name: String,
+    pub scope: String,
+    /// Evidence that this family is complete for exactly `scope`. Absence is
+    /// not completeness; missing tuples remain Unknown.
+    pub completeness: Option<Evidence>,
+    pub facts: Vec<RelationFact>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BoolFactInput {
+    pub name: String,
+    pub observations: Vec<ObservedBool>,
+    /// A caller can explicitly bind Unknown. Authority defaults apply only to
+    /// an absent record, never to this state or to a Conflict.
+    pub explicit_unknown: Option<Evidence>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RosterInput {
+    pub relation: String,
+    pub scope: String,
+    pub persons: Vec<PersonId>,
+    pub completeness: Option<Evidence>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SuppliedEntity {
+    pub entity_type: String,
+    pub id: String,
+    pub evidence: Evidence,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ConstitutionInput {
+    pub roster: RosterInput,
+    pub segment: String,
+    /// False means facts or parameters change inside the requested period and
+    /// the caller must segment before constitution evaluation.
+    pub segment_complete: bool,
+    pub relation_families: Vec<RelationFamilyInput>,
+    pub bool_facts: Vec<BoolFactInput>,
+    pub supplied_entities: Vec<SuppliedEntity>,
+    pub integrity_constraints: Vec<IntegrityConstraint>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum FactRef {
+    Bool(String),
+    Relation { family: String, tuple: Vec<String> },
+}
+
+impl FactRef {
+    pub(crate) fn key(&self) -> String {
+        match self {
+            Self::Bool(name) => format!("bool:{name}"),
+            Self::Relation { family, tuple } => {
+                format!("relation:{family}:{}", tuple.join("\u{1f}"))
+            }
+        }
+    }
+
+    pub(crate) fn named_persons(&self) -> BTreeSet<PersonId> {
+        match self {
+            Self::Bool(_) => BTreeSet::new(),
+            Self::Relation { tuple, .. } => tuple.iter().cloned().collect(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum BoolExpr {
+    Literal(bool),
+    Fact(FactRef),
+    Derived(String),
+    And(Vec<BoolExpr>),
+    Or(Vec<BoolExpr>),
+    Not(Box<BoolExpr>),
+}
+
+impl BoolExpr {
+    pub fn fact(fact: FactRef) -> Self {
+        Self::Fact(fact)
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Stratum {
+    Person,
+    Candidate,
+    Unit,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DerivedBool {
+    pub id: String,
+    pub stratum: Stratum,
+    pub expr: BoolExpr,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct IntegrityConstraint {
+    pub id: String,
+    pub expr: BoolExpr,
+    pub citation: Citation,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum EdgeKind {
+    Base,
+    Combination,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct EdgeDefeater {
+    pub id: String,
+    pub when: BoolExpr,
+    pub citation: Citation,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct EdgeRule {
+    pub id: String,
+    pub kind: EdgeKind,
+    pub left: PersonId,
+    pub right: PersonId,
+    pub when: BoolExpr,
+    pub citation: Citation,
+    /// Guard-level edge defeaters run before the frozen edge set is made.
+    pub defeaters: Vec<EdgeDefeater>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum CutEdgeDecision {
+    /// The named combination provision blocks the cut.
+    Blocked { citation: Citation },
+    /// The cut crosses the named combination provision.
+    Overrides { citation: Citation },
+    /// The legal text does not compel either branch. Evaluation ranges over
+    /// both, so affected people are Indeterminate unless the result is equal.
+    Unresolved { issue: String },
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CutEdgePrecedence {
+    pub edge_rule: String,
+    pub decision: CutEdgeDecision,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CutOrder {
+    pub lower_priority_cut: String,
+    pub citation: Citation,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum MissingElectionPolicy {
+    Unknown,
+    AuthorityDefault { value: bool, citation: Citation },
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ElectionRequirement {
+    pub fact: String,
+    pub actor: String,
+    pub missing: MissingElectionPolicy,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CutRule {
+    pub id: String,
+    pub members: BTreeSet<PersonId>,
+    pub when: BoolExpr,
+    pub citation: Citation,
+    pub election: Option<ElectionRequirement>,
+    pub edge_precedence: Vec<CutEdgePrecedence>,
+    /// Explicit cut-vs-cut precedence declarations. Undeclared co-active
+    /// overlap is a constitution_overlap_conflict.
+    pub precedes: Vec<CutOrder>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AttachmentRule {
+    pub id: String,
+    pub members: BTreeSet<PersonId>,
+    /// A person identifying the provider candidate before attachments run.
+    pub target_anchor: PersonId,
+    pub when: BoolExpr,
+    pub actor: String,
+    pub election: Option<ElectionRequirement>,
+    pub citation: Citation,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BarRule {
+    pub id: String,
+    pub members: BTreeSet<PersonId>,
+    pub when: BoolExpr,
+    pub citation: Citation,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct StatusRule {
+    pub id: String,
+    pub person: PersonId,
+    pub when: BoolExpr,
+    pub citation: Citation,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct EmissionRelations {
+    /// Compile-resolved canonical id; the emitter uses this exact string.
+    pub unit_constituent: String,
+    /// Compile-resolved canonical id; the emitter uses this exact string.
+    pub participating_member: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ConstitutionPlan {
+    pub id: String,
+    pub entity_type: String,
+    pub roster_relation: String,
+    pub relations: EmissionRelations,
+    pub derived_bools: Vec<DerivedBool>,
+    pub edges: Vec<EdgeRule>,
+    pub cuts: Vec<CutRule>,
+    pub attachments: Vec<AttachmentRule>,
+    pub bars: Vec<BarRule>,
+    pub statuses: Vec<StatusRule>,
+    /// A named, effective, cited § 273.1(c)-style policy. None is the default;
+    /// pairwise base-edge chains then remain Indeterminate.
+    pub base_chain_policy: Option<Citation>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct UnitDerivationConfig {
+    pub enabled: bool,
+    pub semantics_version: String,
+    pub max_admissible_worlds: usize,
+}
+
+impl Default for UnitDerivationConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            semantics_version: super::EXPERIMENTAL_SEMANTICS_VERSION.to_string(),
+            max_admissible_worlds: 4096,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Projection {
+    UnitConstituent,
+    ParticipatingMember,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum ProjectionRole {
+    Member,
+    Excluded,
+    BarredIndependent,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Provenance {
+    Supplied {
+        evidence_id: String,
+    },
+    Derived {
+        constitution: String,
+        trace_root: String,
+    },
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DerivedUnit {
+    pub entity_type: String,
+    pub id: UnitId,
+    pub members: Vec<PersonId>,
+    pub provenance: Provenance,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct MembershipTuple {
+    pub relation: String,
+    pub unit: UnitId,
+    pub person: PersonId,
+    pub projection: Projection,
+    pub role: ProjectionRole,
+    pub citations: BTreeSet<Citation>,
+    pub provenance: Provenance,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum IndeterminateKind {
+    Membership,
+    Role(Projection),
+    ConstitutionOverlapConflict,
+    DiscretionNotEncoded,
+    RosterNotAssertedComplete,
+    InconsistentInputs,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct IndeterminatePerson {
+    pub person: PersonId,
+    pub kind: IndeterminateKind,
+    pub unresolved_facts: BTreeSet<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum TraceEvent {
+    FrozenEdge {
+        rule: String,
+        left: String,
+        right: String,
+    },
+    CutApplied {
+        rule: String,
+        actor: Option<String>,
+        request_evidence: BTreeSet<String>,
+    },
+    CutBlocked {
+        cut: String,
+        edge_rule: String,
+        actor: Option<String>,
+        request_evidence: BTreeSet<String>,
+    },
+    CutOverlapConflict {
+        left: String,
+        right: String,
+    },
+    Attachment {
+        rule: String,
+        target_anchor: String,
+        actor: String,
+        request_evidence: BTreeSet<String>,
+    },
+    IndependentBar {
+        rule: String,
+    },
+    StatusExcluded {
+        rule: String,
+        person: String,
+    },
+    ElectionDefault {
+        fact: String,
+        actor: String,
+        value: bool,
+        citation: Citation,
+    },
+    DiscretionNotEncoded {
+        persons: Vec<String>,
+    },
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DerivationTrace {
+    pub root: String,
+    pub worlds_evaluated: usize,
+    pub events: BTreeSet<TraceEvent>,
+    pub completeness_evidence: BTreeSet<String>,
+    pub input_conflicts: BTreeSet<String>,
+    pub input_conflict_impacts: BTreeSet<InputConflictImpact>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct InputConflictImpact {
+    pub fact: String,
+    pub persons: BTreeSet<String>,
+    pub projections: BTreeSet<Projection>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct UnitDerivationResult {
+    pub relations: EmissionRelations,
+    pub units: Vec<DerivedUnit>,
+    pub memberships: Vec<MembershipTuple>,
+    pub indeterminate: Vec<IndeterminatePerson>,
+    pub trace: DerivationTrace,
+}
+
+#[derive(Clone, Debug, Error, PartialEq, Eq)]
+pub enum UnitDerivationError {
+    #[error("unit derivation is disabled; enable the runtime flag explicitly")]
+    Disabled,
+    #[error("unsupported experimental semantics version `{0}`")]
+    UnsupportedExperimentalVersion(String),
+    #[error("duplicate {namespace} id `{id}`")]
+    DuplicateNamespace { namespace: &'static str, id: String },
+    #[error("unknown reference `{reference}` from `{from}`")]
+    UnknownReference { from: String, reference: String },
+    #[error("cyclic dependency: {0}")]
+    CyclicDependency(String),
+    #[error("constitution dependency reaches unit stratum: {0}")]
+    UnitStratumDependency(String),
+    #[error("invalid constitution plan: {0}")]
+    InvalidPlan(String),
+    #[error("evaluation requires segmentation before parameter/fact selection")]
+    RequiresSegmentation,
+    #[error("constitution has {worlds} admissible worlds, exceeding configured maximum {maximum}")]
+    UncheckableWorldSpace { worlds: usize, maximum: usize },
+    #[error("supplied and derived membership both bind relation `{0}`; use the shadow channel")]
+    SuppliedAndDerivedMembership(String),
+    #[error(
+        "shadow comparison for fixture `{fixture}` projection {projection:?} has no frozen ledger entry"
+    )]
+    MissingLedgerEntry {
+        fixture: String,
+        projection: Projection,
+    },
+    #[error(
+        "entity instance id collision for `{id}`: existing {existing_type}, incoming {incoming_type}"
+    )]
+    EntityCollision {
+        id: String,
+        existing_type: String,
+        incoming_type: String,
+    },
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum LiftedTruth {
+    Holds,
+    DoesNotHold,
+    Unknown { reasons: BTreeSet<String> },
+    Conflict { reasons: BTreeSet<String> },
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct LiftedCandidate {
+    pub id: String,
+    pub predicate: LiftedTruth,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct LiftedRelation {
+    pub members: Vec<String>,
+    pub unresolved: BTreeMap<String, LiftedTruth>,
+}
+
+/// An unresolved candidate tuple carried across the phase-1/phase-2 barrier.
+/// Known members remain ordinary `RelationRecord`s; only Unknown/Conflict
+/// candidates live here so the existing closed-world dataset stays unchanged
+/// when the prototype feature is disabled.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RelationKnowledgeRecord {
+    pub name: String,
+    pub tuple: Vec<String>,
+    pub interval: crate::model::Interval,
+    pub truth: LiftedTruth,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum CompleteReduction<T> {
+    Determined(T),
+    Indeterminate { reasons: BTreeSet<String> },
+}
+
+impl LiftedRelation {
+    pub fn count_complete(&self) -> CompleteReduction<usize> {
+        if self.unresolved.is_empty() {
+            CompleteReduction::Determined(self.members.len())
+        } else {
+            let reasons = self
+                .unresolved
+                .values()
+                .flat_map(|truth| match truth {
+                    LiftedTruth::Unknown { reasons } | LiftedTruth::Conflict { reasons } => {
+                        reasons.iter().cloned().collect::<Vec<_>>()
+                    }
+                    LiftedTruth::Holds | LiftedTruth::DoesNotHold => Vec::new(),
+                })
+                .collect();
+            CompleteReduction::Indeterminate { reasons }
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SuppliedMembershipTuple {
+    pub relation: String,
+    pub unit: String,
+    pub person: String,
+    pub projection: Projection,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum LedgerExpectation {
+    Equal,
+    Different,
+    Indeterminate,
+    Conflict,
+    OutOfPilot { reason: String },
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct LedgerEntry {
+    pub fixture: String,
+    pub projection: Projection,
+    pub expectation: LedgerExpectation,
+    pub statutory_basis: Citation,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ObservedComparison {
+    Equal,
+    Different,
+    Indeterminate,
+    Conflict,
+    OutOfPilot,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ComparisonResult {
+    pub fixture: String,
+    pub projection: Projection,
+    pub observed: ObservedComparison,
+    pub expected: LedgerExpectation,
+    pub conforms_to_ledger: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PrototypeRun {
+    pub derivation: UnitDerivationResult,
+    pub comparisons: Vec<ComparisonResult>,
+}

--- a/tests/fixtures/unit_derivation/snap_household_shapes.yaml
+++ b/tests/fixtures/unit_derivation/snap_household_shapes.yaml
@@ -1,0 +1,37 @@
+# Synthetic 7 CFR 273.1 / 273.11 household-shape fixtures. These are engine
+# fixtures only; they do not encode or modify rulespec-us.
+cases:
+  - id: general_purchase_and_prepare_group
+    roster: [adult_a, adult_b, child_c]
+    base_groups:
+      - [adult_a, adult_b, child_c]
+    combination_edges: []
+    status_excluded: []
+    expected_constituent:
+      - [adult_a, adult_b, child_c]
+    expected_participating:
+      - [adult_a, adult_b, child_c]
+
+  - id: mandatory_under_22_parent_combination
+    roster: [parent, child_21, roommate]
+    base_groups: []
+    combination_edges:
+      - [parent, child_21]
+    status_excluded: []
+    expected_constituent:
+      - [child_21, parent]
+      - [roommate]
+    expected_participating:
+      - [child_21, parent]
+      - [roommate]
+
+  - id: excluded_member_kept_as_constituent
+    roster: [claimant, ssn_noncooperator]
+    base_groups:
+      - [claimant, ssn_noncooperator]
+    combination_edges: []
+    status_excluded: [ssn_noncooperator]
+    expected_constituent:
+      - [claimant, ssn_noncooperator]
+    expected_participating:
+      - [claimant]


### PR DESCRIPTION
Stage 2 of #134, per the RFC ratified in #135 (ratification: issue comment 5299498361 — tier A core semantics and tier D interface ratified; tier B legal interpretations deferred; tier C ships no default).

Prototype of the ratified semantics behind the Cargo feature `unit-derivation` (off by default; runtime `UnitDerivationConfig.enabled` independently false):
- Tier A: five-operation algebra (base/combination edges, cuts, attachments, independent-participation bars, status tags); frozen edge sets with simultaneous-cut blocking and pairwise disjointness; per-person per-projection determination with separate `unit_constituent` and `participating_member` roles; conservative dependency-closure locality; scoped per-relation-family completeness; Knowledge-lifted derived relations with Indeterminate complete reductions; typed runtime entity registry with collision rejection; no default base-chain policy.
- Tier D: supplied-and-derived bind errors; checked non-evaluable shadow channel; immutable expected-behavior ledger created before execution; projection-separated partition-normalized comparison; SHA-256 identity preimage with an independently verified test vector; canonical ordering throughout.
- Tier B is not decided anywhere: (b)(1)/(b)(2) precedence supports explicit block, override, or unresolved both-world evaluation; other guard meanings, size keys, provider construction, carry-along scope, institution clauses, and actors remain explicit plan inputs.
- No RuleSpec `kind: unit` parser/lowering and no artifact-v2 schema change; plans use the feature-gated Rust API. Synthetic 7 CFR 273.1/273.11 household shapes as in-repo fixtures; rulespec-us untouched.

Adversarial review (ops nz-lane/_cert/sol-stage2-review.md) BLOCKED the first cut on eight findings — including Indeterminate participation collapsing to a confident count at the phase-2 barrier (the exact `is_holds` failure the RFC names), silent blocked-wins on contradictory identical cuts, and base entities bypassing the registry. Every finding is fixed in this commit and guarded by a named test (e.g. `unknown_status_survives_materialization_and_indeterminates_phase_two_count`, `identical_cuts_with_contradictory_legal_decisions_fail_compilation`); each core fix was mutation-checked (sabotage → its test fails).

Verification: flag off 284 passed (existing behavior; executable byte-identical under a controlled build — the new Cargo feature necessarily changes .rlib metadata, code behavior does not change); flag on 307 passed; all features 322; fmt clean; clippy no new findings against the documented baseline. Diff: 9 files, +5,296, no PROGRESS.md/release/workflow/toolchain changes.

Stage 3 (rulespec-us SNAP household pilot + comparison vs supplied membership) is a separate PR after this lands. Refs #134, #135; consumer: axiom-oracles NZ certificates' aggregation blocker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)