### PR TITLE
Stage 3: NZ family/child aggregation under the ratified unit-derivation algebra

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,6 +89,7 @@ version = "0.2.1"
 dependencies = [
  "chrono",
  "jsonschema",
+ "num-bigint",
  "rust_decimal",
  "rust_decimal_macros",
  "schemars",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ schema = ["dep:schemars"]
 # Stage-2 prototype for the ratified unit-derivation semantics. The runtime
 # configuration inside the module is independently disabled by default. This
 # feature does not extend artifact v2 or any publication/launch surface.
-unit-derivation = []
+unit-derivation = ["dep:num-bigint"]
 
 [[bin]]
 name = "axiom-rules-engine"
@@ -53,6 +53,7 @@ required-features = ["fs"]
 # Default features off: the `clock` feature (wall-clock reads) stays out of
 # the core, which never reads the current time and must not on wasm hosts.
 chrono = { version = "0.4.42", default-features = false, features = ["serde", "std"] }
+num-bigint = { version = "0.4.6", optional = true }
 rust_decimal = { version = "1.39.0", features = ["maths", "serde"] }
 rust_decimal_macros = "1.39.0"
 schemars = { version = "1", features = ["chrono04", "rust_decimal1"], optional = true }

--- a/schemas/compiled-unit-aggregation.stage3.schema.json
+++ b/schemas/compiled-unit-aggregation.stage3.schema.json
@@ -112,6 +112,16 @@
         "citation": {
           "$ref": "#/$defs/AggregationCitation"
         },
+        "engine_computation": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/EngineComputationBinding"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "kind": {
           "$ref": "#/$defs/AggregationInputKind"
         },
@@ -349,7 +359,7 @@
               "authority": "",
               "provision": ""
             },
-            "entitlement_holder_input": ""
+            "reference_person_input": ""
           }
         },
         "partner_relation": {
@@ -871,6 +881,18 @@
           ]
         }
       },
+      "type": "object"
+    },
+    "EngineComputationBinding": {
+      "additionalProperties": false,
+      "properties": {
+        "rule_id": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "rule_id"
+      ],
       "type": "object"
     },
     "FamilyPredicate": {
@@ -1503,12 +1525,12 @@
         "citation": {
           "$ref": "#/$defs/AggregationCitation"
         },
-        "entitlement_holder_input": {
+        "reference_person_input": {
           "type": "string"
         }
       },
       "required": [
-        "entitlement_holder_input",
+        "reference_person_input",
         "citation",
         "caller_determination"
       ],
@@ -2439,6 +2461,12 @@
     "semantics_version": {
       "const": "unit-derivation-stage2/1",
       "type": "string"
+    },
+    "source_artifact": {
+      "$ref": "#/$defs/CompiledProgramArtifact"
+    },
+    "source_artifact_digest": {
+      "type": "string"
     }
   },
   "required": [
@@ -2446,7 +2474,9 @@
     "semantics_version",
     "plan_digest",
     "constitution_digest",
+    "source_artifact_digest",
     "plan",
+    "source_artifact",
     "phase_two_artifact"
   ],
   "title": "Compiled experimental unit aggregation artifact",

--- a/schemas/compiled-unit-aggregation.stage3.schema.json
+++ b/schemas/compiled-unit-aggregation.stage3.schema.json
@@ -1,0 +1,2454 @@
+{
+  "$defs": {
+    "AdultSelectionOperation": {
+      "enum": [
+        "explicit_person_role"
+      ],
+      "type": "string"
+    },
+    "AdultSelectionRule": {
+      "additionalProperties": false,
+      "properties": {
+        "caller_determination": {
+          "type": "string"
+        },
+        "citation": {
+          "$ref": "#/$defs/AggregationCitation"
+        },
+        "operation": {
+          "$ref": "#/$defs/AdultSelectionOperation"
+        }
+      },
+      "required": [
+        "operation",
+        "citation",
+        "caller_determination"
+      ],
+      "type": "object"
+    },
+    "Age18Conditions": {
+      "additionalProperties": false,
+      "properties": {
+        "age": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "attending_school_or_tertiary_input": {
+          "type": "string"
+        },
+        "citation": {
+          "$ref": "#/$defs/AggregationCitation"
+        },
+        "commissioner_period_input": {
+          "type": "string"
+        },
+        "not_financially_independent_input": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "age",
+        "not_financially_independent_input",
+        "attending_school_or_tertiary_input",
+        "commissioner_period_input",
+        "citation"
+      ],
+      "type": "object"
+    },
+    "AggregateSelector": {
+      "enum": [
+        "adults",
+        "all_members"
+      ],
+      "type": "string"
+    },
+    "AggregationCitation": {
+      "additionalProperties": false,
+      "properties": {
+        "authority": {
+          "type": "string"
+        },
+        "provision": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "provision",
+        "authority"
+      ],
+      "type": "object"
+    },
+    "AggregationConstitution": {
+      "additionalProperties": false,
+      "properties": {
+        "entity_type": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "participating_member_relation": {
+          "type": "string"
+        },
+        "roster_relation": {
+          "type": "string"
+        },
+        "unit_constituent_relation": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "entity_type",
+        "roster_relation",
+        "unit_constituent_relation",
+        "participating_member_relation"
+      ],
+      "type": "object"
+    },
+    "AggregationInput": {
+      "additionalProperties": false,
+      "properties": {
+        "citation": {
+          "$ref": "#/$defs/AggregationCitation"
+        },
+        "kind": {
+          "$ref": "#/$defs/AggregationInputKind"
+        },
+        "name": {
+          "type": "string"
+        },
+        "reduction_key": {
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "scope": {
+          "$ref": "#/$defs/AggregationInputScope"
+        }
+      },
+      "required": [
+        "name",
+        "scope",
+        "kind",
+        "citation"
+      ],
+      "type": "object"
+    },
+    "AggregationInputKind": {
+      "enum": [
+        "additive_amount",
+        "child_gross_amount",
+        "family_adjustment",
+        "family_amount",
+        "decimal_rate",
+        "care_fraction",
+        "eligibility_boolean"
+      ],
+      "type": "string"
+    },
+    "AggregationInputScope": {
+      "enum": [
+        "adult",
+        "child",
+        "family"
+      ],
+      "type": "string"
+    },
+    "AggregationMembershipRelation": {
+      "additionalProperties": false,
+      "properties": {
+        "citation": {
+          "$ref": "#/$defs/AggregationCitation"
+        },
+        "direction": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RelationDirection"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "left_role": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/MembershipRole"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "relation": {
+          "type": "string"
+        },
+        "right_role": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/MembershipRole"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "symmetric": {
+          "default": null,
+          "type": [
+            "boolean",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "relation",
+        "citation"
+      ],
+      "type": "object"
+    },
+    "AggregationPlan": {
+      "additionalProperties": false,
+      "properties": {
+        "adult_selection": {
+          "$ref": "#/$defs/AdultSelectionRule",
+          "default": {
+            "caller_determination": "",
+            "citation": {
+              "authority": "",
+              "provision": ""
+            },
+            "operation": "explicit_person_role"
+          }
+        },
+        "age_18_conditions": {
+          "$ref": "#/$defs/Age18Conditions",
+          "default": {
+            "age": 18,
+            "attending_school_or_tertiary_input": "",
+            "citation": {
+              "authority": "",
+              "provision": ""
+            },
+            "commissioner_period_input": "",
+            "not_financially_independent_input": ""
+          }
+        },
+        "broadcasts": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/ChildBroadcast"
+          },
+          "type": "array"
+        },
+        "care": {
+          "$ref": "#/$defs/CareSemantics",
+          "default": {
+            "citation": {
+              "authority": "",
+              "provision": ""
+            },
+            "claimant_care_fraction_input": "",
+            "principal_care_input": ""
+          }
+        },
+        "child_agreements": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/ChildAgreement"
+          },
+          "type": "array"
+        },
+        "child_counts": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/ChildCount"
+          },
+          "type": "array"
+        },
+        "child_minima": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/ChildMinimum"
+          },
+          "type": "array"
+        },
+        "child_projections": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/ChildProjection"
+          },
+          "type": "array"
+        },
+        "child_relation": {
+          "type": "string"
+        },
+        "constitution": {
+          "$ref": "#/$defs/AggregationConstitution"
+        },
+        "decimal_precision": {
+          "format": "uint32",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "family_predicates": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/FamilyPredicate"
+          },
+          "type": "array"
+        },
+        "family_reductions": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/FamilyReduction"
+          },
+          "type": "array"
+        },
+        "family_shape_scalars": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/FamilyShapeScalar"
+          },
+          "type": "array"
+        },
+        "id": {
+          "type": "string"
+        },
+        "inputs": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/AggregationInput"
+          },
+          "type": "array"
+        },
+        "limitations": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/DeclaredLimitation"
+          },
+          "type": "array"
+        },
+        "membership_relations": {
+          "items": {
+            "$ref": "#/$defs/AggregationMembershipRelation"
+          },
+          "type": "array"
+        },
+        "partner_presence": {
+          "$ref": "#/$defs/PartnerPresenceRule",
+          "default": {
+            "caller_determination": "",
+            "citation": {
+              "authority": "",
+              "provision": ""
+            },
+            "entitlement_holder_input": ""
+          }
+        },
+        "partner_relation": {
+          "type": "string"
+        },
+        "scalar_aggregations": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/ScalarAggregation"
+          },
+          "type": "array"
+        },
+        "schema": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "schema",
+        "id",
+        "decimal_precision",
+        "constitution",
+        "membership_relations",
+        "partner_relation",
+        "child_relation"
+      ],
+      "type": "object"
+    },
+    "CareSemantics": {
+      "additionalProperties": false,
+      "properties": {
+        "citation": {
+          "$ref": "#/$defs/AggregationCitation"
+        },
+        "claimant_care_fraction_input": {
+          "type": "string"
+        },
+        "principal_care_input": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "principal_care_input",
+        "claimant_care_fraction_input",
+        "citation"
+      ],
+      "type": "object"
+    },
+    "ChildAgreement": {
+      "additionalProperties": false,
+      "properties": {
+        "citation": {
+          "$ref": "#/$defs/AggregationCitation"
+        },
+        "eligible_if": {
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "empty_value": {
+          "type": "string"
+        },
+        "input": {
+          "type": "string"
+        },
+        "output": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "output",
+        "input",
+        "empty_value",
+        "citation"
+      ],
+      "type": "object"
+    },
+    "ChildBroadcast": {
+      "additionalProperties": false,
+      "properties": {
+        "citation": {
+          "$ref": "#/$defs/AggregationCitation"
+        },
+        "family_input": {
+          "type": "string"
+        },
+        "output": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "output",
+        "family_input",
+        "citation"
+      ],
+      "type": "object"
+    },
+    "ChildCount": {
+      "additionalProperties": false,
+      "properties": {
+        "citation": {
+          "$ref": "#/$defs/AggregationCitation"
+        },
+        "maximum_age": {
+          "default": null,
+          "format": "int64",
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "minimum_age": {
+          "default": null,
+          "format": "int64",
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "output": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "output",
+        "citation"
+      ],
+      "type": "object"
+    },
+    "ChildMinimum": {
+      "additionalProperties": false,
+      "properties": {
+        "citation": {
+          "$ref": "#/$defs/AggregationCitation"
+        },
+        "empty_value": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "input": {
+          "type": "string"
+        },
+        "output": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "output",
+        "input",
+        "empty_value",
+        "citation"
+      ],
+      "type": "object"
+    },
+    "ChildProjection": {
+      "additionalProperties": false,
+      "properties": {
+        "citation": {
+          "$ref": "#/$defs/AggregationCitation"
+        },
+        "input": {
+          "type": "string"
+        },
+        "output": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "output",
+        "input",
+        "citation"
+      ],
+      "type": "object"
+    },
+    "ComparisonOpSpec": {
+      "enum": [
+        "lt",
+        "lte",
+        "gt",
+        "gte",
+        "eq",
+        "ne"
+      ],
+      "type": "string"
+    },
+    "CompiledInputCatalogEntry": {
+      "properties": {
+        "canonical_request_name": {
+          "type": "string"
+        },
+        "request_names": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "slot": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "slot",
+        "canonical_request_name",
+        "request_names"
+      ],
+      "type": "object"
+    },
+    "CompiledProgramArtifact": {
+      "properties": {
+        "artifact_format_version": {
+          "format": "uint32",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "engine_version": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/$defs/CompiledProgramMetadata"
+        },
+        "program": {
+          "$ref": "#/$defs/ProgramSpec"
+        }
+      },
+      "required": [
+        "artifact_format_version",
+        "program",
+        "metadata"
+      ],
+      "type": "object"
+    },
+    "CompiledProgramMetadata": {
+      "properties": {
+        "evaluation_order": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "fast_path": {
+          "$ref": "#/$defs/FastPathMetadata"
+        },
+        "input_catalog": {
+          "default": [],
+          "description": "Defaulted only so an artifact that predates the catalog can be read at\nall. Absence is filled from the embedded program in `from_json_source`;\na catalog that IS present is still checked against the program, so an\nexplicit `[]` remains a mismatch rather than a way to skip the check.",
+          "items": {
+            "$ref": "#/$defs/CompiledInputCatalogEntry"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "evaluation_order",
+        "fast_path"
+      ],
+      "type": "object"
+    },
+    "ContinuousFamilyReduction": {
+      "additionalProperties": false,
+      "properties": {
+        "family_income_input": {
+          "type": "string"
+        },
+        "output": {
+          "type": "string"
+        },
+        "rate_input": {
+          "type": "string"
+        },
+        "threshold_input": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "output",
+        "family_income_input",
+        "threshold_input",
+        "rate_input"
+      ],
+      "type": "object"
+    },
+    "DTypeSpec": {
+      "description": "Output data type. Canonical: judgment, bool, integer, decimal, text, date. Aliases (accepted, but not emitted): PascalCase forms and Money/money/Rate/rate for decimal.",
+      "enum": [
+        "judgment",
+        "Judgment",
+        "bool",
+        "Bool",
+        "Boolean",
+        "boolean",
+        "integer",
+        "Integer",
+        "decimal",
+        "Decimal",
+        "Money",
+        "money",
+        "Rate",
+        "rate",
+        "text",
+        "Text",
+        "date",
+        "Date"
+      ],
+      "type": "string"
+    },
+    "DeclaredLimitation": {
+      "additionalProperties": false,
+      "properties": {
+        "citation": {
+          "$ref": "#/$defs/AggregationCitation"
+        },
+        "id": {
+          "type": "string"
+        },
+        "statement": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "statement",
+        "citation"
+      ],
+      "type": "object"
+    },
+    "DerivedSpec": {
+      "oneOf": [
+        {
+          "properties": {
+            "expr": {
+              "$ref": "#/$defs/ScalarExprSpec"
+            },
+            "semantics": {
+              "const": "scalar",
+              "type": "string"
+            }
+          },
+          "required": [
+            "semantics",
+            "expr"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "expr": {
+              "$ref": "#/$defs/JudgmentExprSpec"
+            },
+            "semantics": {
+              "const": "judgment",
+              "type": "string"
+            }
+          },
+          "required": [
+            "semantics",
+            "expr"
+          ],
+          "type": "object"
+        }
+      ],
+      "properties": {
+        "corpus_citation_path": {
+          "description": "Corpus provision path of the rule's origin module\n(`module.source_verification.corpus_citation_path`), carried per rule\nso artifact consumers can join the rule to its legal source.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "dtype": {
+          "$ref": "#/$defs/DTypeSpec"
+        },
+        "entity": {
+          "type": "string"
+        },
+        "id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "name": {
+          "type": "string"
+        },
+        "period": {
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "rounding": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RoundingModeSpec"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Opt-in output-rounding mode. When present AND `unit` is a declared\ncurrency, the rule's output is rounded to the unit's `minor_units` under\nthis mode in every execution path. Absent means today's behavior (no\nrounding). Declaring it on a non-currency unit is a compile error."
+        },
+        "source": {
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "source_url": {
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "unit": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "versions": {
+          "items": {
+            "$ref": "#/$defs/DerivedVersionSpec"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "name",
+        "entity",
+        "dtype"
+      ],
+      "type": "object"
+    },
+    "DerivedVersionSpec": {
+      "oneOf": [
+        {
+          "properties": {
+            "expr": {
+              "$ref": "#/$defs/ScalarExprSpec"
+            },
+            "semantics": {
+              "const": "scalar",
+              "type": "string"
+            }
+          },
+          "required": [
+            "semantics",
+            "expr"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "expr": {
+              "$ref": "#/$defs/JudgmentExprSpec"
+            },
+            "semantics": {
+              "const": "judgment",
+              "type": "string"
+            }
+          },
+          "required": [
+            "semantics",
+            "expr"
+          ],
+          "type": "object"
+        }
+      ],
+      "properties": {
+        "effective_from": {
+          "format": "date",
+          "type": "string"
+        },
+        "effective_to": {
+          "format": "date",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "effective_from"
+      ],
+      "type": "object"
+    },
+    "EncodingProvenance": {
+      "additionalProperties": false,
+      "description": "Who and what produced the encoding: tool (`encoder`, for example\n`axiom-encode/0.2.645`), `model`, `run_id`, and human `reviewed_by`.\nAll fields optional; unknown subfields are rejected so typos do not\nsilently pass for provenance.",
+      "properties": {
+        "encoder": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "model": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "reviewed_by": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "run_id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "type": "object"
+    },
+    "FamilyPredicate": {
+      "additionalProperties": false,
+      "properties": {
+        "citation": {
+          "$ref": "#/$defs/AggregationCitation"
+        },
+        "operation": {
+          "$ref": "#/$defs/FamilyPredicateOperation"
+        },
+        "output": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "output",
+        "operation",
+        "citation"
+      ],
+      "type": "object"
+    },
+    "FamilyPredicateOperation": {
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "count": {
+              "type": "string"
+            },
+            "kind": {
+              "const": "count_at_least",
+              "type": "string"
+            },
+            "minimum": {
+              "format": "int64",
+              "type": "integer"
+            }
+          },
+          "required": [
+            "kind",
+            "count",
+            "minimum"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "kind": {
+              "const": "youngest_age_at_least",
+              "type": "string"
+            },
+            "minimum": {
+              "format": "int64",
+              "type": "integer"
+            },
+            "youngest": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "youngest",
+            "minimum"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "count": {
+              "type": "string"
+            },
+            "kind": {
+              "const": "sole_parent_with_children",
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "count"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "count": {
+              "type": "string"
+            },
+            "kind": {
+              "const": "sole_parent_youngest_age_at_least",
+              "type": "string"
+            },
+            "minimum": {
+              "format": "int64",
+              "type": "integer"
+            },
+            "youngest": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "count",
+            "youngest",
+            "minimum"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "FamilyReduction": {
+      "additionalProperties": false,
+      "properties": {
+        "care_fraction_input": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "child_gross_input": {
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "child_value": {
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "citation": {
+          "$ref": "#/$defs/AggregationCitation"
+        },
+        "continuous": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ContinuousFamilyReduction"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "family_adjustment_input": {
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "family_once_value": {
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "gross_output": {
+          "type": "string"
+        },
+        "maximum_age": {
+          "default": null,
+          "format": "int64",
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "minimum_age": {
+          "default": null,
+          "format": "int64",
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "operation": {
+          "$ref": "#/$defs/FamilyReductionOperation"
+        },
+        "output": {
+          "type": "string"
+        },
+        "reduction_key": {
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "output",
+        "gross_output",
+        "operation",
+        "citation"
+      ],
+      "type": "object"
+    },
+    "FamilyReductionOperation": {
+      "enum": [
+        "sum_children_then_subtract_family_once"
+      ],
+      "type": "string"
+    },
+    "FamilyShapeScalar": {
+      "additionalProperties": false,
+      "properties": {
+        "citation": {
+          "$ref": "#/$defs/AggregationCitation"
+        },
+        "operation": {
+          "$ref": "#/$defs/FamilyShapeScalarOperation"
+        },
+        "output": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "output",
+        "operation",
+        "citation"
+      ],
+      "type": "object"
+    },
+    "FamilyShapeScalarOperation": {
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "count": {
+              "type": "string"
+            },
+            "kind": {
+              "const": "eldest_care_units",
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "count"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "count": {
+              "type": "string"
+            },
+            "kind": {
+              "const": "subsequent_care_units",
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "count"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "absent": {
+              "type": "string"
+            },
+            "count": {
+              "type": "string"
+            },
+            "kind": {
+              "const": "fixed_if_children",
+              "type": "string"
+            },
+            "present": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "count",
+            "present",
+            "absent"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "FastPathMetadata": {
+      "properties": {
+        "blockers": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "compatible": {
+          "type": "boolean"
+        },
+        "strategy": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "strategy",
+        "compatible",
+        "blockers"
+      ],
+      "type": "object"
+    },
+    "IndexedParameterSpec": {
+      "properties": {
+        "corpus_citation_path": {
+          "description": "Corpus provision path of the rule's origin module\n(`module.source_verification.corpus_citation_path`), carried per rule\nso artifact consumers can join the parameter to its legal source.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "id": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "indexed_by": {
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "name": {
+          "type": "string"
+        },
+        "source": {
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "source_url": {
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "unit": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "versions": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/ParameterVersionSpec"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "JudgmentExprSpec": {
+      "oneOf": [
+        {
+          "properties": {
+            "kind": {
+              "const": "comparison",
+              "type": "string"
+            },
+            "left": {
+              "$ref": "#/$defs/ScalarExprSpec"
+            },
+            "op": {
+              "$ref": "#/$defs/ComparisonOpSpec"
+            },
+            "right": {
+              "$ref": "#/$defs/ScalarExprSpec"
+            }
+          },
+          "required": [
+            "kind",
+            "left",
+            "op",
+            "right"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "kind": {
+              "const": "derived",
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "name"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "current_slot": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "kind": {
+              "const": "relation_member",
+              "type": "string"
+            },
+            "related_slot": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "relation": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "relation",
+            "current_slot",
+            "related_slot"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "items": {
+              "items": {
+                "$ref": "#/$defs/JudgmentExprSpec"
+              },
+              "type": "array"
+            },
+            "kind": {
+              "const": "and",
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "items"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "items": {
+              "items": {
+                "$ref": "#/$defs/JudgmentExprSpec"
+              },
+              "type": "array"
+            },
+            "kind": {
+              "const": "or",
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "items"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "item": {
+              "$ref": "#/$defs/JudgmentExprSpec"
+            },
+            "kind": {
+              "const": "not",
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "item"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "Holds when exactly one item holds. First-class in the serialized\nsurface so artifacts and graph consumers see one n-input gate;\n`to_model` lowers it to the flat Or-of-And-of-Nots expansion the\nformula sugar produced before this variant existed, so evaluation,\nshort-circuit reads, missing-input faults, and trace text are\nunchanged. Outcomes and faults also match hand-written expansions\non every input; trace TEXT does not match those byte-for-byte,\nbecause hand-chained and/or nest as binary pairs while this\nlowering is flat n-ary. Expression-level, additive to the\nserialized surface — no artifact-format-version bump.",
+          "properties": {
+            "items": {
+              "items": {
+                "$ref": "#/$defs/JudgmentExprSpec"
+              },
+              "type": "array"
+            },
+            "kind": {
+              "const": "exactly_one",
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "items"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "MembershipRole": {
+      "enum": [
+        "caregiver",
+        "child",
+        "partner"
+      ],
+      "type": "string"
+    },
+    "ModuleMetadata": {
+      "description": "Module-level metadata block of a RuleSpec document. Every field is\noptional; the whole block is descriptive and inert — it never affects\nlowering output names, compilation, or execution. The lowered\n[`ProgramSpec`] keeps the (merged) root module's metadata so tooling\nreading a loaded module or a compiled artifact can see it.",
+      "properties": {
+        "encoding_provenance": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/EncodingProvenance"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "kind": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "source_verification": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SourceVerification"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "status": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "summary": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "title": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "validation": {
+          "items": {
+            "$ref": "#/$defs/ValidationRecord"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "OverPeriodsKindSpec": {
+      "description": "The over-periods reduction vocabulary, mirroring\n[`crate::model::OverPeriodsKind`].",
+      "enum": [
+        "sum",
+        "max",
+        "count",
+        "sum_top_n"
+      ],
+      "type": "string"
+    },
+    "ParameterVersionSpec": {
+      "properties": {
+        "effective_from": {
+          "format": "date",
+          "type": "string"
+        },
+        "effective_to": {
+          "format": "date",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "values": {
+          "additionalProperties": false,
+          "patternProperties": {
+            "^-?\\d+$": {
+              "$ref": "#/$defs/ScalarValueSpec"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "required": [
+        "effective_from",
+        "values"
+      ],
+      "type": "object"
+    },
+    "PartnerPresenceRule": {
+      "additionalProperties": false,
+      "properties": {
+        "caller_determination": {
+          "type": "string"
+        },
+        "citation": {
+          "$ref": "#/$defs/AggregationCitation"
+        },
+        "entitlement_holder_input": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "entitlement_holder_input",
+        "citation",
+        "caller_determination"
+      ],
+      "type": "object"
+    },
+    "ProgramSpec": {
+      "properties": {
+        "derived": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/DerivedSpec"
+          },
+          "type": "array"
+        },
+        "module": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ModuleMetadata"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Module-level metadata (source pinning, encoding provenance,\nvalidation status) carried through RuleSpec lowering for tooling and\nartifact pass-through. Load/compile boundaries validate it; execution\nsemantics do not depend on it."
+        },
+        "parameters": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/IndexedParameterSpec"
+          },
+          "type": "array"
+        },
+        "relations": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/RelationSpec"
+          },
+          "type": "array"
+        },
+        "units": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/UnitSpec"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "RelatedValueRefSpec": {
+      "oneOf": [
+        {
+          "properties": {
+            "kind": {
+              "const": "input",
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "name"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "kind": {
+              "const": "derived",
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "name"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "RelationDerivationSpec": {
+      "properties": {
+        "current_slot": {
+          "format": "uint",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "entity": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "member_relation": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "predicate": {
+          "$ref": "#/$defs/JudgmentExprSpec"
+        },
+        "related_slot": {
+          "format": "uint",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "slot_entities": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "source_relation": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "source_relation",
+        "current_slot",
+        "related_slot",
+        "predicate"
+      ],
+      "type": "object"
+    },
+    "RelationDirection": {
+      "enum": [
+        "directed",
+        "symmetric"
+      ],
+      "type": "string"
+    },
+    "RelationSpec": {
+      "properties": {
+        "arity": {
+          "format": "uint",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "derivation": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RelationDerivationSpec"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "name": {
+          "type": "string"
+        },
+        "slot_entities": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "name",
+        "arity"
+      ],
+      "type": "object"
+    },
+    "RoundingModeSpec": {
+      "description": "The RuleSpec `rounding:` vocabulary, mirroring [`crate::model::RoundingMode`].",
+      "enum": [
+        "half_up",
+        "half_even",
+        "floor",
+        "ceil"
+      ],
+      "type": "string"
+    },
+    "ScalarAggregation": {
+      "additionalProperties": false,
+      "properties": {
+        "citation": {
+          "$ref": "#/$defs/AggregationCitation"
+        },
+        "input": {
+          "type": "string"
+        },
+        "output": {
+          "type": "string"
+        },
+        "selector": {
+          "$ref": "#/$defs/AggregateSelector"
+        }
+      },
+      "required": [
+        "output",
+        "input",
+        "selector",
+        "citation"
+      ],
+      "type": "object"
+    },
+    "ScalarExprSpec": {
+      "oneOf": [
+        {
+          "properties": {
+            "kind": {
+              "const": "literal",
+              "type": "string"
+            },
+            "value": {
+              "$ref": "#/$defs/ScalarValueSpec"
+            }
+          },
+          "required": [
+            "kind",
+            "value"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "kind": {
+              "const": "input",
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "name"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "default": {
+              "$ref": "#/$defs/ScalarValueSpec"
+            },
+            "kind": {
+              "const": "input_or_else",
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "name",
+            "default"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "kind": {
+              "const": "derived",
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "name"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "index": {
+              "$ref": "#/$defs/ScalarExprSpec"
+            },
+            "kind": {
+              "const": "parameter_lookup",
+              "type": "string"
+            },
+            "parameter": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "parameter",
+            "index"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "items": {
+              "items": {
+                "$ref": "#/$defs/ScalarExprSpec"
+              },
+              "type": "array"
+            },
+            "kind": {
+              "const": "add",
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "items"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "kind": {
+              "const": "sub",
+              "type": "string"
+            },
+            "left": {
+              "$ref": "#/$defs/ScalarExprSpec"
+            },
+            "right": {
+              "$ref": "#/$defs/ScalarExprSpec"
+            }
+          },
+          "required": [
+            "kind",
+            "left",
+            "right"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "kind": {
+              "const": "mul",
+              "type": "string"
+            },
+            "left": {
+              "$ref": "#/$defs/ScalarExprSpec"
+            },
+            "right": {
+              "$ref": "#/$defs/ScalarExprSpec"
+            }
+          },
+          "required": [
+            "kind",
+            "left",
+            "right"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "kind": {
+              "const": "div",
+              "type": "string"
+            },
+            "left": {
+              "$ref": "#/$defs/ScalarExprSpec"
+            },
+            "right": {
+              "$ref": "#/$defs/ScalarExprSpec"
+            }
+          },
+          "required": [
+            "kind",
+            "left",
+            "right"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "items": {
+              "items": {
+                "$ref": "#/$defs/ScalarExprSpec"
+              },
+              "type": "array"
+            },
+            "kind": {
+              "const": "max",
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "items"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "items": {
+              "items": {
+                "$ref": "#/$defs/ScalarExprSpec"
+              },
+              "type": "array"
+            },
+            "kind": {
+              "const": "min",
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "items"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "kind": {
+              "const": "ceil",
+              "type": "string"
+            },
+            "value": {
+              "$ref": "#/$defs/ScalarExprSpec"
+            }
+          },
+          "required": [
+            "kind",
+            "value"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "kind": {
+              "const": "floor",
+              "type": "string"
+            },
+            "value": {
+              "$ref": "#/$defs/ScalarExprSpec"
+            }
+          },
+          "required": [
+            "kind",
+            "value"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "kind": {
+              "const": "period_start",
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "kind": {
+              "const": "period_end",
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "date": {
+              "$ref": "#/$defs/ScalarExprSpec"
+            },
+            "days": {
+              "$ref": "#/$defs/ScalarExprSpec"
+            },
+            "kind": {
+              "const": "date_add_days",
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "date",
+            "days"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "from": {
+              "$ref": "#/$defs/ScalarExprSpec"
+            },
+            "kind": {
+              "const": "days_between",
+              "type": "string"
+            },
+            "to": {
+              "$ref": "#/$defs/ScalarExprSpec"
+            }
+          },
+          "required": [
+            "kind",
+            "from",
+            "to"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "current_slot": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "kind": {
+              "const": "count_related",
+              "type": "string"
+            },
+            "related_slot": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "relation": {
+              "type": "string"
+            },
+            "where": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/JudgmentExprSpec"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null
+            }
+          },
+          "required": [
+            "kind",
+            "relation",
+            "current_slot",
+            "related_slot"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "current_slot": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "kind": {
+              "const": "sum_related",
+              "type": "string"
+            },
+            "related_slot": {
+              "format": "uint",
+              "minimum": 0,
+              "type": "integer"
+            },
+            "relation": {
+              "type": "string"
+            },
+            "value": {
+              "$ref": "#/$defs/RelatedValueRefSpec"
+            },
+            "where": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/JudgmentExprSpec"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "default": null
+            }
+          },
+          "required": [
+            "kind",
+            "relation",
+            "current_slot",
+            "related_slot",
+            "value"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "condition": {
+              "$ref": "#/$defs/JudgmentExprSpec"
+            },
+            "else_expr": {
+              "$ref": "#/$defs/ScalarExprSpec"
+            },
+            "kind": {
+              "const": "if",
+              "type": "string"
+            },
+            "then_expr": {
+              "$ref": "#/$defs/ScalarExprSpec"
+            }
+          },
+          "required": [
+            "kind",
+            "condition",
+            "then_expr",
+            "else_expr"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "Reduction over an entity's own period axis (lifetime execution only).\n`n` is present only for the `sum_top_n` reduction. Expression-level,\nadditive to the serialized surface — no artifact-format-version bump.",
+          "properties": {
+            "kind": {
+              "const": "over_periods",
+              "type": "string"
+            },
+            "n": {
+              "anyOf": [
+                {
+                  "$ref": "#/$defs/ScalarExprSpec"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "over": {
+              "$ref": "#/$defs/OverPeriodsKindSpec"
+            },
+            "value": {
+              "$ref": "#/$defs/ScalarExprSpec"
+            }
+          },
+          "required": [
+            "kind",
+            "over",
+            "value"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "ScalarValueSpec": {
+      "oneOf": [
+        {
+          "properties": {
+            "kind": {
+              "const": "bool",
+              "type": "string"
+            },
+            "value": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "kind",
+            "value"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "kind": {
+              "const": "integer",
+              "type": "string"
+            },
+            "value": {
+              "format": "int64",
+              "type": "integer"
+            }
+          },
+          "required": [
+            "kind",
+            "value"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "kind": {
+              "const": "decimal",
+              "type": "string"
+            },
+            "value": {
+              "description": "Decimal value as a quoted string (arbitrary precision) or a JSON integer; floats are rejected.",
+              "type": [
+                "string",
+                "integer"
+              ]
+            }
+          },
+          "required": [
+            "kind",
+            "value"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "kind": {
+              "const": "text",
+              "type": "string"
+            },
+            "value": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "value"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "kind": {
+              "const": "date",
+              "type": "string"
+            },
+            "value": {
+              "format": "date",
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "value"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "SourceVerification": {
+      "additionalProperties": false,
+      "description": "Grounding of a module in legal source text. `corpus_citation_path`\naddresses the provision in the Axiom corpus; `source_sha256` pins the\nSHA-256 hex digest of the exact provision text the module was encoded\nfrom, so tooling can detect mechanically when the published source has\nchanged out from under the encoding. `upstream_source_check` records the\nhigher-authority sources checked before using guidance or another\nimplementation source. The mapping is exact: the singular citation path\nis required and unknown/plural fields are rejected.",
+      "properties": {
+        "corpus_citation_path": {
+          "type": "string"
+        },
+        "source_sha256": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "upstream_source_check": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/UpstreamSourceCheck"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      },
+      "required": [
+        "corpus_citation_path"
+      ],
+      "type": "object"
+    },
+    "UnitSpec": {
+      "oneOf": [
+        {
+          "properties": {
+            "kind": {
+              "const": "currency",
+              "type": "string"
+            },
+            "minor_units": {
+              "format": "uint8",
+              "maximum": 255,
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          "required": [
+            "kind",
+            "minor_units"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "kind": {
+              "const": "count",
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "kind": {
+              "const": "ratio",
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "kind": {
+              "const": "duration",
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "kind": {
+              "const": "custom",
+              "type": "string"
+            },
+            "label": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "label"
+          ],
+          "type": "object"
+        }
+      ],
+      "properties": {
+        "name": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "type": "object"
+    },
+    "UpstreamSourceCheck": {
+      "additionalProperties": false,
+      "description": "Structural record of a higher-authority source audit. The encoder owns\nsemantic policy for accepted statuses, path authority, and rationale\nquality; the engine preserves the exact typed record in compiled artifacts.",
+      "properties": {
+        "checked_paths": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "rationale": {
+          "type": "string"
+        },
+        "status": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "status",
+        "checked_paths",
+        "rationale"
+      ],
+      "type": "object"
+    },
+    "ValidationRecord": {
+      "description": "One oracle-validation result for the module: which oracle, whether the\nencoding currently matches it, and when it last ran.",
+      "properties": {
+        "last_run": {
+          "format": "date",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "oracle": {
+          "type": "string"
+        },
+        "status": {
+          "$ref": "#/$defs/ValidationStatus"
+        }
+      },
+      "required": [
+        "oracle",
+        "status"
+      ],
+      "type": "object"
+    },
+    "ValidationStatus": {
+      "description": "Outcome of an oracle validation run. Any other status string is\nrejected at parse time.",
+      "enum": [
+        "matches",
+        "mismatches",
+        "pending"
+      ],
+      "type": "string"
+    }
+  },
+  "$id": "https://schemas.axiom-foundation.org/rules-engine/compiled-unit-aggregation.stage3.schema.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "additionalProperties": false,
+  "description": "Feature-gated, canonically digested aggregation plan with an embedded production-validated phase-two artifact.",
+  "properties": {
+    "constitution_digest": {
+      "type": "string"
+    },
+    "format": {
+      "const": "axiom/compiled-unit-aggregation-stage3/1",
+      "type": "string"
+    },
+    "phase_two_artifact": {
+      "$ref": "#/$defs/CompiledProgramArtifact"
+    },
+    "plan": {
+      "$ref": "#/$defs/AggregationPlan"
+    },
+    "plan_digest": {
+      "type": "string"
+    },
+    "semantics_version": {
+      "const": "unit-derivation-stage2/1",
+      "type": "string"
+    }
+  },
+  "required": [
+    "format",
+    "semantics_version",
+    "plan_digest",
+    "constitution_digest",
+    "plan",
+    "phase_two_artifact"
+  ],
+  "title": "Compiled experimental unit aggregation artifact",
+  "type": "object"
+}

--- a/schemas/experimental-unit-aggregation-plan.stage3.schema.json
+++ b/schemas/experimental-unit-aggregation-plan.stage3.schema.json
@@ -1,0 +1,927 @@
+{
+  "$defs": {
+    "AdultSelectionOperation": {
+      "enum": [
+        "explicit_person_role"
+      ],
+      "type": "string"
+    },
+    "AdultSelectionRule": {
+      "additionalProperties": false,
+      "properties": {
+        "caller_determination": {
+          "type": "string"
+        },
+        "citation": {
+          "$ref": "#/$defs/AggregationCitation"
+        },
+        "operation": {
+          "$ref": "#/$defs/AdultSelectionOperation"
+        }
+      },
+      "required": [
+        "operation",
+        "citation",
+        "caller_determination"
+      ],
+      "type": "object"
+    },
+    "Age18Conditions": {
+      "additionalProperties": false,
+      "properties": {
+        "age": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "attending_school_or_tertiary_input": {
+          "type": "string"
+        },
+        "citation": {
+          "$ref": "#/$defs/AggregationCitation"
+        },
+        "commissioner_period_input": {
+          "type": "string"
+        },
+        "not_financially_independent_input": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "age",
+        "not_financially_independent_input",
+        "attending_school_or_tertiary_input",
+        "commissioner_period_input",
+        "citation"
+      ],
+      "type": "object"
+    },
+    "AggregateSelector": {
+      "enum": [
+        "adults",
+        "all_members"
+      ],
+      "type": "string"
+    },
+    "AggregationCitation": {
+      "additionalProperties": false,
+      "properties": {
+        "authority": {
+          "type": "string"
+        },
+        "provision": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "provision",
+        "authority"
+      ],
+      "type": "object"
+    },
+    "AggregationConstitution": {
+      "additionalProperties": false,
+      "properties": {
+        "entity_type": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "participating_member_relation": {
+          "type": "string"
+        },
+        "roster_relation": {
+          "type": "string"
+        },
+        "unit_constituent_relation": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "entity_type",
+        "roster_relation",
+        "unit_constituent_relation",
+        "participating_member_relation"
+      ],
+      "type": "object"
+    },
+    "AggregationInput": {
+      "additionalProperties": false,
+      "properties": {
+        "citation": {
+          "$ref": "#/$defs/AggregationCitation"
+        },
+        "kind": {
+          "$ref": "#/$defs/AggregationInputKind"
+        },
+        "name": {
+          "type": "string"
+        },
+        "reduction_key": {
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "scope": {
+          "$ref": "#/$defs/AggregationInputScope"
+        }
+      },
+      "required": [
+        "name",
+        "scope",
+        "kind",
+        "citation"
+      ],
+      "type": "object"
+    },
+    "AggregationInputKind": {
+      "enum": [
+        "additive_amount",
+        "child_gross_amount",
+        "family_adjustment",
+        "family_amount",
+        "decimal_rate",
+        "care_fraction",
+        "eligibility_boolean"
+      ],
+      "type": "string"
+    },
+    "AggregationInputScope": {
+      "enum": [
+        "adult",
+        "child",
+        "family"
+      ],
+      "type": "string"
+    },
+    "AggregationMembershipRelation": {
+      "additionalProperties": false,
+      "properties": {
+        "citation": {
+          "$ref": "#/$defs/AggregationCitation"
+        },
+        "direction": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RelationDirection"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "left_role": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/MembershipRole"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "relation": {
+          "type": "string"
+        },
+        "right_role": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/MembershipRole"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "symmetric": {
+          "default": null,
+          "type": [
+            "boolean",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "relation",
+        "citation"
+      ],
+      "type": "object"
+    },
+    "CareSemantics": {
+      "additionalProperties": false,
+      "properties": {
+        "citation": {
+          "$ref": "#/$defs/AggregationCitation"
+        },
+        "claimant_care_fraction_input": {
+          "type": "string"
+        },
+        "principal_care_input": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "principal_care_input",
+        "claimant_care_fraction_input",
+        "citation"
+      ],
+      "type": "object"
+    },
+    "ChildAgreement": {
+      "additionalProperties": false,
+      "properties": {
+        "citation": {
+          "$ref": "#/$defs/AggregationCitation"
+        },
+        "eligible_if": {
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "empty_value": {
+          "type": "string"
+        },
+        "input": {
+          "type": "string"
+        },
+        "output": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "output",
+        "input",
+        "empty_value",
+        "citation"
+      ],
+      "type": "object"
+    },
+    "ChildBroadcast": {
+      "additionalProperties": false,
+      "properties": {
+        "citation": {
+          "$ref": "#/$defs/AggregationCitation"
+        },
+        "family_input": {
+          "type": "string"
+        },
+        "output": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "output",
+        "family_input",
+        "citation"
+      ],
+      "type": "object"
+    },
+    "ChildCount": {
+      "additionalProperties": false,
+      "properties": {
+        "citation": {
+          "$ref": "#/$defs/AggregationCitation"
+        },
+        "maximum_age": {
+          "default": null,
+          "format": "int64",
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "minimum_age": {
+          "default": null,
+          "format": "int64",
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "output": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "output",
+        "citation"
+      ],
+      "type": "object"
+    },
+    "ChildMinimum": {
+      "additionalProperties": false,
+      "properties": {
+        "citation": {
+          "$ref": "#/$defs/AggregationCitation"
+        },
+        "empty_value": {
+          "format": "int64",
+          "type": "integer"
+        },
+        "input": {
+          "type": "string"
+        },
+        "output": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "output",
+        "input",
+        "empty_value",
+        "citation"
+      ],
+      "type": "object"
+    },
+    "ChildProjection": {
+      "additionalProperties": false,
+      "properties": {
+        "citation": {
+          "$ref": "#/$defs/AggregationCitation"
+        },
+        "input": {
+          "type": "string"
+        },
+        "output": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "output",
+        "input",
+        "citation"
+      ],
+      "type": "object"
+    },
+    "ContinuousFamilyReduction": {
+      "additionalProperties": false,
+      "properties": {
+        "family_income_input": {
+          "type": "string"
+        },
+        "output": {
+          "type": "string"
+        },
+        "rate_input": {
+          "type": "string"
+        },
+        "threshold_input": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "output",
+        "family_income_input",
+        "threshold_input",
+        "rate_input"
+      ],
+      "type": "object"
+    },
+    "DeclaredLimitation": {
+      "additionalProperties": false,
+      "properties": {
+        "citation": {
+          "$ref": "#/$defs/AggregationCitation"
+        },
+        "id": {
+          "type": "string"
+        },
+        "statement": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "statement",
+        "citation"
+      ],
+      "type": "object"
+    },
+    "FamilyPredicate": {
+      "additionalProperties": false,
+      "properties": {
+        "citation": {
+          "$ref": "#/$defs/AggregationCitation"
+        },
+        "operation": {
+          "$ref": "#/$defs/FamilyPredicateOperation"
+        },
+        "output": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "output",
+        "operation",
+        "citation"
+      ],
+      "type": "object"
+    },
+    "FamilyPredicateOperation": {
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "count": {
+              "type": "string"
+            },
+            "kind": {
+              "const": "count_at_least",
+              "type": "string"
+            },
+            "minimum": {
+              "format": "int64",
+              "type": "integer"
+            }
+          },
+          "required": [
+            "kind",
+            "count",
+            "minimum"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "kind": {
+              "const": "youngest_age_at_least",
+              "type": "string"
+            },
+            "minimum": {
+              "format": "int64",
+              "type": "integer"
+            },
+            "youngest": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "youngest",
+            "minimum"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "count": {
+              "type": "string"
+            },
+            "kind": {
+              "const": "sole_parent_with_children",
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "count"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "count": {
+              "type": "string"
+            },
+            "kind": {
+              "const": "sole_parent_youngest_age_at_least",
+              "type": "string"
+            },
+            "minimum": {
+              "format": "int64",
+              "type": "integer"
+            },
+            "youngest": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "count",
+            "youngest",
+            "minimum"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "FamilyReduction": {
+      "additionalProperties": false,
+      "properties": {
+        "care_fraction_input": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "child_gross_input": {
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "child_value": {
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "citation": {
+          "$ref": "#/$defs/AggregationCitation"
+        },
+        "continuous": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ContinuousFamilyReduction"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "family_adjustment_input": {
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "family_once_value": {
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "gross_output": {
+          "type": "string"
+        },
+        "maximum_age": {
+          "default": null,
+          "format": "int64",
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "minimum_age": {
+          "default": null,
+          "format": "int64",
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "operation": {
+          "$ref": "#/$defs/FamilyReductionOperation"
+        },
+        "output": {
+          "type": "string"
+        },
+        "reduction_key": {
+          "default": null,
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "output",
+        "gross_output",
+        "operation",
+        "citation"
+      ],
+      "type": "object"
+    },
+    "FamilyReductionOperation": {
+      "enum": [
+        "sum_children_then_subtract_family_once"
+      ],
+      "type": "string"
+    },
+    "FamilyShapeScalar": {
+      "additionalProperties": false,
+      "properties": {
+        "citation": {
+          "$ref": "#/$defs/AggregationCitation"
+        },
+        "operation": {
+          "$ref": "#/$defs/FamilyShapeScalarOperation"
+        },
+        "output": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "output",
+        "operation",
+        "citation"
+      ],
+      "type": "object"
+    },
+    "FamilyShapeScalarOperation": {
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "count": {
+              "type": "string"
+            },
+            "kind": {
+              "const": "eldest_care_units",
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "count"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "count": {
+              "type": "string"
+            },
+            "kind": {
+              "const": "subsequent_care_units",
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "count"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "absent": {
+              "type": "string"
+            },
+            "count": {
+              "type": "string"
+            },
+            "kind": {
+              "const": "fixed_if_children",
+              "type": "string"
+            },
+            "present": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "count",
+            "present",
+            "absent"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "MembershipRole": {
+      "enum": [
+        "caregiver",
+        "child",
+        "partner"
+      ],
+      "type": "string"
+    },
+    "PartnerPresenceRule": {
+      "additionalProperties": false,
+      "properties": {
+        "caller_determination": {
+          "type": "string"
+        },
+        "citation": {
+          "$ref": "#/$defs/AggregationCitation"
+        },
+        "entitlement_holder_input": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "entitlement_holder_input",
+        "citation",
+        "caller_determination"
+      ],
+      "type": "object"
+    },
+    "RelationDirection": {
+      "enum": [
+        "directed",
+        "symmetric"
+      ],
+      "type": "string"
+    },
+    "ScalarAggregation": {
+      "additionalProperties": false,
+      "properties": {
+        "citation": {
+          "$ref": "#/$defs/AggregationCitation"
+        },
+        "input": {
+          "type": "string"
+        },
+        "output": {
+          "type": "string"
+        },
+        "selector": {
+          "$ref": "#/$defs/AggregateSelector"
+        }
+      },
+      "required": [
+        "output",
+        "input",
+        "selector",
+        "citation"
+      ],
+      "type": "object"
+    }
+  },
+  "$id": "https://schemas.axiom-foundation.org/rules-engine/experimental-unit-aggregation-plan.stage3.schema.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "additionalProperties": false,
+  "description": "Feature-gated authoring document compiled into a canonically digested unit aggregation artifact.",
+  "properties": {
+    "adult_selection": {
+      "$ref": "#/$defs/AdultSelectionRule",
+      "default": {
+        "caller_determination": "",
+        "citation": {
+          "authority": "",
+          "provision": ""
+        },
+        "operation": "explicit_person_role"
+      }
+    },
+    "age_18_conditions": {
+      "$ref": "#/$defs/Age18Conditions",
+      "default": {
+        "age": 18,
+        "attending_school_or_tertiary_input": "",
+        "citation": {
+          "authority": "",
+          "provision": ""
+        },
+        "commissioner_period_input": "",
+        "not_financially_independent_input": ""
+      }
+    },
+    "broadcasts": {
+      "default": [],
+      "items": {
+        "$ref": "#/$defs/ChildBroadcast"
+      },
+      "type": "array"
+    },
+    "care": {
+      "$ref": "#/$defs/CareSemantics",
+      "default": {
+        "citation": {
+          "authority": "",
+          "provision": ""
+        },
+        "claimant_care_fraction_input": "",
+        "principal_care_input": ""
+      }
+    },
+    "child_agreements": {
+      "default": [],
+      "items": {
+        "$ref": "#/$defs/ChildAgreement"
+      },
+      "type": "array"
+    },
+    "child_counts": {
+      "default": [],
+      "items": {
+        "$ref": "#/$defs/ChildCount"
+      },
+      "type": "array"
+    },
+    "child_minima": {
+      "default": [],
+      "items": {
+        "$ref": "#/$defs/ChildMinimum"
+      },
+      "type": "array"
+    },
+    "child_projections": {
+      "default": [],
+      "items": {
+        "$ref": "#/$defs/ChildProjection"
+      },
+      "type": "array"
+    },
+    "child_relation": {
+      "type": "string"
+    },
+    "constitution": {
+      "$ref": "#/$defs/AggregationConstitution"
+    },
+    "decimal_precision": {
+      "format": "uint32",
+      "minimum": 0,
+      "type": "integer"
+    },
+    "family_predicates": {
+      "default": [],
+      "items": {
+        "$ref": "#/$defs/FamilyPredicate"
+      },
+      "type": "array"
+    },
+    "family_reductions": {
+      "default": [],
+      "items": {
+        "$ref": "#/$defs/FamilyReduction"
+      },
+      "type": "array"
+    },
+    "family_shape_scalars": {
+      "default": [],
+      "items": {
+        "$ref": "#/$defs/FamilyShapeScalar"
+      },
+      "type": "array"
+    },
+    "id": {
+      "type": "string"
+    },
+    "inputs": {
+      "default": [],
+      "items": {
+        "$ref": "#/$defs/AggregationInput"
+      },
+      "type": "array"
+    },
+    "limitations": {
+      "default": [],
+      "items": {
+        "$ref": "#/$defs/DeclaredLimitation"
+      },
+      "type": "array"
+    },
+    "membership_relations": {
+      "items": {
+        "$ref": "#/$defs/AggregationMembershipRelation"
+      },
+      "type": "array"
+    },
+    "partner_presence": {
+      "$ref": "#/$defs/PartnerPresenceRule",
+      "default": {
+        "caller_determination": "",
+        "citation": {
+          "authority": "",
+          "provision": ""
+        },
+        "entitlement_holder_input": ""
+      }
+    },
+    "partner_relation": {
+      "type": "string"
+    },
+    "scalar_aggregations": {
+      "default": [],
+      "items": {
+        "$ref": "#/$defs/ScalarAggregation"
+      },
+      "type": "array"
+    },
+    "schema": {
+      "const": "axiom/unit-aggregation-plan-stage3/1",
+      "type": "string"
+    }
+  },
+  "required": [
+    "schema",
+    "id",
+    "decimal_precision",
+    "constitution",
+    "membership_relations",
+    "partner_relation",
+    "child_relation"
+  ],
+  "title": "Experimental unit aggregation plan",
+  "type": "object"
+}

--- a/schemas/experimental-unit-aggregation-plan.stage3.schema.json
+++ b/schemas/experimental-unit-aggregation-plan.stage3.schema.json
@@ -112,6 +112,16 @@
         "citation": {
           "$ref": "#/$defs/AggregationCitation"
         },
+        "engine_computation": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/EngineComputationBinding"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "kind": {
           "$ref": "#/$defs/AggregationInputKind"
         },
@@ -402,6 +412,18 @@
         "id",
         "statement",
         "citation"
+      ],
+      "type": "object"
+    },
+    "EngineComputationBinding": {
+      "additionalProperties": false,
+      "properties": {
+        "rule_id": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "rule_id"
       ],
       "type": "object"
     },
@@ -714,12 +736,12 @@
         "citation": {
           "$ref": "#/$defs/AggregationCitation"
         },
-        "entitlement_holder_input": {
+        "reference_person_input": {
           "type": "string"
         }
       },
       "required": [
-        "entitlement_holder_input",
+        "reference_person_input",
         "citation",
         "caller_determination"
       ],
@@ -895,7 +917,7 @@
           "authority": "",
           "provision": ""
         },
-        "entitlement_holder_input": ""
+        "reference_person_input": ""
       }
     },
     "partner_relation": {

--- a/schemas/unit-aggregation-request.stage3.schema.json
+++ b/schemas/unit-aggregation-request.stage3.schema.json
@@ -1,0 +1,507 @@
+{
+  "$defs": {
+    "AggregationEvidence": {
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "id"
+      ],
+      "type": "object"
+    },
+    "AggregationFamilyInput": {
+      "additionalProperties": false,
+      "properties": {
+        "anchor_person": {
+          "type": "string"
+        },
+        "evidence": {
+          "$ref": "#/$defs/AggregationEvidence"
+        },
+        "named_people": {
+          "additionalProperties": {
+            "$ref": "#/$defs/AggregationKnowledge2"
+          },
+          "default": {},
+          "type": "object"
+        },
+        "scalars": {
+          "additionalProperties": {
+            "$ref": "#/$defs/AggregationKnowledge2"
+          },
+          "default": {},
+          "type": "object"
+        }
+      },
+      "required": [
+        "anchor_person",
+        "evidence"
+      ],
+      "type": "object"
+    },
+    "AggregationKnowledge": {
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "evidence": {
+              "$ref": "#/$defs/AggregationEvidence"
+            },
+            "status": {
+              "const": "known",
+              "type": "string"
+            },
+            "value": {
+              "format": "int64",
+              "type": "integer"
+            }
+          },
+          "required": [
+            "status",
+            "value",
+            "evidence"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "evidence": {
+              "$ref": "#/$defs/AggregationEvidence"
+            },
+            "status": {
+              "const": "unknown",
+              "type": "string"
+            }
+          },
+          "required": [
+            "status",
+            "evidence"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "observations": {
+              "items": {
+                "$ref": "#/$defs/AggregationObservation"
+              },
+              "type": "array"
+            },
+            "status": {
+              "const": "observations",
+              "type": "string"
+            }
+          },
+          "required": [
+            "status",
+            "observations"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "observations": {
+              "items": {
+                "$ref": "#/$defs/AggregationObservation"
+              },
+              "type": "array"
+            },
+            "status": {
+              "const": "conflict",
+              "type": "string"
+            }
+          },
+          "required": [
+            "status",
+            "observations"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "AggregationKnowledge2": {
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "evidence": {
+              "$ref": "#/$defs/AggregationEvidence"
+            },
+            "status": {
+              "const": "known",
+              "type": "string"
+            },
+            "value": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "status",
+            "value",
+            "evidence"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "evidence": {
+              "$ref": "#/$defs/AggregationEvidence"
+            },
+            "status": {
+              "const": "unknown",
+              "type": "string"
+            }
+          },
+          "required": [
+            "status",
+            "evidence"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "observations": {
+              "items": {
+                "$ref": "#/$defs/AggregationObservation2"
+              },
+              "type": "array"
+            },
+            "status": {
+              "const": "observations",
+              "type": "string"
+            }
+          },
+          "required": [
+            "status",
+            "observations"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "observations": {
+              "items": {
+                "$ref": "#/$defs/AggregationObservation2"
+              },
+              "type": "array"
+            },
+            "status": {
+              "const": "conflict",
+              "type": "string"
+            }
+          },
+          "required": [
+            "status",
+            "observations"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "AggregationKnowledge3": {
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "evidence": {
+              "$ref": "#/$defs/AggregationEvidence"
+            },
+            "status": {
+              "const": "known",
+              "type": "string"
+            },
+            "value": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "status",
+            "value",
+            "evidence"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "evidence": {
+              "$ref": "#/$defs/AggregationEvidence"
+            },
+            "status": {
+              "const": "unknown",
+              "type": "string"
+            }
+          },
+          "required": [
+            "status",
+            "evidence"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "observations": {
+              "items": {
+                "$ref": "#/$defs/AggregationObservation3"
+              },
+              "type": "array"
+            },
+            "status": {
+              "const": "observations",
+              "type": "string"
+            }
+          },
+          "required": [
+            "status",
+            "observations"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "observations": {
+              "items": {
+                "$ref": "#/$defs/AggregationObservation3"
+              },
+              "type": "array"
+            },
+            "status": {
+              "const": "conflict",
+              "type": "string"
+            }
+          },
+          "required": [
+            "status",
+            "observations"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "AggregationObservation": {
+      "additionalProperties": false,
+      "properties": {
+        "evidence": {
+          "$ref": "#/$defs/AggregationEvidence"
+        },
+        "value": {
+          "format": "int64",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "value",
+        "evidence"
+      ],
+      "type": "object"
+    },
+    "AggregationObservation2": {
+      "additionalProperties": false,
+      "properties": {
+        "evidence": {
+          "$ref": "#/$defs/AggregationEvidence"
+        },
+        "value": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "value",
+        "evidence"
+      ],
+      "type": "object"
+    },
+    "AggregationObservation3": {
+      "additionalProperties": false,
+      "properties": {
+        "evidence": {
+          "$ref": "#/$defs/AggregationEvidence"
+        },
+        "value": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "value",
+        "evidence"
+      ],
+      "type": "object"
+    },
+    "AggregationPerson": {
+      "additionalProperties": false,
+      "properties": {
+        "age_years": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/AggregationKnowledge"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "evidence": {
+          "$ref": "#/$defs/AggregationEvidence"
+        },
+        "facts": {
+          "additionalProperties": {
+            "$ref": "#/$defs/AggregationKnowledge3"
+          },
+          "default": {},
+          "type": "object"
+        },
+        "id": {
+          "type": "string"
+        },
+        "role": {
+          "$ref": "#/$defs/AggregationPersonRole"
+        },
+        "scalars": {
+          "additionalProperties": {
+            "$ref": "#/$defs/AggregationKnowledge2"
+          },
+          "default": {},
+          "type": "object"
+        }
+      },
+      "required": [
+        "id",
+        "role",
+        "evidence"
+      ],
+      "type": "object"
+    },
+    "AggregationPersonRole": {
+      "enum": [
+        "adult",
+        "child"
+      ],
+      "type": "string"
+    },
+    "AggregationRelationFact": {
+      "additionalProperties": false,
+      "properties": {
+        "knowledge": {
+          "$ref": "#/$defs/AggregationKnowledge3"
+        },
+        "tuple": {
+          "items": {
+            "type": "string"
+          },
+          "maxItems": 2,
+          "minItems": 2,
+          "type": "array"
+        }
+      },
+      "required": [
+        "tuple",
+        "knowledge"
+      ],
+      "type": "object"
+    },
+    "AggregationRelationFamily": {
+      "additionalProperties": false,
+      "properties": {
+        "completeness": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/AggregationEvidence"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "facts": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/AggregationRelationFact"
+          },
+          "type": "array"
+        },
+        "name": {
+          "type": "string"
+        },
+        "scope": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "scope"
+      ],
+      "type": "object"
+    }
+  },
+  "$id": "https://schemas.axiom-foundation.org/rules-engine/unit-aggregation-request.stage3.schema.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "additionalProperties": false,
+  "description": "Evidence-bearing Knowledge-valued roster, relationship, person, child, and family inputs.",
+  "properties": {
+    "family_inputs": {
+      "default": [],
+      "items": {
+        "$ref": "#/$defs/AggregationFamilyInput"
+      },
+      "type": "array"
+    },
+    "persons": {
+      "items": {
+        "$ref": "#/$defs/AggregationPerson"
+      },
+      "type": "array"
+    },
+    "relations": {
+      "default": [],
+      "items": {
+        "$ref": "#/$defs/AggregationRelationFamily"
+      },
+      "type": "array"
+    },
+    "roster_completeness": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/AggregationEvidence"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "scope": {
+      "type": "string"
+    },
+    "segment": {
+      "type": "string"
+    },
+    "segment_completeness": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/AggregationEvidence"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    }
+  },
+  "required": [
+    "scope",
+    "segment",
+    "persons"
+  ],
+  "title": "Experimental unit aggregation request",
+  "type": "object"
+}

--- a/schemas/unit-aggregation-request.stage3.schema.json
+++ b/schemas/unit-aggregation-request.stage3.schema.json
@@ -352,6 +352,12 @@
           ],
           "default": null
         },
+        "engine_computations": {
+          "additionalProperties": {
+            "$ref": "#/$defs/EngineComputationRequest"
+          },
+          "type": "object"
+        },
         "evidence": {
           "$ref": "#/$defs/AggregationEvidence"
         },
@@ -443,6 +449,193 @@
         "scope"
       ],
       "type": "object"
+    },
+    "DatasetSpec": {
+      "properties": {
+        "inputs": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/InputRecordSpec"
+          },
+          "type": "array"
+        },
+        "relations": {
+          "default": [],
+          "items": {
+            "$ref": "#/$defs/RelationRecordSpec"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "EngineComputationRequest": {
+      "additionalProperties": false,
+      "properties": {
+        "dataset": {
+          "$ref": "#/$defs/DatasetSpec"
+        }
+      },
+      "required": [
+        "dataset"
+      ],
+      "type": "object"
+    },
+    "InputRecordSpec": {
+      "properties": {
+        "entity": {
+          "type": "string"
+        },
+        "entity_id": {
+          "type": "string"
+        },
+        "interval": {
+          "$ref": "#/$defs/IntervalSpec"
+        },
+        "name": {
+          "type": "string"
+        },
+        "value": {
+          "$ref": "#/$defs/ScalarValueSpec"
+        }
+      },
+      "required": [
+        "name",
+        "entity",
+        "entity_id",
+        "interval",
+        "value"
+      ],
+      "type": "object"
+    },
+    "IntervalSpec": {
+      "properties": {
+        "end": {
+          "format": "date",
+          "type": "string"
+        },
+        "start": {
+          "format": "date",
+          "type": "string"
+        }
+      },
+      "required": [
+        "start",
+        "end"
+      ],
+      "type": "object"
+    },
+    "RelationRecordSpec": {
+      "properties": {
+        "interval": {
+          "$ref": "#/$defs/IntervalSpec"
+        },
+        "name": {
+          "type": "string"
+        },
+        "tuple": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "required": [
+        "name",
+        "tuple",
+        "interval"
+      ],
+      "type": "object"
+    },
+    "ScalarValueSpec": {
+      "oneOf": [
+        {
+          "properties": {
+            "kind": {
+              "const": "bool",
+              "type": "string"
+            },
+            "value": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "kind",
+            "value"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "kind": {
+              "const": "integer",
+              "type": "string"
+            },
+            "value": {
+              "format": "int64",
+              "type": "integer"
+            }
+          },
+          "required": [
+            "kind",
+            "value"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "kind": {
+              "const": "decimal",
+              "type": "string"
+            },
+            "value": {
+              "description": "Decimal value as a quoted string (arbitrary precision) or a JSON integer; floats are rejected.",
+              "type": [
+                "string",
+                "integer"
+              ]
+            }
+          },
+          "required": [
+            "kind",
+            "value"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "kind": {
+              "const": "text",
+              "type": "string"
+            },
+            "value": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "value"
+          ],
+          "type": "object"
+        },
+        {
+          "properties": {
+            "kind": {
+              "const": "date",
+              "type": "string"
+            },
+            "value": {
+              "format": "date",
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind",
+            "value"
+          ],
+          "type": "object"
+        }
+      ]
     }
   },
   "$id": "https://schemas.axiom-foundation.org/rules-engine/unit-aggregation-request.stage3.schema.json",

--- a/schemas/unit-aggregation-result.stage3.schema.json
+++ b/schemas/unit-aggregation-result.stage3.schema.json
@@ -1,0 +1,292 @@
+{
+  "$defs": {
+    "AggregatedChild": {
+      "additionalProperties": false,
+      "properties": {
+        "age_bands": {
+          "additionalProperties": {
+            "$ref": "#/$defs/AggregationValue2"
+          },
+          "type": "object"
+        },
+        "age_years": {
+          "$ref": "#/$defs/AggregationValue4"
+        },
+        "family": {
+          "type": "string"
+        },
+        "person": {
+          "type": "string"
+        },
+        "scalars": {
+          "additionalProperties": {
+            "$ref": "#/$defs/AggregationValue3"
+          },
+          "type": "object"
+        }
+      },
+      "required": [
+        "person",
+        "family",
+        "age_years",
+        "age_bands",
+        "scalars"
+      ],
+      "type": "object"
+    },
+    "AggregatedFamily": {
+      "additionalProperties": false,
+      "properties": {
+        "children": {
+          "items": {
+            "$ref": "#/$defs/AggregatedChild"
+          },
+          "type": "array"
+        },
+        "counts": {
+          "additionalProperties": {
+            "$ref": "#/$defs/AggregationValue4"
+          },
+          "type": "object"
+        },
+        "id": {
+          "type": "string"
+        },
+        "members": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "partner_present": {
+          "$ref": "#/$defs/AggregationValue2"
+        },
+        "predicates": {
+          "additionalProperties": {
+            "$ref": "#/$defs/AggregationValue2"
+          },
+          "type": "object"
+        },
+        "scalars": {
+          "additionalProperties": {
+            "$ref": "#/$defs/AggregationValue3"
+          },
+          "type": "object"
+        }
+      },
+      "required": [
+        "id",
+        "members",
+        "partner_present",
+        "scalars",
+        "counts",
+        "predicates",
+        "children"
+      ],
+      "type": "object"
+    },
+    "AggregationValue": {
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "status": {
+              "const": "determined",
+              "type": "string"
+            },
+            "value": {
+              "items": {
+                "$ref": "#/$defs/AggregatedFamily"
+              },
+              "type": "array"
+            }
+          },
+          "required": [
+            "status",
+            "value"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "reasons": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array",
+              "uniqueItems": true
+            },
+            "status": {
+              "const": "indeterminate",
+              "type": "string"
+            }
+          },
+          "required": [
+            "status",
+            "reasons"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "AggregationValue2": {
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "status": {
+              "const": "determined",
+              "type": "string"
+            },
+            "value": {
+              "type": "boolean"
+            }
+          },
+          "required": [
+            "status",
+            "value"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "reasons": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array",
+              "uniqueItems": true
+            },
+            "status": {
+              "const": "indeterminate",
+              "type": "string"
+            }
+          },
+          "required": [
+            "status",
+            "reasons"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "AggregationValue3": {
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "status": {
+              "const": "determined",
+              "type": "string"
+            },
+            "value": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "status",
+            "value"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "reasons": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array",
+              "uniqueItems": true
+            },
+            "status": {
+              "const": "indeterminate",
+              "type": "string"
+            }
+          },
+          "required": [
+            "status",
+            "reasons"
+          ],
+          "type": "object"
+        }
+      ]
+    },
+    "AggregationValue4": {
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "properties": {
+            "status": {
+              "const": "determined",
+              "type": "string"
+            },
+            "value": {
+              "format": "int64",
+              "type": "integer"
+            }
+          },
+          "required": [
+            "status",
+            "value"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "reasons": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array",
+              "uniqueItems": true
+            },
+            "status": {
+              "const": "indeterminate",
+              "type": "string"
+            }
+          },
+          "required": [
+            "status",
+            "reasons"
+          ],
+          "type": "object"
+        }
+      ]
+    }
+  },
+  "$id": "https://schemas.axiom-foundation.org/rules-engine/unit-aggregation-result.stage3.schema.json",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "additionalProperties": false,
+  "description": "Knowledge-valued family aggregation outputs with canonical plan and request-bound trace digests.",
+  "properties": {
+    "families": {
+      "$ref": "#/$defs/AggregationValue"
+    },
+    "plan": {
+      "type": "string"
+    },
+    "plan_digest": {
+      "type": "string"
+    },
+    "schema": {
+      "const": "axiom/unit-aggregation-plan-stage3/1",
+      "type": "string"
+    },
+    "trace_root": {
+      "type": "string"
+    }
+  },
+  "required": [
+    "schema",
+    "plan",
+    "plan_digest",
+    "trace_root",
+    "families"
+  ],
+  "title": "Experimental unit aggregation result",
+  "type": "object"
+}

--- a/schemas/unit-aggregation-result.stage3.schema.json
+++ b/schemas/unit-aggregation-result.stage3.schema.json
@@ -5,12 +5,12 @@
       "properties": {
         "age_bands": {
           "additionalProperties": {
-            "$ref": "#/$defs/AggregationValue2"
+            "$ref": "#/$defs/AggregationValue"
           },
           "type": "object"
         },
         "age_years": {
-          "$ref": "#/$defs/AggregationValue4"
+          "$ref": "#/$defs/AggregationValue3"
         },
         "family": {
           "type": "string"
@@ -20,7 +20,7 @@
         },
         "scalars": {
           "additionalProperties": {
-            "$ref": "#/$defs/AggregationValue3"
+            "$ref": "#/$defs/AggregationValue2"
           },
           "type": "object"
         }
@@ -45,7 +45,7 @@
         },
         "counts": {
           "additionalProperties": {
-            "$ref": "#/$defs/AggregationValue4"
+            "$ref": "#/$defs/AggregationValue3"
           },
           "type": "object"
         },
@@ -59,17 +59,17 @@
           "type": "array"
         },
         "partner_present": {
-          "$ref": "#/$defs/AggregationValue2"
+          "$ref": "#/$defs/AggregationValue"
         },
         "predicates": {
           "additionalProperties": {
-            "$ref": "#/$defs/AggregationValue2"
+            "$ref": "#/$defs/AggregationValue"
           },
           "type": "object"
         },
         "scalars": {
           "additionalProperties": {
-            "$ref": "#/$defs/AggregationValue3"
+            "$ref": "#/$defs/AggregationValue2"
           },
           "type": "object"
         }
@@ -85,7 +85,7 @@
       ],
       "type": "object"
     },
-    "AggregationValue": {
+    "AggregationFamilyKnowledge": {
       "oneOf": [
         {
           "additionalProperties": false,
@@ -120,6 +120,15 @@
             "status": {
               "const": "indeterminate",
               "type": "string"
+            },
+            "value": {
+              "items": {
+                "$ref": "#/$defs/AggregatedFamily"
+              },
+              "type": [
+                "array",
+                "null"
+              ]
             }
           },
           "required": [
@@ -130,7 +139,7 @@
         }
       ]
     },
-    "AggregationValue2": {
+    "AggregationValue": {
       "oneOf": [
         {
           "additionalProperties": false,
@@ -172,7 +181,7 @@
         }
       ]
     },
-    "AggregationValue3": {
+    "AggregationValue2": {
       "oneOf": [
         {
           "additionalProperties": false,
@@ -214,7 +223,7 @@
         }
       ]
     },
-    "AggregationValue4": {
+    "AggregationValue3": {
       "oneOf": [
         {
           "additionalProperties": false,
@@ -264,7 +273,7 @@
   "description": "Knowledge-valued family aggregation outputs with canonical plan and request-bound trace digests.",
   "properties": {
     "families": {
-      "$ref": "#/$defs/AggregationValue"
+      "$ref": "#/$defs/AggregationFamilyKnowledge"
     },
     "plan": {
       "type": "string"

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,18 +17,136 @@ fn main() {
     }
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum TopLevelCommand {
+    Compile,
+    CompileComposed,
+    RunCompiled,
+    #[cfg(feature = "unit-derivation")]
+    CompileUnitAggregation,
+    #[cfg(feature = "unit-derivation")]
+    RunUnitAggregation,
+    EmitSchemas,
+    Migrate,
+    Capabilities,
+    Version,
+    Help,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct CommandMetadata {
+    command: TopLevelCommand,
+    name: &'static str,
+    aliases: &'static [&'static str],
+    description: &'static [&'static str],
+}
+
+const TOP_LEVEL_COMMANDS: &[CommandMetadata] = &[
+    CommandMetadata {
+        command: TopLevelCommand::Compile,
+        name: "compile",
+        aliases: &[],
+        description: &[
+            "Compile an atomic RuleSpec module inside a canonical country",
+            "checkout into a program artifact.",
+        ],
+    },
+    CommandMetadata {
+        command: TopLevelCommand::CompileComposed,
+        name: "compile-composed",
+        aliases: &[],
+        description: &[
+            "Compile an originless `module.kind: composition` produced by",
+            "axiom-compose.",
+        ],
+    },
+    CommandMetadata {
+        command: TopLevelCommand::RunCompiled,
+        name: "run-compiled",
+        aliases: &[],
+        description: &["Execute a compiled artifact against a JSON request on stdin."],
+    },
+    #[cfg(feature = "unit-derivation")]
+    CommandMetadata {
+        command: TopLevelCommand::CompileUnitAggregation,
+        name: "compile-unit-aggregation",
+        aliases: &[],
+        description: &[
+            "Compile and register an experimental typed aggregation artifact",
+            "(unit-derivation feature only).",
+        ],
+    },
+    #[cfg(feature = "unit-derivation")]
+    CommandMetadata {
+        command: TopLevelCommand::RunUnitAggregation,
+        name: "run-unit-aggregation",
+        aliases: &[],
+        description: &[
+            "Run a registered experimental aggregation artifact against JSON",
+            "(unit-derivation feature only).",
+        ],
+    },
+    CommandMetadata {
+        command: TopLevelCommand::EmitSchemas,
+        name: "emit-schemas",
+        aliases: &[],
+        description: &["Write JSON Schemas for the wire types (schema feature only)."],
+    },
+    CommandMetadata {
+        command: TopLevelCommand::Migrate,
+        name: "migrate",
+        aliases: &[],
+        description: &[
+            "Corpus-migration tooling; `migrate scan <path>...` inventories",
+            "hand-expanded exactly-one patterns (#152).",
+        ],
+    },
+    CommandMetadata {
+        command: TopLevelCommand::Capabilities,
+        name: "capabilities",
+        aliases: &[],
+        description: &[
+            "Print, as JSON, the engine version and the artifact format",
+            "version the loader enforces. Semver alone cannot answer",
+            "whether an artifact will load; this can.",
+        ],
+    },
+    CommandMetadata {
+        command: TopLevelCommand::Version,
+        name: "version",
+        aliases: &["--version"],
+        description: &["Print the engine version."],
+    },
+    CommandMetadata {
+        command: TopLevelCommand::Help,
+        name: "help",
+        aliases: &["--help", "-h"],
+        description: &["Print this message."],
+    },
+];
+
+fn recognize_top_level_command(name: &str) -> Option<TopLevelCommand> {
+    TOP_LEVEL_COMMANDS
+        .iter()
+        .find(|metadata| metadata.name == name || metadata.aliases.contains(&name))
+        .map(|metadata| metadata.command)
+}
+
 fn run() -> Result<(), Box<dyn std::error::Error>> {
     let mut args = env::args().skip(1);
-    if let Some(command) = args.next() {
-        match command.as_str() {
-            "--version" | "version" => {
+    if let Some(command_name) = args.next() {
+        let Some(command) = recognize_top_level_command(&command_name) else {
+            return Err(format!("unknown command `{command_name}`\n\n{}", top_usage()).into());
+        };
+        match command {
+            TopLevelCommand::Version => {
                 if args.next().is_some() {
                     return Err("`version` takes no arguments".into());
                 }
                 println!("{}", version_line());
                 return Ok(());
             }
-            "capabilities" => {
+            TopLevelCommand::Capabilities => {
                 if args.next().is_some() {
                     return Err("`capabilities` takes no arguments".into());
                 }
@@ -41,19 +159,26 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
                 );
                 return Ok(());
             }
-            "--help" | "-h" | "help" => {
-                println!("{TOP_USAGE}");
+            TopLevelCommand::Help => {
+                println!("{}", top_usage());
                 return Ok(());
             }
-            "compile" => return run_compile(args.collect(), false),
-            "compile-composed" => return run_compile(args.collect(), true),
-            "run-compiled" => return run_compiled(args.collect()),
+            TopLevelCommand::Compile => return run_compile(args.collect(), false),
+            TopLevelCommand::CompileComposed => return run_compile(args.collect(), true),
+            TopLevelCommand::RunCompiled => return run_compiled(args.collect()),
             #[cfg(feature = "unit-derivation")]
-            "run-unit-aggregation" => return run_unit_aggregation(args.collect()),
+            TopLevelCommand::CompileUnitAggregation => {
+                return run_compile_unit_aggregation(args.collect());
+            }
+            #[cfg(feature = "unit-derivation")]
+            TopLevelCommand::RunUnitAggregation => return run_unit_aggregation(args.collect()),
             #[cfg(feature = "schema")]
-            "emit-schemas" => return run_emit_schemas(args.collect()),
-            "migrate" => return run_migrate(args.collect()),
-            _ => return Err(format!("unknown command `{command}`\n\n{TOP_USAGE}").into()),
+            TopLevelCommand::EmitSchemas => return run_emit_schemas(args.collect()),
+            #[cfg(not(feature = "schema"))]
+            TopLevelCommand::EmitSchemas => {
+                return Err(format!("unknown command `{command_name}`\n\n{}", top_usage()).into());
+            }
+            TopLevelCommand::Migrate => return run_migrate(args.collect()),
         }
     }
 
@@ -62,7 +187,7 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
     // a crash rather than as "I expected JSON on stdin". Only consume stdin when it is
     // actually piped (#120).
     if io::stdin().is_terminal() {
-        println!("{TOP_USAGE}");
+        println!("{}", top_usage());
         return Ok(());
     }
 
@@ -80,31 +205,74 @@ fn version_line() -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{COMPILE_USAGE, TOP_USAGE, version_line};
+    use std::collections::BTreeSet;
+
+    #[cfg(feature = "unit-derivation")]
+    use super::TopLevelCommand;
+    use super::{
+        COMPILE_USAGE, TOP_LEVEL_COMMANDS, recognize_top_level_command, top_usage, version_line,
+    };
 
     #[test]
     fn version_line_uses_package_version() {
         assert_eq!(version_line(), "axiom-rules-engine 0.2.1");
     }
 
-    /// Top-level help must name every command `run` dispatches on, so adding a command
-    /// without documenting it fails here rather than silently leaving users without a way
-    /// to discover it (#120).
+    /// Registration is the sole command-name inventory: recognition and rendered help
+    /// must agree for every feature-enabled entry and alias.
     #[test]
-    fn top_usage_lists_every_dispatched_command() {
-        for command in [
-            "compile",
-            "compile-composed",
-            "run-compiled",
-            "emit-schemas",
-            "capabilities",
-            "version",
-            "help",
-        ] {
+    fn top_level_command_metadata_drives_recognition_and_help() {
+        let usage = top_usage();
+        let mut names = BTreeSet::new();
+        for metadata in TOP_LEVEL_COMMANDS {
             assert!(
-                TOP_USAGE.contains(command),
-                "top-level usage does not mention `{command}`"
+                names.insert(metadata.name),
+                "duplicate top-level command name `{}`",
+                metadata.name
             );
+            assert_eq!(
+                recognize_top_level_command(metadata.name),
+                Some(metadata.command)
+            );
+            assert!(
+                usage.lines().any(|line| {
+                    line.trim_start().split_whitespace().next() == Some(metadata.name)
+                }),
+                "top-level usage does not list `{}`",
+                metadata.name
+            );
+            for alias in metadata.aliases {
+                assert!(names.insert(alias), "duplicate top-level alias `{alias}`");
+                assert_eq!(recognize_top_level_command(alias), Some(metadata.command));
+            }
+        }
+    }
+
+    #[test]
+    fn unit_aggregation_registration_matches_the_feature_gate() {
+        let usage = top_usage();
+        #[cfg(feature = "unit-derivation")]
+        {
+            assert_eq!(
+                recognize_top_level_command("compile-unit-aggregation"),
+                Some(TopLevelCommand::CompileUnitAggregation)
+            );
+            assert_eq!(
+                recognize_top_level_command("run-unit-aggregation"),
+                Some(TopLevelCommand::RunUnitAggregation)
+            );
+            assert!(usage.contains("  compile-unit-aggregation"));
+            assert!(usage.contains("  run-unit-aggregation  "));
+        }
+        #[cfg(not(feature = "unit-derivation"))]
+        {
+            assert_eq!(
+                recognize_top_level_command("compile-unit-aggregation"),
+                None
+            );
+            assert_eq!(recognize_top_level_command("run-unit-aggregation"), None);
+            assert!(!usage.contains("compile-unit-aggregation"));
+            assert!(!usage.contains("run-unit-aggregation"));
         }
     }
 
@@ -112,32 +280,21 @@ mod tests {
     /// the compile-specific text, which is what made `--help` useless before (#120).
     #[test]
     fn top_usage_is_distinct_from_compile_usage() {
-        assert_ne!(TOP_USAGE, COMPILE_USAGE);
-        assert!(TOP_USAGE.starts_with("axiom-rules-engine — RuleSpec compiler and runtime"));
+        let usage = top_usage();
+        assert_ne!(usage, COMPILE_USAGE);
+        assert!(usage.starts_with("axiom-rules-engine — RuleSpec compiler and runtime"));
     }
 }
 
-const TOP_USAGE: &str = "\
+const TOP_USAGE_HEADER: &str = "\
 axiom-rules-engine — RuleSpec compiler and runtime
 
 usage: axiom-rules-engine <command> [options]
        axiom-rules-engine < request.json
 
-commands:
-  compile           Compile an atomic RuleSpec module inside a canonical country
-                    checkout into a program artifact.
-  compile-composed  Compile an originless `module.kind: composition` produced by
-                    axiom-compose.
-  run-compiled      Execute a compiled artifact against a JSON request on stdin.
-  emit-schemas      Write JSON Schemas for the wire types (schema feature only).
-  migrate           Corpus-migration tooling; `migrate scan <path>...` inventories
-                    hand-expanded exactly-one patterns (#152).
-  capabilities      Print, as JSON, the engine version and the artifact format
-                    version the loader enforces. Semver alone cannot answer
-                    whether an artifact will load; this can.
-  version           Print the engine version.
-  help              Print this message.
+commands:\n";
 
+const TOP_USAGE_FOOTER: &str = "\
 Run `axiom-rules-engine <command> --help` for the options of a specific command.
 
 With no command and a piped stdin, a self-contained JSON `ExecutionRequest` is read
@@ -148,6 +305,30 @@ from stdin and its response written to stdout:
 Note: the released v0.1.1 binary has a different compile interface from this one —
 its `compile` takes only --program and --output, and it has no `compile-composed`.
 See docs/install.md.";
+
+fn top_usage() -> String {
+    let mut usage = String::from(TOP_USAGE_HEADER);
+    for metadata in TOP_LEVEL_COMMANDS {
+        usage.push_str("  ");
+        usage.push_str(metadata.name);
+        let padding = if metadata.name.len() < 18 {
+            18 - metadata.name.len()
+        } else {
+            2
+        };
+        usage.push_str(&" ".repeat(padding));
+        usage.push_str(metadata.description[0]);
+        usage.push('\n');
+        for continuation in &metadata.description[1..] {
+            usage.push_str("                    ");
+            usage.push_str(continuation);
+            usage.push('\n');
+        }
+    }
+    usage.push('\n');
+    usage.push_str(TOP_USAGE_FOOTER);
+    usage
+}
 
 const COMPILE_USAGE: &str = "\
 usage: axiom-rules-engine compile --program <absolute rules.yaml> --rulespec-root <absolute rulespec-cc> [--rulespec-root <absolute rulespec-cc>]... --output <compiled.json> [--corpus-provisions <path>]...
@@ -265,23 +446,75 @@ fn run_compiled(args: Vec<String>) -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[cfg(feature = "unit-derivation")]
-const UNIT_AGGREGATION_USAGE: &str = "\
-usage: axiom-rules-engine run-unit-aggregation --plan <plan.yaml> --enable-experimental-unit-derivation < request.json
+const COMPILE_UNIT_AGGREGATION_USAGE: &str = "\
+usage: axiom-rules-engine compile-unit-aggregation --plan <plan.yaml> --output <compiled-aggregation.json>
 
-This command is compiled only with the off-by-default `unit-derivation` Cargo
-feature. The explicit runtime switch is also mandatory. Its plan and result
-use the named experimental channel, never compiled artifact v2.";
+The authoring YAML is accepted only at this compile boundary. The output is a
+canonically digested experimental artifact containing a production-validated
+phase-two program; run-unit-aggregation accepts only that compiled artifact.";
 
 #[cfg(feature = "unit-derivation")]
-fn run_unit_aggregation(args: Vec<String>) -> Result<(), Box<dyn std::error::Error>> {
+fn run_compile_unit_aggregation(args: Vec<String>) -> Result<(), Box<dyn std::error::Error>> {
     let mut plan_path: Option<PathBuf> = None;
-    let mut enabled = false;
+    let mut output_path: Option<PathBuf> = None;
     let mut iter = args.into_iter();
     while let Some(arg) = iter.next() {
         match arg.as_str() {
             "--plan" => {
                 plan_path = Some(PathBuf::from(
                     iter.next().ok_or("`--plan` requires a path argument")?,
+                ));
+            }
+            "--output" => {
+                output_path = Some(PathBuf::from(
+                    iter.next().ok_or("`--output` requires a path argument")?,
+                ));
+            }
+            "--help" | "-h" => {
+                println!("{COMPILE_UNIT_AGGREGATION_USAGE}");
+                return Ok(());
+            }
+            _ => {
+                return Err(format!(
+                    "unknown compile-unit-aggregation argument `{arg}`\n{COMPILE_UNIT_AGGREGATION_USAGE}"
+                )
+                .into());
+            }
+        }
+    }
+    let plan_path = plan_path.ok_or("missing required `--plan /path/to/plan.yaml` argument")?;
+    let output_path = output_path
+        .ok_or("missing required `--output /path/to/compiled-aggregation.json` argument")?;
+    let source = std::fs::read_to_string(&plan_path)?;
+    let mut registry =
+        axiom_rules_engine::unit_derivation::UnitDerivationDocumentRegistry::default();
+    let artifact = registry.register_aggregation_source(&source)?;
+    std::fs::write(&output_path, artifact.to_json_pretty()?)?;
+    println!("compiled_unit_aggregation: {}", output_path.display());
+    println!("plan: {}", artifact.plan_id());
+    println!("plan_digest: {}", artifact.plan_digest);
+    Ok(())
+}
+
+#[cfg(feature = "unit-derivation")]
+const UNIT_AGGREGATION_USAGE: &str = "\
+usage: axiom-rules-engine run-unit-aggregation --artifact <compiled-aggregation.json> --enable-experimental-unit-derivation < request.json
+
+This command is compiled only with the off-by-default `unit-derivation` Cargo
+feature. The explicit runtime switch is also mandatory. Raw plan sidecars are
+not executable; the artifact must pass the experimental document registry and
+the embedded production phase-two artifact loader.";
+
+#[cfg(feature = "unit-derivation")]
+fn run_unit_aggregation(args: Vec<String>) -> Result<(), Box<dyn std::error::Error>> {
+    let mut artifact_path: Option<PathBuf> = None;
+    let mut enabled = false;
+    let mut iter = args.into_iter();
+    while let Some(arg) = iter.next() {
+        match arg.as_str() {
+            "--artifact" => {
+                artifact_path = Some(PathBuf::from(
+                    iter.next().ok_or("`--artifact` requires a path argument")?,
                 ));
             }
             "--enable-experimental-unit-derivation" => enabled = true,
@@ -303,9 +536,15 @@ fn run_unit_aggregation(args: Vec<String>) -> Result<(), Box<dyn std::error::Err
                 .into(),
         );
     }
-    let plan_path = plan_path.ok_or("missing required `--plan /path/to/plan.yaml` argument")?;
-    let plan_source = std::fs::read_to_string(plan_path)?;
-    let plan = axiom_rules_engine::unit_derivation::parse_aggregation_plan(&plan_source)?;
+    let artifact_path = artifact_path
+        .ok_or("missing required `--artifact /path/to/compiled-aggregation.json` argument")?;
+    let artifact_source = std::fs::read_to_string(artifact_path)?;
+    let mut registry =
+        axiom_rules_engine::unit_derivation::UnitDerivationDocumentRegistry::default();
+    let plan_id = {
+        let artifact = registry.register_aggregation_json(&artifact_source)?;
+        artifact.plan_id().to_string()
+    };
     let mut input = String::new();
     io::stdin().read_to_string(&mut input)?;
     let request: axiom_rules_engine::unit_derivation::AggregationRequest =
@@ -314,8 +553,7 @@ fn run_unit_aggregation(args: Vec<String>) -> Result<(), Box<dyn std::error::Err
         enabled: true,
         ..Default::default()
     };
-    let result =
-        axiom_rules_engine::unit_derivation::execute_aggregation_plan(&plan, &request, &config)?;
+    let result = registry.execute_aggregation(&plan_id, &request, &config)?;
     println!("{}", serde_json::to_string_pretty(&result)?);
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,6 +48,8 @@ fn run() -> Result<(), Box<dyn std::error::Error>> {
             "compile" => return run_compile(args.collect(), false),
             "compile-composed" => return run_compile(args.collect(), true),
             "run-compiled" => return run_compiled(args.collect()),
+            #[cfg(feature = "unit-derivation")]
+            "run-unit-aggregation" => return run_unit_aggregation(args.collect()),
             #[cfg(feature = "schema")]
             "emit-schemas" => return run_emit_schemas(args.collect()),
             "migrate" => return run_migrate(args.collect()),
@@ -259,6 +261,62 @@ fn run_compiled(args: Vec<String>) -> Result<(), Box<dyn std::error::Error>> {
     let request: CompiledExecutionRequest = serde_json::from_str(&input)?;
     let response = execute_compiled_request(artifact, request)?;
     println!("{}", serde_json::to_string_pretty(&response)?);
+    Ok(())
+}
+
+#[cfg(feature = "unit-derivation")]
+const UNIT_AGGREGATION_USAGE: &str = "\
+usage: axiom-rules-engine run-unit-aggregation --plan <plan.yaml> --enable-experimental-unit-derivation < request.json
+
+This command is compiled only with the off-by-default `unit-derivation` Cargo
+feature. The explicit runtime switch is also mandatory. Its plan and result
+use the named experimental channel, never compiled artifact v2.";
+
+#[cfg(feature = "unit-derivation")]
+fn run_unit_aggregation(args: Vec<String>) -> Result<(), Box<dyn std::error::Error>> {
+    let mut plan_path: Option<PathBuf> = None;
+    let mut enabled = false;
+    let mut iter = args.into_iter();
+    while let Some(arg) = iter.next() {
+        match arg.as_str() {
+            "--plan" => {
+                plan_path = Some(PathBuf::from(
+                    iter.next().ok_or("`--plan` requires a path argument")?,
+                ));
+            }
+            "--enable-experimental-unit-derivation" => enabled = true,
+            "--help" | "-h" => {
+                println!("{UNIT_AGGREGATION_USAGE}");
+                return Ok(());
+            }
+            _ => {
+                return Err(format!(
+                    "unknown run-unit-aggregation argument `{arg}`\n{UNIT_AGGREGATION_USAGE}"
+                )
+                .into());
+            }
+        }
+    }
+    if !enabled {
+        return Err(
+            "unit derivation is disabled; pass --enable-experimental-unit-derivation explicitly"
+                .into(),
+        );
+    }
+    let plan_path = plan_path.ok_or("missing required `--plan /path/to/plan.yaml` argument")?;
+    let plan_source = std::fs::read_to_string(plan_path)?;
+    let plan = axiom_rules_engine::unit_derivation::parse_aggregation_plan(&plan_source)?;
+    let mut input = String::new();
+    io::stdin().read_to_string(&mut input)?;
+    let request: axiom_rules_engine::unit_derivation::AggregationRequest =
+        serde_json::from_str(&input)?;
+    let config = axiom_rules_engine::unit_derivation::UnitDerivationConfig {
+        enabled: true,
+        ..Default::default()
+    };
+    let result =
+        axiom_rules_engine::unit_derivation::execute_aggregation_plan(&plan, &request, &config)?;
+    println!("{}", serde_json::to_string_pretty(&result)?);
     Ok(())
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -447,15 +447,17 @@ fn run_compiled(args: Vec<String>) -> Result<(), Box<dyn std::error::Error>> {
 
 #[cfg(feature = "unit-derivation")]
 const COMPILE_UNIT_AGGREGATION_USAGE: &str = "\
-usage: axiom-rules-engine compile-unit-aggregation --plan <plan.yaml> --output <compiled-aggregation.json>
+usage: axiom-rules-engine compile-unit-aggregation --plan <plan.yaml> --source-artifact <compiled-program.json> --output <compiled-aggregation.json>
 
 The authoring YAML is accepted only at this compile boundary. The output is a
 canonically digested experimental artifact containing a production-validated
-phase-two program; run-unit-aggregation accepts only that compiled artifact.";
+source program and phase-two program; run-unit-aggregation accepts only that
+compiled artifact.";
 
 #[cfg(feature = "unit-derivation")]
 fn run_compile_unit_aggregation(args: Vec<String>) -> Result<(), Box<dyn std::error::Error>> {
     let mut plan_path: Option<PathBuf> = None;
+    let mut source_artifact_path: Option<PathBuf> = None;
     let mut output_path: Option<PathBuf> = None;
     let mut iter = args.into_iter();
     while let Some(arg) = iter.next() {
@@ -468,6 +470,12 @@ fn run_compile_unit_aggregation(args: Vec<String>) -> Result<(), Box<dyn std::er
             "--output" => {
                 output_path = Some(PathBuf::from(
                     iter.next().ok_or("`--output` requires a path argument")?,
+                ));
+            }
+            "--source-artifact" => {
+                source_artifact_path = Some(PathBuf::from(
+                    iter.next()
+                        .ok_or("`--source-artifact` requires a path argument")?,
                 ));
             }
             "--help" | "-h" => {
@@ -483,12 +491,15 @@ fn run_compile_unit_aggregation(args: Vec<String>) -> Result<(), Box<dyn std::er
         }
     }
     let plan_path = plan_path.ok_or("missing required `--plan /path/to/plan.yaml` argument")?;
+    let source_artifact_path = source_artifact_path
+        .ok_or("missing required `--source-artifact /path/to/compiled-program.json` argument")?;
     let output_path = output_path
         .ok_or("missing required `--output /path/to/compiled-aggregation.json` argument")?;
     let source = std::fs::read_to_string(&plan_path)?;
+    let source_artifact = CompiledProgramArtifact::from_json_file(&source_artifact_path)?;
     let mut registry =
         axiom_rules_engine::unit_derivation::UnitDerivationDocumentRegistry::default();
-    let artifact = registry.register_aggregation_source(&source)?;
+    let artifact = registry.register_aggregation_source(&source, &source_artifact)?;
     std::fs::write(&output_path, artifact.to_json_pretty()?)?;
     println!("compiled_unit_aggregation: {}", output_path.display());
     println!("plan: {}", artifact.plan_id());

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -15,6 +15,9 @@
 //!   consumers. `compiled-artifact.v1` remains published unchanged so stored
 //!   v1 artifacts have a stable historical schema, but this engine does not
 //!   execute them.
+//! - With both `schema` and `unit-derivation` enabled, four explicitly
+//!   experimental stage-3 schemas cover the aggregation authoring plan,
+//!   compiled artifact, Knowledge-valued request, and Knowledge-valued result.
 //!
 //! Fidelity is the whole point: a file that serde deserializes MUST validate
 //! against its schema, and a file that validates MUST deserialize. That goal
@@ -58,7 +61,7 @@ const CORPUS_CITATION_PATH_PATTERN: &str = "^[a-z]{2,3}(?:-[a-z0-9]+)*/[a-z][a-z
 /// byte-identical; the `emit-schemas` CLI subcommand writes the same set.
 #[cfg(feature = "schema")]
 pub fn all_schemas() -> Vec<NamedSchema> {
-    vec![
+    let mut schemas = vec![
         NamedSchema {
             file_name: "rulespec-module.v1.schema.json",
             schema: rulespec_module_schema(),
@@ -75,7 +78,27 @@ pub fn all_schemas() -> Vec<NamedSchema> {
             file_name: "compiled-artifact.v2.schema.json",
             schema: compiled_artifact_schema(),
         },
-    ]
+    ];
+    #[cfg(feature = "unit-derivation")]
+    schemas.extend([
+        NamedSchema {
+            file_name: "experimental-unit-aggregation-plan.stage3.schema.json",
+            schema: unit_aggregation_plan_schema(),
+        },
+        NamedSchema {
+            file_name: "compiled-unit-aggregation.stage3.schema.json",
+            schema: compiled_unit_aggregation_schema(),
+        },
+        NamedSchema {
+            file_name: "unit-aggregation-request.stage3.schema.json",
+            schema: unit_aggregation_request_schema(),
+        },
+        NamedSchema {
+            file_name: "unit-aggregation-result.stage3.schema.json",
+            schema: unit_aggregation_result_schema(),
+        },
+    ]);
+    schemas
 }
 
 /// Serialize a schema to the canonical on-disk text: pretty-printed with two
@@ -145,6 +168,92 @@ pub fn compiled_artifact_schema() -> Value {
          version. Produced by `axiom-rules-engine compile`.",
     );
     schema
+}
+
+#[cfg(all(feature = "schema", feature = "unit-derivation"))]
+pub fn unit_aggregation_plan_schema() -> Value {
+    let mut schema = serde_json::to_value(schema_for!(crate::unit_derivation::AggregationPlan))
+        .expect("unit aggregation plan schema serializes");
+    set_property_const(
+        &mut schema,
+        "schema",
+        crate::unit_derivation::EXPERIMENTAL_AGGREGATION_PLAN_SCHEMA,
+    );
+    stamp_meta(
+        &mut schema,
+        "experimental-unit-aggregation-plan.stage3",
+        "Experimental unit aggregation plan",
+        "Feature-gated authoring document compiled into a canonically digested unit aggregation artifact.",
+    );
+    schema
+}
+
+#[cfg(all(feature = "schema", feature = "unit-derivation"))]
+pub fn compiled_unit_aggregation_schema() -> Value {
+    let mut schema = serde_json::to_value(schema_for!(
+        crate::unit_derivation::CompiledAggregationArtifact
+    ))
+    .expect("compiled unit aggregation schema serializes");
+    set_property_const(
+        &mut schema,
+        "format",
+        crate::unit_derivation::COMPILED_AGGREGATION_ARTIFACT_FORMAT,
+    );
+    set_property_const(
+        &mut schema,
+        "semantics_version",
+        crate::unit_derivation::EXPERIMENTAL_SEMANTICS_VERSION,
+    );
+    stamp_meta(
+        &mut schema,
+        "compiled-unit-aggregation.stage3",
+        "Compiled experimental unit aggregation artifact",
+        "Feature-gated, canonically digested aggregation plan with an embedded production-validated phase-two artifact.",
+    );
+    schema
+}
+
+#[cfg(all(feature = "schema", feature = "unit-derivation"))]
+pub fn unit_aggregation_request_schema() -> Value {
+    let mut schema = serde_json::to_value(schema_for!(crate::unit_derivation::AggregationRequest))
+        .expect("unit aggregation request schema serializes");
+    stamp_meta(
+        &mut schema,
+        "unit-aggregation-request.stage3",
+        "Experimental unit aggregation request",
+        "Evidence-bearing Knowledge-valued roster, relationship, person, child, and family inputs.",
+    );
+    schema
+}
+
+#[cfg(all(feature = "schema", feature = "unit-derivation"))]
+pub fn unit_aggregation_result_schema() -> Value {
+    let mut schema = serde_json::to_value(schema_for!(crate::unit_derivation::AggregationResult))
+        .expect("unit aggregation result schema serializes");
+    set_property_const(
+        &mut schema,
+        "schema",
+        crate::unit_derivation::EXPERIMENTAL_AGGREGATION_PLAN_SCHEMA,
+    );
+    stamp_meta(
+        &mut schema,
+        "unit-aggregation-result.stage3",
+        "Experimental unit aggregation result",
+        "Knowledge-valued family aggregation outputs with canonical plan and request-bound trace digests.",
+    );
+    schema
+}
+
+#[cfg(all(feature = "schema", feature = "unit-derivation"))]
+fn set_property_const(schema: &mut Value, property: &str, value: &str) {
+    if let Some(property_schema) = schema
+        .get_mut("properties")
+        .and_then(Value::as_object_mut)
+        .and_then(|properties| properties.get_mut(property))
+        .and_then(Value::as_object_mut)
+    {
+        property_schema.insert("const".to_string(), json!(value));
+    }
 }
 
 #[cfg(feature = "schema")]

--- a/src/unit_derivation/aggregation.rs
+++ b/src/unit_derivation/aggregation.rs
@@ -1,20 +1,34 @@
 use std::collections::{BTreeMap, BTreeSet};
 
+use chrono::NaiveDate;
 use num_bigint::BigInt;
 use serde::{Deserialize, Serialize};
 
 use super::types::*;
 
-#[derive(Clone, Debug, Deserialize)]
+pub const COMPILED_AGGREGATION_ARTIFACT_FORMAT: &str = "axiom/compiled-unit-aggregation-stage3/1";
+
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct AggregationPlan {
     pub schema: String,
     pub id: String,
     pub decimal_precision: u32,
     pub constitution: AggregationConstitution,
+    #[serde(default)]
+    pub inputs: Vec<AggregationInput>,
     pub membership_relations: Vec<AggregationMembershipRelation>,
     pub partner_relation: String,
     pub child_relation: String,
+    #[serde(default)]
+    pub partner_presence: PartnerPresenceRule,
+    #[serde(default)]
+    pub adult_selection: AdultSelectionRule,
+    #[serde(default)]
+    pub age_18_conditions: Age18Conditions,
+    #[serde(default)]
+    pub care: CareSemantics,
     #[serde(default)]
     pub scalar_aggregations: Vec<ScalarAggregation>,
     #[serde(default)]
@@ -22,12 +36,23 @@ pub struct AggregationPlan {
     #[serde(default)]
     pub child_minima: Vec<ChildMinimum>,
     #[serde(default)]
+    pub family_predicates: Vec<FamilyPredicate>,
+    #[serde(default)]
+    pub family_shape_scalars: Vec<FamilyShapeScalar>,
+    #[serde(default)]
+    pub child_agreements: Vec<ChildAgreement>,
+    #[serde(default)]
+    pub child_projections: Vec<ChildProjection>,
+    #[serde(default)]
     pub broadcasts: Vec<ChildBroadcast>,
     #[serde(default)]
     pub family_reductions: Vec<FamilyReduction>,
+    #[serde(default)]
+    pub limitations: Vec<DeclaredLimitation>,
 }
 
-#[derive(Clone, Debug, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct AggregationConstitution {
     pub id: String,
@@ -37,16 +62,176 @@ pub struct AggregationConstitution {
     pub participating_member_relation: String,
 }
 
-#[derive(Clone, Debug, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AggregationInputScope {
+    Adult,
+    Child,
+    Family,
+}
+
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AggregationInputKind {
+    AdditiveAmount,
+    ChildGrossAmount,
+    FamilyAdjustment,
+    FamilyAmount,
+    DecimalRate,
+    CareFraction,
+    EligibilityBoolean,
+}
+
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AggregationInput {
+    pub name: String,
+    pub scope: AggregationInputScope,
+    pub kind: AggregationInputKind,
+    #[serde(default)]
+    pub reduction_key: Option<String>,
+    pub citation: AggregationCitation,
+}
+
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum RelationDirection {
+    Directed,
+    Symmetric,
+}
+
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum MembershipRole {
+    Caregiver,
+    Child,
+    Partner,
+}
+
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct AggregationMembershipRelation {
     pub relation: String,
     #[serde(default)]
-    pub symmetric: bool,
+    pub direction: Option<RelationDirection>,
+    #[serde(default)]
+    pub symmetric: Option<bool>,
+    #[serde(default)]
+    pub left_role: Option<MembershipRole>,
+    #[serde(default)]
+    pub right_role: Option<MembershipRole>,
     pub citation: AggregationCitation,
 }
 
-#[derive(Clone, Debug, Deserialize)]
+impl AggregationMembershipRelation {
+    fn effective_direction(&self) -> Option<RelationDirection> {
+        self.direction.or_else(|| {
+            self.symmetric.map(|value| {
+                if value {
+                    RelationDirection::Symmetric
+                } else {
+                    RelationDirection::Directed
+                }
+            })
+        })
+    }
+}
+
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PartnerPresenceRule {
+    pub entitlement_holder_input: String,
+    pub citation: AggregationCitation,
+    pub caller_determination: String,
+}
+
+impl Default for PartnerPresenceRule {
+    fn default() -> Self {
+        Self {
+            entitlement_holder_input: String::new(),
+            citation: AggregationCitation::default(),
+            caller_determination: String::new(),
+        }
+    }
+}
+
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AdultSelectionRule {
+    pub operation: AdultSelectionOperation,
+    pub citation: AggregationCitation,
+    pub caller_determination: String,
+}
+
+impl Default for AdultSelectionRule {
+    fn default() -> Self {
+        Self {
+            operation: AdultSelectionOperation::ExplicitPersonRole,
+            citation: AggregationCitation::default(),
+            caller_determination: String::new(),
+        }
+    }
+}
+
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AdultSelectionOperation {
+    ExplicitPersonRole,
+}
+
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Age18Conditions {
+    pub age: i64,
+    pub not_financially_independent_input: String,
+    pub attending_school_or_tertiary_input: String,
+    pub commissioner_period_input: String,
+    pub citation: AggregationCitation,
+}
+
+impl Default for Age18Conditions {
+    fn default() -> Self {
+        Self {
+            age: 18,
+            not_financially_independent_input: String::new(),
+            attending_school_or_tertiary_input: String::new(),
+            commissioner_period_input: String::new(),
+            citation: AggregationCitation::default(),
+        }
+    }
+}
+
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CareSemantics {
+    pub principal_care_input: String,
+    pub claimant_care_fraction_input: String,
+    pub citation: AggregationCitation,
+}
+
+impl Default for CareSemantics {
+    fn default() -> Self {
+        Self {
+            principal_care_input: String::new(),
+            claimant_care_fraction_input: String::new(),
+            citation: AggregationCitation::default(),
+        }
+    }
+}
+
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
 #[serde(deny_unknown_fields)]
 pub struct AggregationCitation {
     pub provision: String,
@@ -59,14 +244,27 @@ impl From<&AggregationCitation> for Citation {
     }
 }
 
-#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DeclaredLimitation {
+    pub id: String,
+    pub statement: String,
+    pub citation: AggregationCitation,
+}
+
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum AggregateSelector {
     Adults,
+    // Retained solely so an old unsafe document reaches semantic validation
+    // and receives a named scope/provenance error rather than a YAML typo.
     AllMembers,
 }
 
-#[derive(Clone, Debug, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct ScalarAggregation {
     pub output: String,
@@ -75,7 +273,8 @@ pub struct ScalarAggregation {
     pub citation: AggregationCitation,
 }
 
-#[derive(Clone, Debug, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct ChildCount {
     pub output: String,
@@ -86,7 +285,8 @@ pub struct ChildCount {
     pub citation: AggregationCitation,
 }
 
-#[derive(Clone, Debug, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct ChildMinimum {
     pub output: String,
@@ -95,7 +295,86 @@ pub struct ChildMinimum {
     pub citation: AggregationCitation,
 }
 
-#[derive(Clone, Debug, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct FamilyPredicate {
+    pub output: String,
+    pub operation: FamilyPredicateOperation,
+    pub citation: AggregationCitation,
+}
+
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
+pub enum FamilyPredicateOperation {
+    CountAtLeast {
+        count: String,
+        minimum: i64,
+    },
+    YoungestAgeAtLeast {
+        youngest: String,
+        minimum: i64,
+    },
+    SoleParentWithChildren {
+        count: String,
+    },
+    SoleParentYoungestAgeAtLeast {
+        count: String,
+        youngest: String,
+        minimum: i64,
+    },
+}
+
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct FamilyShapeScalar {
+    pub output: String,
+    pub operation: FamilyShapeScalarOperation,
+    pub citation: AggregationCitation,
+}
+
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
+pub enum FamilyShapeScalarOperation {
+    EldestCareUnits {
+        count: String,
+    },
+    SubsequentCareUnits {
+        count: String,
+    },
+    FixedIfChildren {
+        count: String,
+        present: String,
+        absent: String,
+    },
+}
+
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ChildAgreement {
+    pub output: String,
+    pub input: String,
+    #[serde(default)]
+    pub eligible_if: Option<String>,
+    pub empty_value: String,
+    pub citation: AggregationCitation,
+}
+
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ChildProjection {
+    pub output: String,
+    pub input: String,
+    pub citation: AggregationCitation,
+}
+
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct ChildBroadcast {
     pub output: String,
@@ -103,85 +382,433 @@ pub struct ChildBroadcast {
     pub citation: AggregationCitation,
 }
 
-#[derive(Clone, Debug, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct FamilyReduction {
     pub output: String,
     pub gross_output: String,
     pub operation: FamilyReductionOperation,
-    pub child_value: String,
-    pub family_once_value: String,
+    #[serde(default)]
+    pub reduction_key: Option<String>,
+    #[serde(default)]
+    pub child_gross_input: Option<String>,
+    #[serde(default)]
+    pub family_adjustment_input: Option<String>,
+    // Legacy unsafe spellings are parsed deliberately and rejected by the
+    // typed validator with a named error.
+    #[serde(default)]
+    pub child_value: Option<String>,
+    #[serde(default)]
+    pub family_once_value: Option<String>,
+    pub care_fraction_input: Option<String>,
     #[serde(default)]
     pub minimum_age: Option<i64>,
     #[serde(default)]
     pub maximum_age: Option<i64>,
+    #[serde(default)]
+    pub continuous: Option<ContinuousFamilyReduction>,
     pub citation: AggregationCitation,
 }
 
-#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Eq)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum FamilyReductionOperation {
-    /// Sum per-child gross credits, require every child-carried family value
-    /// to agree, and subtract that value exactly once from the family total.
     SumChildrenThenSubtractFamilyOnce,
 }
 
-#[derive(Clone, Debug, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ContinuousFamilyReduction {
+    pub output: String,
+    pub family_income_input: String,
+    pub threshold_input: String,
+    pub rate_input: String,
+}
+
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+#[serde(deny_unknown_fields)]
+pub struct AggregationEvidence {
+    pub id: String,
+}
+
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct AggregationObservation<T> {
+    pub value: T,
+    pub evidence: AggregationEvidence,
+}
+
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "status", rename_all = "snake_case", deny_unknown_fields)]
+pub enum AggregationKnowledge<T> {
+    Known {
+        value: T,
+        evidence: AggregationEvidence,
+    },
+    Unknown {
+        evidence: AggregationEvidence,
+    },
+    Observations {
+        observations: Vec<AggregationObservation<T>>,
+    },
+    Conflict {
+        observations: Vec<AggregationObservation<T>>,
+    },
+}
+
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct AggregationRequest {
     pub scope: String,
     pub segment: String,
-    pub primary_person: String,
+    pub roster_completeness: Option<AggregationEvidence>,
+    pub segment_completeness: Option<AggregationEvidence>,
     pub persons: Vec<AggregationPerson>,
     #[serde(default)]
-    pub relations: BTreeMap<String, Vec<[String; 2]>>,
+    pub relations: Vec<AggregationRelationFamily>,
     #[serde(default)]
-    pub family_scalars: BTreeMap<String, String>,
+    pub family_inputs: Vec<AggregationFamilyInput>,
 }
 
-#[derive(Clone, Debug, Deserialize)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AggregationFamilyInput {
+    pub anchor_person: String,
+    pub evidence: AggregationEvidence,
+    #[serde(default)]
+    pub named_people: BTreeMap<String, AggregationKnowledge<String>>,
+    #[serde(default)]
+    pub scalars: BTreeMap<String, AggregationKnowledge<String>>,
+}
+
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+#[serde(rename_all = "snake_case")]
+pub enum AggregationPersonRole {
+    Adult,
+    Child,
+}
+
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct AggregationPerson {
     pub id: String,
+    pub role: AggregationPersonRole,
+    pub evidence: AggregationEvidence,
     #[serde(default)]
-    pub age_years: Option<i64>,
+    pub age_years: Option<AggregationKnowledge<i64>>,
     #[serde(default)]
-    pub scalars: BTreeMap<String, String>,
+    pub scalars: BTreeMap<String, AggregationKnowledge<String>>,
+    #[serde(default)]
+    pub facts: BTreeMap<String, AggregationKnowledge<bool>>,
 }
 
-#[derive(Clone, Debug, Serialize, PartialEq, Eq)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AggregationRelationFamily {
+    pub name: String,
+    pub scope: String,
+    pub completeness: Option<AggregationEvidence>,
+    #[serde(default)]
+    pub facts: Vec<AggregationRelationFact>,
+}
+
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AggregationRelationFact {
+    pub tuple: [String; 2],
+    pub knowledge: AggregationKnowledge<bool>,
+}
+
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "status", rename_all = "snake_case", deny_unknown_fields)]
+pub enum AggregationValue<T> {
+    Determined { value: T },
+    Indeterminate { reasons: BTreeSet<String> },
+}
+
+impl<T> AggregationValue<T> {
+    fn determined(value: T) -> Self {
+        Self::Determined { value }
+    }
+
+    fn indeterminate(reasons: BTreeSet<String>) -> Self {
+        Self::Indeterminate { reasons }
+    }
+}
+
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
 pub struct AggregationResult {
     pub schema: String,
     pub plan: String,
-    pub families: Vec<AggregatedFamily>,
-    pub trace_roots: Vec<String>,
+    pub plan_digest: String,
+    pub trace_root: String,
+    pub families: AggregationValue<Vec<AggregatedFamily>>,
 }
 
-#[derive(Clone, Debug, Serialize, PartialEq, Eq)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
 pub struct AggregatedFamily {
     pub id: String,
     pub members: Vec<String>,
-    pub partner_present: bool,
-    pub scalars: BTreeMap<String, String>,
-    pub counts: BTreeMap<String, i64>,
+    pub partner_present: AggregationValue<bool>,
+    pub scalars: BTreeMap<String, AggregationValue<String>>,
+    pub counts: BTreeMap<String, AggregationValue<i64>>,
+    pub predicates: BTreeMap<String, AggregationValue<bool>>,
     pub children: Vec<AggregatedChild>,
 }
 
-#[derive(Clone, Debug, Serialize, PartialEq, Eq)]
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
 pub struct AggregatedChild {
     pub person: String,
     pub family: String,
-    pub age_years: i64,
-    pub age_bands: BTreeMap<String, bool>,
-    pub scalars: BTreeMap<String, String>,
+    pub age_years: AggregationValue<i64>,
+    pub age_bands: BTreeMap<String, AggregationValue<bool>>,
+    pub scalars: BTreeMap<String, AggregationValue<String>>,
 }
 
-pub fn parse_aggregation_plan(source: &str) -> Result<AggregationPlan, UnitDerivationError> {
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CompiledAggregationArtifact {
+    pub format: String,
+    pub semantics_version: String,
+    pub plan_digest: String,
+    pub constitution_digest: String,
+    pub plan: AggregationPlan,
+    pub phase_two_artifact: crate::compile::CompiledProgramArtifact,
+}
+
+impl CompiledAggregationArtifact {
+    pub fn plan_id(&self) -> &str {
+        &self.plan.id
+    }
+
+    pub fn to_json_pretty(&self) -> Result<String, UnitDerivationError> {
+        serde_json::to_string_pretty(self).map_err(|error| {
+            UnitDerivationError::InvalidAggregationArtifact(format!(
+                "could not serialize compiled artifact: {error}"
+            ))
+        })
+    }
+
+    pub fn from_json_str(source: &str) -> Result<Self, UnitDerivationError> {
+        let artifact: Self = serde_json::from_str(source).map_err(|error| {
+            UnitDerivationError::InvalidAggregationArtifact(format!(
+                "could not deserialize compiled artifact: {error}"
+            ))
+        })?;
+        validate_compiled_artifact(artifact)
+    }
+
+    fn constitution_digest_bytes(&self) -> Result<[u8; 32], UnitDerivationError> {
+        decode_digest(&self.constitution_digest)
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct UnitDerivationDocumentRegistry {
+    aggregation: BTreeMap<String, CompiledAggregationArtifact>,
+}
+
+impl UnitDerivationDocumentRegistry {
+    pub fn register_aggregation_source(
+        &mut self,
+        source: &str,
+    ) -> Result<&CompiledAggregationArtifact, UnitDerivationError> {
+        let artifact = compile_aggregation_plan(source)?;
+        self.register_aggregation_artifact(artifact)
+    }
+
+    pub fn register_aggregation_json(
+        &mut self,
+        source: &str,
+    ) -> Result<&CompiledAggregationArtifact, UnitDerivationError> {
+        let artifact = CompiledAggregationArtifact::from_json_str(source)?;
+        self.register_aggregation_artifact(artifact)
+    }
+
+    pub fn register_aggregation_artifact(
+        &mut self,
+        artifact: CompiledAggregationArtifact,
+    ) -> Result<&CompiledAggregationArtifact, UnitDerivationError> {
+        let artifact = validate_compiled_artifact(artifact)?;
+        let id = artifact.plan.id.clone();
+        if self.aggregation.contains_key(&id) {
+            return Err(UnitDerivationError::DuplicateNamespace {
+                namespace: "compiled unit-derivation document",
+                id,
+            });
+        }
+        self.aggregation.insert(id.clone(), artifact);
+        Ok(&self.aggregation[&id])
+    }
+
+    pub fn aggregation(&self, id: &str) -> Option<&CompiledAggregationArtifact> {
+        self.aggregation.get(id)
+    }
+
+    pub fn execute_aggregation(
+        &self,
+        id: &str,
+        request: &AggregationRequest,
+        config: &UnitDerivationConfig,
+    ) -> Result<AggregationResult, UnitDerivationError> {
+        let artifact =
+            self.aggregation
+                .get(id)
+                .ok_or_else(|| UnitDerivationError::UnknownReference {
+                    from: "unit-derivation document registry".to_string(),
+                    reference: id.to_string(),
+                })?;
+        execute_aggregation_plan(artifact, request, config)
+    }
+}
+
+pub(crate) fn compile_aggregation_plan(
+    source: &str,
+) -> Result<CompiledAggregationArtifact, UnitDerivationError> {
     let plan: AggregationPlan = serde_yaml::from_str(source).map_err(|error| {
         UnitDerivationError::InvalidPlan(format!("invalid aggregation plan YAML: {error}"))
     })?;
+    compile_aggregation_plan_value(plan)
+}
+
+fn compile_aggregation_plan_value(
+    plan: AggregationPlan,
+) -> Result<CompiledAggregationArtifact, UnitDerivationError> {
     validate_aggregation_plan(&plan)?;
-    Ok(plan)
+    let phase_two_artifact = compile_phase_two_artifact(&plan)?;
+    let plan_digest = digest_text(&canonical_plan_bytes(&plan)?);
+    let constitution_digest = digest_text(&canonical_constitution_bytes(&plan)?);
+    Ok(CompiledAggregationArtifact {
+        format: COMPILED_AGGREGATION_ARTIFACT_FORMAT.to_string(),
+        semantics_version: super::EXPERIMENTAL_SEMANTICS_VERSION.to_string(),
+        plan_digest,
+        constitution_digest,
+        plan,
+        phase_two_artifact,
+    })
+}
+
+fn validate_compiled_artifact(
+    artifact: CompiledAggregationArtifact,
+) -> Result<CompiledAggregationArtifact, UnitDerivationError> {
+    if artifact.format != COMPILED_AGGREGATION_ARTIFACT_FORMAT {
+        return Err(UnitDerivationError::InvalidAggregationArtifact(format!(
+            "unsupported format `{}`",
+            artifact.format
+        )));
+    }
+    if artifact.semantics_version != super::EXPERIMENTAL_SEMANTICS_VERSION {
+        return Err(UnitDerivationError::InvalidAggregationArtifact(format!(
+            "unsupported semantics version `{}`",
+            artifact.semantics_version
+        )));
+    }
+    let expected = compile_aggregation_plan_value(artifact.plan.clone())?;
+    if artifact.plan_digest != expected.plan_digest {
+        return Err(UnitDerivationError::InvalidAggregationArtifact(
+            "advertised plan digest does not match the embedded plan".to_string(),
+        ));
+    }
+    if artifact.constitution_digest != expected.constitution_digest {
+        return Err(UnitDerivationError::InvalidAggregationArtifact(
+            "advertised constitution digest does not match the embedded plan".to_string(),
+        ));
+    }
+    let actual_phase = serde_json::to_value(&artifact.phase_two_artifact).map_err(|error| {
+        UnitDerivationError::InvalidAggregationArtifact(format!(
+            "could not inspect embedded phase-two artifact: {error}"
+        ))
+    })?;
+    let expected_phase = serde_json::to_value(&expected.phase_two_artifact).map_err(|error| {
+        UnitDerivationError::InvalidAggregationArtifact(format!(
+            "could not inspect regenerated phase-two artifact: {error}"
+        ))
+    })?;
+    if actual_phase != expected_phase {
+        return Err(UnitDerivationError::InvalidAggregationArtifact(
+            "embedded phase-two artifact does not match the registered plan".to_string(),
+        ));
+    }
+    // Run the production artifact loader as the final registry boundary. This
+    // is the same metadata/version/program validation used by run-compiled.
+    let phase_source = serde_json::to_string(&artifact.phase_two_artifact).map_err(|error| {
+        UnitDerivationError::InvalidAggregationArtifact(format!(
+            "could not serialize embedded phase-two artifact: {error}"
+        ))
+    })?;
+    crate::compile::CompiledProgramArtifact::from_json_str(&phase_source).map_err(|error| {
+        UnitDerivationError::InvalidAggregationArtifact(format!(
+            "production phase-two artifact validation failed: {error}"
+        ))
+    })?;
+    Ok(artifact)
+}
+
+fn compile_phase_two_artifact(
+    plan: &AggregationPlan,
+) -> Result<crate::compile::CompiledProgramArtifact, UnitDerivationError> {
+    let mut relations = plan
+        .membership_relations
+        .iter()
+        .map(|relation| crate::spec::RelationSpec {
+            name: relation.relation.clone(),
+            arity: 2,
+            slot_entities: vec!["Person".to_string(), "Person".to_string()],
+            derivation: None,
+        })
+        .collect::<Vec<_>>();
+    relations.push(crate::spec::RelationSpec {
+        name: plan.constitution.unit_constituent_relation.clone(),
+        arity: 2,
+        slot_entities: vec![plan.constitution.entity_type.clone(), "Person".to_string()],
+        derivation: None,
+    });
+    relations.push(crate::spec::RelationSpec {
+        name: plan.constitution.participating_member_relation.clone(),
+        arity: 2,
+        slot_entities: vec![plan.constitution.entity_type.clone(), "Person".to_string()],
+        derivation: None,
+    });
+    relations.sort_by(|left, right| left.name.cmp(&right.name));
+    let spec = crate::spec::ProgramSpec {
+        relations,
+        ..Default::default()
+    };
+    let compiled = crate::compile::CompiledProgramArtifact::compile(spec).map_err(|error| {
+        UnitDerivationError::InvalidAggregationArtifact(format!(
+            "phase-two program did not compile through the production path: {error}"
+        ))
+    })?;
+    let serialized = serde_json::to_string(&compiled).map_err(|error| {
+        UnitDerivationError::InvalidAggregationArtifact(format!(
+            "phase-two program did not serialize: {error}"
+        ))
+    })?;
+    crate::compile::CompiledProgramArtifact::from_json_str(&serialized).map_err(|error| {
+        UnitDerivationError::InvalidAggregationArtifact(format!(
+            "phase-two program did not reload through the production path: {error}"
+        ))
+    })
 }
 
 fn validate_aggregation_plan(plan: &AggregationPlan) -> Result<(), UnitDerivationError> {
@@ -195,6 +822,8 @@ fn validate_aggregation_plan(plan: &AggregationPlan) -> Result<(), UnitDerivatio
         || plan.constitution.id.is_empty()
         || plan.constitution.entity_type.is_empty()
         || plan.constitution.roster_relation.is_empty()
+        || plan.constitution.unit_constituent_relation.is_empty()
+        || plan.constitution.participating_member_relation.is_empty()
     {
         return Err(UnitDerivationError::InvalidPlan(
             "aggregation plan and constitution identities must be non-empty".to_string(),
@@ -205,34 +834,208 @@ fn validate_aggregation_plan(plan: &AggregationPlan) -> Result<(), UnitDerivatio
             "aggregation decimal_precision must be positive".to_string(),
         ));
     }
-    let mut relations = BTreeSet::new();
+
+    // This check deliberately precedes all new-schema required-field checks.
+    // The committed reviewer fixture used the old accepted shape and must be
+    // rejected for the semantic grammar hole, not merely for missing new keys.
+    let mut reduction_consumers = BTreeMap::<String, String>::new();
+    for reduction in &plan.family_reductions {
+        let key = reduction
+            .reduction_key
+            .clone()
+            .unwrap_or_else(|| "untyped-family-scope".to_string());
+        if let Some(first) = reduction_consumers.insert(key.clone(), reduction.output.clone()) {
+            return Err(UnitDerivationError::DuplicateFamilyScopeReduction {
+                key,
+                first,
+                second: reduction.output.clone(),
+            });
+        }
+    }
+
+    validate_citation(&plan.partner_presence.citation, "partner presence")?;
+    validate_citation(&plan.adult_selection.citation, "adult selection")?;
+    validate_citation(&plan.age_18_conditions.citation, "age-18 conditions")?;
+    validate_citation(&plan.care.citation, "care semantics")?;
+    if plan.partner_presence.entitlement_holder_input.is_empty()
+        || plan.partner_presence.caller_determination.is_empty()
+    {
+        return Err(UnitDerivationError::InvalidPlan(
+            "partner presence requires an explicit entitlement-holder input and caller-determination statement"
+                .to_string(),
+        ));
+    }
+    if plan.adult_selection.operation != AdultSelectionOperation::ExplicitPersonRole
+        || plan.adult_selection.caller_determination.is_empty()
+    {
+        return Err(UnitDerivationError::InvalidPlan(
+            "adult selection requires an explicit evidence-bearing person role and caller-determination statement"
+                .to_string(),
+        ));
+    }
+    if plan.age_18_conditions.age != 18
+        || plan
+            .age_18_conditions
+            .not_financially_independent_input
+            .is_empty()
+        || plan
+            .age_18_conditions
+            .attending_school_or_tertiary_input
+            .is_empty()
+        || plan.age_18_conditions.commissioner_period_input.is_empty()
+    {
+        return Err(UnitDerivationError::InvalidPlan(
+            "MC 9 age-18 conditions must explicitly name financial-dependence, education, and Commissioner-period inputs"
+                .to_string(),
+        ));
+    }
+    if plan.care.principal_care_input.is_empty()
+        || plan.care.claimant_care_fraction_input.is_empty()
+    {
+        return Err(UnitDerivationError::InvalidPlan(
+            "care semantics must explicitly name principal-care and claimant-care-fraction inputs"
+                .to_string(),
+        ));
+    }
+
+    let mut inputs = BTreeMap::new();
+    for input in &plan.inputs {
+        validate_citation(&input.citation, &format!("input `{}`", input.name))?;
+        if input.name.is_empty() || inputs.insert(input.name.clone(), input).is_some() {
+            return Err(UnitDerivationError::DuplicateNamespace {
+                namespace: "aggregation input",
+                id: input.name.clone(),
+            });
+        }
+        if matches!(
+            input.kind,
+            AggregationInputKind::ChildGrossAmount | AggregationInputKind::FamilyAdjustment
+        ) && input.reduction_key.as_deref().is_none_or(str::is_empty)
+        {
+            return Err(UnitDerivationError::InvalidPlan(format!(
+                "typed reduction input `{}` needs a non-empty reduction_key",
+                input.name
+            )));
+        }
+    }
+
+    validate_input_ref(
+        &inputs,
+        &plan.age_18_conditions.not_financially_independent_input,
+        "MC 9 financial-dependence condition",
+        AggregationInputScope::Child,
+        AggregationInputKind::EligibilityBoolean,
+    )?;
+    validate_input_ref(
+        &inputs,
+        &plan.age_18_conditions.attending_school_or_tertiary_input,
+        "MC 9 education condition",
+        AggregationInputScope::Child,
+        AggregationInputKind::EligibilityBoolean,
+    )?;
+    validate_input_ref(
+        &inputs,
+        &plan.age_18_conditions.commissioner_period_input,
+        "MC 9 Commissioner-period condition",
+        AggregationInputScope::Child,
+        AggregationInputKind::EligibilityBoolean,
+    )?;
+    validate_input_ref(
+        &inputs,
+        &plan.care.principal_care_input,
+        "principal-care condition",
+        AggregationInputScope::Child,
+        AggregationInputKind::EligibilityBoolean,
+    )?;
+    validate_input_ref(
+        &inputs,
+        &plan.care.claimant_care_fraction_input,
+        "MG 2(5) claimant-care fraction",
+        AggregationInputScope::Child,
+        AggregationInputKind::CareFraction,
+    )?;
+
+    let mut relations = BTreeMap::new();
     for relation in &plan.membership_relations {
-        if relation.relation.is_empty() || !relations.insert(relation.relation.clone()) {
+        validate_citation(
+            &relation.citation,
+            &format!("membership relation `{}`", relation.relation),
+        )?;
+        if relation.relation.is_empty()
+            || relations
+                .insert(relation.relation.clone(), relation)
+                .is_some()
+        {
             return Err(UnitDerivationError::DuplicateNamespace {
                 namespace: "aggregation membership relation",
                 id: relation.relation.clone(),
             });
         }
-        if relation.citation.provision.is_empty() || relation.citation.authority.is_empty() {
+        if relation.direction.is_some() && relation.symmetric.is_some() {
             return Err(UnitDerivationError::InvalidPlan(format!(
-                "membership relation `{}` needs a complete citation",
+                "membership relation `{}` supplies both direction and legacy symmetric",
+                relation.relation
+            )));
+        }
+        if relation.effective_direction().is_none()
+            || relation.left_role.is_none()
+            || relation.right_role.is_none()
+        {
+            return Err(UnitDerivationError::InvalidPlan(format!(
+                "membership relation `{}` must declare direction and both tuple roles",
                 relation.relation
             )));
         }
     }
-    for required in [&plan.partner_relation, &plan.child_relation] {
-        if !relations.contains(required) {
-            return Err(UnitDerivationError::UnknownReference {
-                from: plan.id.clone(),
-                reference: required.clone(),
-            });
+    let partner = relations.get(&plan.partner_relation).ok_or_else(|| {
+        UnitDerivationError::UnknownReference {
+            from: plan.id.clone(),
+            reference: plan.partner_relation.clone(),
         }
+    })?;
+    if partner.effective_direction() != Some(RelationDirection::Symmetric)
+        || partner.left_role != Some(MembershipRole::Partner)
+        || partner.right_role != Some(MembershipRole::Partner)
+    {
+        return Err(UnitDerivationError::InvalidPlan(
+            "partner relation must be symmetric with partner/partner roles".to_string(),
+        ));
+    }
+    let child = relations.get(&plan.child_relation).ok_or_else(|| {
+        UnitDerivationError::UnknownReference {
+            from: plan.id.clone(),
+            reference: plan.child_relation.clone(),
+        }
+    })?;
+    if child.effective_direction() != Some(RelationDirection::Directed)
+        || child.left_role != Some(MembershipRole::Caregiver)
+        || child.right_role != Some(MembershipRole::Child)
+    {
+        return Err(UnitDerivationError::InvalidPlan(
+            "child relation must be directed caregiver-to-child".to_string(),
+        ));
     }
 
     let mut outputs = BTreeSet::new();
     for aggregation in &plan.scalar_aggregations {
         validate_citation(&aggregation.citation, &aggregation.output)?;
         insert_output(&mut outputs, &aggregation.output)?;
+        if aggregation.selector != AggregateSelector::Adults {
+            return Err(UnitDerivationError::InvalidAggregationOperand {
+                operation: aggregation.output.clone(),
+                input: aggregation.input.clone(),
+                expected: "adult-scoped additive amount".to_string(),
+                found: "all-members scalar aggregation can consume child-carried reductions"
+                    .to_string(),
+            });
+        }
+        validate_input_ref(
+            &inputs,
+            &aggregation.input,
+            &aggregation.output,
+            AggregationInputScope::Adult,
+            AggregationInputKind::AdditiveAmount,
+        )?;
     }
     for count in &plan.child_counts {
         validate_citation(&count.citation, &count.output)?;
@@ -241,11 +1044,121 @@ fn validate_aggregation_plan(plan: &AggregationPlan) -> Result<(), UnitDerivatio
     }
     for minimum in &plan.child_minima {
         validate_citation(&minimum.citation, &minimum.output)?;
+        if minimum.input != "age_years" {
+            return Err(UnitDerivationError::InvalidPlan(format!(
+                "child minimum `{}` uses unsupported input `{}`",
+                minimum.output, minimum.input
+            )));
+        }
         insert_output(&mut outputs, &minimum.output)?;
+    }
+    let count_outputs = plan
+        .child_counts
+        .iter()
+        .map(|count| count.output.as_str())
+        .collect::<BTreeSet<_>>();
+    let minimum_outputs = plan
+        .child_minima
+        .iter()
+        .map(|minimum| minimum.output.as_str())
+        .collect::<BTreeSet<_>>();
+    for predicate in &plan.family_predicates {
+        validate_citation(&predicate.citation, &predicate.output)?;
+        let (count, youngest) = match &predicate.operation {
+            FamilyPredicateOperation::CountAtLeast { count, .. }
+            | FamilyPredicateOperation::SoleParentWithChildren { count } => {
+                (Some(count.as_str()), None)
+            }
+            FamilyPredicateOperation::YoungestAgeAtLeast { youngest, .. } => {
+                (None, Some(youngest.as_str()))
+            }
+            FamilyPredicateOperation::SoleParentYoungestAgeAtLeast {
+                count, youngest, ..
+            } => (Some(count.as_str()), Some(youngest.as_str())),
+        };
+        if count.is_some_and(|name| !count_outputs.contains(name))
+            || youngest.is_some_and(|name| !minimum_outputs.contains(name))
+        {
+            return Err(UnitDerivationError::UnknownReference {
+                from: predicate.output.clone(),
+                reference: count.or(youngest).unwrap_or_default().to_string(),
+            });
+        }
+        insert_output(&mut outputs, &predicate.output)?;
+    }
+    for scalar in &plan.family_shape_scalars {
+        validate_citation(&scalar.citation, &scalar.output)?;
+        let count = match &scalar.operation {
+            FamilyShapeScalarOperation::EldestCareUnits { count }
+            | FamilyShapeScalarOperation::SubsequentCareUnits { count }
+            | FamilyShapeScalarOperation::FixedIfChildren { count, .. } => count,
+        };
+        if !count_outputs.contains(count.as_str()) {
+            return Err(UnitDerivationError::UnknownReference {
+                from: scalar.output.clone(),
+                reference: count.clone(),
+            });
+        }
+        insert_output(&mut outputs, &scalar.output)?;
+    }
+    for agreement in &plan.child_agreements {
+        validate_citation(&agreement.citation, &agreement.output)?;
+        insert_output(&mut outputs, &agreement.output)?;
+        validate_input_ref(
+            &inputs,
+            &agreement.input,
+            &agreement.output,
+            AggregationInputScope::Child,
+            AggregationInputKind::CareFraction,
+        )?;
+        if let Some(condition) = &agreement.eligible_if {
+            validate_input_ref(
+                &inputs,
+                condition,
+                &agreement.output,
+                AggregationInputScope::Child,
+                AggregationInputKind::EligibilityBoolean,
+            )?;
+        }
+    }
+    for projection in &plan.child_projections {
+        validate_citation(&projection.citation, &projection.output)?;
+        insert_output(&mut outputs, &projection.output)?;
+        let input =
+            inputs
+                .get(&projection.input)
+                .ok_or_else(|| UnitDerivationError::UnknownReference {
+                    from: projection.output.clone(),
+                    reference: projection.input.clone(),
+                })?;
+        if input.scope != AggregationInputScope::Child
+            || input.kind == AggregationInputKind::EligibilityBoolean
+        {
+            return invalid_operand(
+                &projection.output,
+                &projection.input,
+                "Child-scoped scalar input",
+                input,
+            );
+        }
     }
     for broadcast in &plan.broadcasts {
         validate_citation(&broadcast.citation, &broadcast.output)?;
         insert_output(&mut outputs, &broadcast.output)?;
+        let input = inputs.get(&broadcast.family_input).ok_or_else(|| {
+            UnitDerivationError::UnknownReference {
+                from: broadcast.output.clone(),
+                reference: broadcast.family_input.clone(),
+            }
+        })?;
+        if input.scope != AggregationInputScope::Family {
+            return invalid_operand(
+                &broadcast.output,
+                &broadcast.family_input,
+                "family-scoped input",
+                input,
+            );
+        }
     }
     for reduction in &plan.family_reductions {
         validate_citation(&reduction.citation, &reduction.output)?;
@@ -256,19 +1169,152 @@ fn validate_aggregation_plan(plan: &AggregationPlan) -> Result<(), UnitDerivatio
         )?;
         insert_output(&mut outputs, &reduction.output)?;
         insert_output(&mut outputs, &reduction.gross_output)?;
-        if plan.scalar_aggregations.iter().any(|aggregation| {
-            aggregation.input == reduction.child_value
-                || aggregation.input == reduction.family_once_value
-                || aggregation.output == reduction.output
-                || aggregation.output == reduction.gross_output
-        }) {
-            return Err(UnitDerivationError::InvalidPlan(format!(
-                "family-once reduction `{}` reserves its child, abatement, and output fields from ordinary scalar aggregation",
-                reduction.output
-            )));
+        let key = reduction.reduction_key.as_deref().unwrap_or_default();
+        if key.is_empty()
+            || reduction.child_value.is_some()
+            || reduction.family_once_value.is_some()
+            || reduction
+                .child_gross_input
+                .as_deref()
+                .is_none_or(str::is_empty)
+            || reduction
+                .family_adjustment_input
+                .as_deref()
+                .is_none_or(str::is_empty)
+        {
+            return Err(UnitDerivationError::InvalidAggregationOperand {
+                operation: reduction.output.clone(),
+                input: reduction
+                    .family_once_value
+                    .clone()
+                    .or_else(|| reduction.family_adjustment_input.clone())
+                    .unwrap_or_default(),
+                expected:
+                    "one registered Family-scoped adjustment and one typed ChildGross operand"
+                        .to_string(),
+                found: "legacy child-carried or untyped family-once operand".to_string(),
+            });
+        }
+        let child_input = inputs
+            .get(reduction.child_gross_input.as_deref().unwrap())
+            .ok_or_else(|| UnitDerivationError::UnknownReference {
+                from: reduction.output.clone(),
+                reference: reduction.child_gross_input.clone().unwrap_or_default(),
+            })?;
+        if child_input.scope != AggregationInputScope::Child
+            || child_input.kind != AggregationInputKind::ChildGrossAmount
+            || child_input.reduction_key.as_deref() != Some(key)
+        {
+            return invalid_operand(
+                &reduction.output,
+                &child_input.name,
+                &format!("ChildGross({key})"),
+                child_input,
+            );
+        }
+        let adjustment = inputs
+            .get(reduction.family_adjustment_input.as_deref().unwrap())
+            .ok_or_else(|| UnitDerivationError::UnknownReference {
+                from: reduction.output.clone(),
+                reference: reduction
+                    .family_adjustment_input
+                    .clone()
+                    .unwrap_or_default(),
+            })?;
+        if adjustment.scope != AggregationInputScope::Family
+            || adjustment.kind != AggregationInputKind::FamilyAdjustment
+            || adjustment.reduction_key.as_deref() != Some(key)
+        {
+            return invalid_operand(
+                &reduction.output,
+                &adjustment.name,
+                &format!("FamilyAdjustment({key})"),
+                adjustment,
+            );
+        }
+        if reduction.care_fraction_input.as_deref()
+            != Some(plan.care.claimant_care_fraction_input.as_str())
+        {
+            return Err(UnitDerivationError::InvalidAggregationOperand {
+                operation: reduction.output.clone(),
+                input: reduction.care_fraction_input.clone().unwrap_or_default(),
+                expected: format!(
+                    "MG 2(5) care input `{}`",
+                    plan.care.claimant_care_fraction_input
+                ),
+                found: "missing or different care operand".to_string(),
+            });
+        }
+        if let Some(continuous) = &reduction.continuous {
+            insert_output(&mut outputs, &continuous.output)?;
+            validate_input_ref(
+                &inputs,
+                &continuous.family_income_input,
+                &continuous.output,
+                AggregationInputScope::Family,
+                AggregationInputKind::FamilyAmount,
+            )?;
+            validate_input_ref(
+                &inputs,
+                &continuous.threshold_input,
+                &continuous.output,
+                AggregationInputScope::Family,
+                AggregationInputKind::FamilyAmount,
+            )?;
+            validate_input_ref(
+                &inputs,
+                &continuous.rate_input,
+                &continuous.output,
+                AggregationInputScope::Family,
+                AggregationInputKind::DecimalRate,
+            )?;
+        }
+    }
+    for limitation in &plan.limitations {
+        validate_citation(
+            &limitation.citation,
+            &format!("limitation `{}`", limitation.id),
+        )?;
+        if limitation.id.is_empty() || limitation.statement.is_empty() {
+            return Err(UnitDerivationError::InvalidPlan(
+                "declared limitations require non-empty ids and statements".to_string(),
+            ));
         }
     }
     Ok(())
+}
+
+fn validate_input_ref(
+    inputs: &BTreeMap<String, &AggregationInput>,
+    name: &str,
+    operation: &str,
+    scope: AggregationInputScope,
+    kind: AggregationInputKind,
+) -> Result<(), UnitDerivationError> {
+    let input = inputs
+        .get(name)
+        .ok_or_else(|| UnitDerivationError::UnknownReference {
+            from: operation.to_string(),
+            reference: name.to_string(),
+        })?;
+    if input.scope != scope || input.kind != kind {
+        return invalid_operand(operation, name, &format!("{scope:?}/{kind:?}"), input);
+    }
+    Ok(())
+}
+
+fn invalid_operand<T>(
+    operation: &str,
+    input_name: &str,
+    expected: &str,
+    input: &AggregationInput,
+) -> Result<T, UnitDerivationError> {
+    Err(UnitDerivationError::InvalidAggregationOperand {
+        operation: operation.to_string(),
+        input: input_name.to_string(),
+        expected: expected.to_string(),
+        found: format!("{:?}/{:?}", input.scope, input.kind),
+    })
 }
 
 fn validate_citation(
@@ -309,72 +1355,516 @@ fn validate_age_range(
     Ok(())
 }
 
-pub fn execute_aggregation_plan(
-    plan: &AggregationPlan,
+fn normalized_plan(plan: &AggregationPlan) -> AggregationPlan {
+    let mut normalized = plan.clone();
+    normalized
+        .inputs
+        .sort_by(|left, right| left.name.cmp(&right.name));
+    normalized
+        .membership_relations
+        .sort_by(|left, right| left.relation.cmp(&right.relation));
+    normalized
+        .scalar_aggregations
+        .sort_by(|left, right| left.output.cmp(&right.output));
+    normalized
+        .child_counts
+        .sort_by(|left, right| left.output.cmp(&right.output));
+    normalized
+        .child_minima
+        .sort_by(|left, right| left.output.cmp(&right.output));
+    normalized
+        .family_predicates
+        .sort_by(|left, right| left.output.cmp(&right.output));
+    normalized
+        .family_shape_scalars
+        .sort_by(|left, right| left.output.cmp(&right.output));
+    normalized
+        .child_agreements
+        .sort_by(|left, right| left.output.cmp(&right.output));
+    normalized
+        .child_projections
+        .sort_by(|left, right| left.output.cmp(&right.output));
+    normalized
+        .broadcasts
+        .sort_by(|left, right| left.output.cmp(&right.output));
+    normalized
+        .family_reductions
+        .sort_by(|left, right| left.output.cmp(&right.output));
+    normalized
+        .limitations
+        .sort_by(|left, right| left.id.cmp(&right.id));
+    normalized
+}
+
+fn canonical_plan_bytes(plan: &AggregationPlan) -> Result<Vec<u8>, UnitDerivationError> {
+    let normalized = normalized_plan(plan);
+    let mut bytes = b"axiom.unit-aggregation.plan.stage3\0".to_vec();
+    bytes.extend(serde_json::to_vec(&normalized).map_err(|error| {
+        UnitDerivationError::InvalidAggregationArtifact(format!(
+            "could not canonically encode plan: {error}"
+        ))
+    })?);
+    Ok(bytes)
+}
+
+fn canonical_constitution_bytes(plan: &AggregationPlan) -> Result<Vec<u8>, UnitDerivationError> {
+    let normalized = normalized_plan(plan);
+    let value = serde_json::json!({
+        "constitution": normalized.constitution,
+        "membership_relations": normalized.membership_relations,
+        "partner_relation": normalized.partner_relation,
+        "child_relation": normalized.child_relation,
+        "partner_presence": normalized.partner_presence,
+        "adult_selection": normalized.adult_selection,
+        "age_18_conditions": normalized.age_18_conditions,
+        "care": normalized.care,
+    });
+    let mut bytes = b"axiom.unit-aggregation.constitution.stage3\0".to_vec();
+    bytes.extend(serde_json::to_vec(&value).map_err(|error| {
+        UnitDerivationError::InvalidAggregationArtifact(format!(
+            "could not canonically encode constitution: {error}"
+        ))
+    })?);
+    Ok(bytes)
+}
+
+fn digest_text(bytes: &[u8]) -> String {
+    format!("sha256:{}", hex(&super::evaluate::sha256(bytes)))
+}
+
+fn decode_digest(value: &str) -> Result<[u8; 32], UnitDerivationError> {
+    let raw = value.strip_prefix("sha256:").ok_or_else(|| {
+        UnitDerivationError::InvalidAggregationArtifact(format!(
+            "digest `{value}` lacks sha256 prefix"
+        ))
+    })?;
+    if raw.len() != 64 {
+        return Err(UnitDerivationError::InvalidAggregationArtifact(format!(
+            "digest `{value}` is not 32 bytes"
+        )));
+    }
+    let mut output = [0_u8; 32];
+    for (index, slot) in output.iter_mut().enumerate() {
+        *slot = u8::from_str_radix(&raw[index * 2..index * 2 + 2], 16).map_err(|_| {
+            UnitDerivationError::InvalidAggregationArtifact(format!(
+                "digest `{value}` is not hexadecimal"
+            ))
+        })?;
+    }
+    Ok(output)
+}
+
+fn hex(bytes: &[u8]) -> String {
+    const DIGITS: &[u8; 16] = b"0123456789abcdef";
+    let mut output = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        output.push(DIGITS[(byte >> 4) as usize] as char);
+        output.push(DIGITS[(byte & 0x0f) as usize] as char);
+    }
+    output
+}
+
+pub(crate) fn execute_aggregation_plan(
+    artifact: &CompiledAggregationArtifact,
     request: &AggregationRequest,
     config: &UnitDerivationConfig,
 ) -> Result<AggregationResult, UnitDerivationError> {
-    validate_aggregation_plan(plan)?;
-    let people = request
-        .persons
+    if !config.enabled {
+        return Err(UnitDerivationError::Disabled);
+    }
+    let artifact = validate_compiled_artifact(artifact.clone())?;
+    let plan = &artifact.plan;
+    let people = validate_request(plan, request)?;
+
+    let relation_reasons = request
+        .relations
         .iter()
-        .map(|person| (person.id.clone(), person))
-        .collect::<BTreeMap<_, _>>();
-    if people.len() != request.persons.len() {
-        return Err(UnitDerivationError::DuplicateNamespace {
-            namespace: "aggregation person",
-            id: request
-                .persons
-                .iter()
-                .find(|person| {
-                    request
-                        .persons
-                        .iter()
-                        .filter(|other| other.id == person.id)
-                        .count()
-                        > 1
-                })
-                .map(|person| person.id.clone())
-                .unwrap_or_default(),
+        .flat_map(|family| {
+            family.facts.iter().flat_map(|fact| {
+                resolve_knowledge(
+                    Some(&fact.knowledge),
+                    &format!(
+                        "relation:{}:{}:{}",
+                        family.name, fact.tuple[0], fact.tuple[1]
+                    ),
+                )
+                .err()
+                .into_iter()
+                .flatten()
+            })
+        })
+        .collect::<BTreeSet<_>>();
+    if !relation_reasons.is_empty() {
+        let families = AggregationValue::indeterminate(relation_reasons);
+        let trace_root = aggregation_trace_root(&artifact, request, "", &families)?;
+        return Ok(AggregationResult {
+            schema: super::EXPERIMENTAL_AGGREGATION_PLAN_SCHEMA.to_string(),
+            plan: plan.id.clone(),
+            plan_digest: artifact.plan_digest.clone(),
+            trace_root,
+            families,
         });
     }
-    if !people.contains_key(&request.primary_person) {
-        return Err(UnitDerivationError::InvalidPlan(format!(
-            "primary person `{}` is outside the roster",
-            request.primary_person
-        )));
+
+    if request.segment_completeness.is_none() {
+        let reasons = BTreeSet::from([format!("segment-completeness:{}", request.segment)]);
+        let families = AggregationValue::indeterminate(reasons);
+        let trace_root = aggregation_trace_root(&artifact, request, "", &families)?;
+        return Ok(AggregationResult {
+            schema: super::EXPERIMENTAL_AGGREGATION_PLAN_SCHEMA.to_string(),
+            plan: plan.id.clone(),
+            plan_digest: artifact.plan_digest.clone(),
+            trace_root,
+            families,
+        });
     }
-    if request.scope.is_empty() || request.segment.is_empty() || people.is_empty() {
+
+    let (mut compiled, input) = bind_constitution(&artifact, request, &people)?;
+    // Roster grounding is request-specific, but family identity is defined by
+    // the registered constitution semantics, not by the N-person grounding.
+    compiled.semantics_digest = artifact.constitution_digest_bytes()?;
+    let prototype = super::Prototype::new(
+        compiled,
+        config.clone(),
+        super::FrozenLedger::new(Vec::new())?,
+    );
+    let run = prototype.run(&input, &[], None)?;
+    if !run.derivation.indeterminate.is_empty() {
+        let reasons = run
+            .derivation
+            .indeterminate
+            .iter()
+            .flat_map(|item| item.unresolved_facts.iter().cloned())
+            .collect::<BTreeSet<_>>();
+        let families = AggregationValue::indeterminate(if reasons.is_empty() {
+            BTreeSet::from(["indeterminate-family-membership".to_string()])
+        } else {
+            reasons
+        });
+        let trace_root =
+            aggregation_trace_root(&artifact, request, &run.derivation.trace.root, &families)?;
+        return Ok(AggregationResult {
+            schema: super::EXPERIMENTAL_AGGREGATION_PLAN_SCHEMA.to_string(),
+            plan: plan.id.clone(),
+            plan_digest: artifact.plan_digest.clone(),
+            trace_root,
+            families,
+        });
+    }
+
+    let program = artifact
+        .phase_two_artifact
+        .program
+        .to_program()
+        .map_err(|error| {
+            UnitDerivationError::InvalidAggregationArtifact(format!(
+                "registered phase-two program did not materialize: {error}"
+            ))
+        })?;
+    let interval = parse_segment_interval(&request.segment)?;
+    let (base, input_knowledge) =
+        bind_aggregation_dataset(plan, request, &people, &run.derivation.units, &interval)?;
+    let phase_two = super::materialize_phase_two_dataset_with_knowledge(
+        &base,
+        input_knowledge,
+        &program,
+        &input,
+        &run,
+        interval.clone(),
+    )?;
+    for person in people.keys() {
+        if phase_two.registry().get(person).is_none() {
+            return Err(UnitDerivationError::InvalidPlan(format!(
+                "typed materialization registry omitted person `{person}`"
+            )));
+        }
+    }
+    for unit in &run.derivation.units {
+        if phase_two.registry().get(&unit.id).is_none() {
+            return Err(UnitDerivationError::InvalidPlan(format!(
+                "typed materialization registry omitted family `{}`",
+                unit.id
+            )));
+        }
+    }
+
+    let period = crate::model::Period {
+        kind: crate::model::PeriodKind::Custom("unit-aggregation".to_string()),
+        start: interval.start,
+        end: interval.end,
+    };
+    let role_index = RelationshipRoleIndex::new(plan, &phase_two, &period)?;
+    let mut families = run
+        .derivation
+        .units
+        .iter()
+        .map(|unit| aggregate_family(plan, &phase_two, &period, &role_index, unit))
+        .collect::<Result<Vec<_>, _>>()?;
+    families.sort_by(|left, right| left.id.cmp(&right.id));
+    let families = AggregationValue::determined(families);
+    let trace_root =
+        aggregation_trace_root(&artifact, request, &run.derivation.trace.root, &families)?;
+    Ok(AggregationResult {
+        schema: super::EXPERIMENTAL_AGGREGATION_PLAN_SCHEMA.to_string(),
+        plan: plan.id.clone(),
+        plan_digest: artifact.plan_digest,
+        trace_root,
+        families,
+    })
+}
+
+fn validate_request<'a>(
+    plan: &AggregationPlan,
+    request: &'a AggregationRequest,
+) -> Result<BTreeMap<String, &'a AggregationPerson>, UnitDerivationError> {
+    if request.scope.is_empty() || request.segment.is_empty() || request.persons.is_empty() {
         return Err(UnitDerivationError::InvalidPlan(
             "aggregation scope, segment, and roster must be non-empty".to_string(),
         ));
     }
-
-    let relation_plans = plan
-        .membership_relations
-        .iter()
-        .map(|relation| (relation.relation.as_str(), relation))
-        .collect::<BTreeMap<_, _>>();
-    for (name, tuples) in &request.relations {
-        if !relation_plans.contains_key(name.as_str()) {
-            return Err(UnitDerivationError::UnknownReference {
-                from: "aggregation request relation".to_string(),
-                reference: name.clone(),
+    let mut people = BTreeMap::new();
+    for person in &request.persons {
+        if person.id.is_empty() || person.evidence.id.is_empty() {
+            return Err(UnitDerivationError::InvalidPlan(
+                "every aggregation person needs a non-empty id and evidence id".to_string(),
+            ));
+        }
+        if people.insert(person.id.clone(), person).is_some() {
+            return Err(UnitDerivationError::DuplicateNamespace {
+                namespace: "aggregation person",
+                id: person.id.clone(),
             });
         }
-        for tuple in tuples {
-            if tuple[0] == tuple[1]
-                || !people.contains_key(&tuple[0])
-                || !people.contains_key(&tuple[1])
+    }
+    let declared_inputs = plan
+        .inputs
+        .iter()
+        .map(|input| (input.name.as_str(), input))
+        .collect::<BTreeMap<_, _>>();
+    for person in people.values() {
+        if let Some(age) = &person.age_years {
+            validate_knowledge_evidence(age, &format!("person `{}` age", person.id))?;
+        }
+        for name in person.scalars.keys().chain(person.facts.keys()) {
+            if !declared_inputs.contains_key(name.as_str()) {
+                return Err(UnitDerivationError::UnknownReference {
+                    from: format!("aggregation person `{}`", person.id),
+                    reference: name.clone(),
+                });
+            }
+        }
+        for name in person.facts.keys() {
+            let input = declared_inputs[name.as_str()];
+            validate_knowledge_evidence(
+                &person.facts[name],
+                &format!("person `{}` fact `{name}`", person.id),
+            )?;
+            if input.kind != AggregationInputKind::EligibilityBoolean {
+                return invalid_operand(
+                    &format!("person `{}` fact", person.id),
+                    name,
+                    "eligibility boolean",
+                    input,
+                );
+            }
+            if input.scope != AggregationInputScope::Child
+                || person.role != AggregationPersonRole::Child
             {
-                return Err(UnitDerivationError::InvalidPlan(format!(
-                    "relation `{name}` contains invalid roster tuple {:?}",
-                    tuple
-                )));
+                return invalid_operand(
+                    &format!("person `{}` fact", person.id),
+                    name,
+                    "Child-scoped eligibility boolean on an explicit child role",
+                    input,
+                );
+            }
+        }
+        for name in person.scalars.keys() {
+            let input = declared_inputs[name.as_str()];
+            validate_knowledge_evidence(
+                &person.scalars[name],
+                &format!("person `{}` scalar `{name}`", person.id),
+            )?;
+            if input.kind == AggregationInputKind::EligibilityBoolean {
+                return invalid_operand(
+                    &format!("person `{}` scalar", person.id),
+                    name,
+                    "numeric scalar",
+                    input,
+                );
+            }
+            let expected_role = match input.scope {
+                AggregationInputScope::Adult => AggregationPersonRole::Adult,
+                AggregationInputScope::Child => AggregationPersonRole::Child,
+                AggregationInputScope::Family => {
+                    return invalid_operand(
+                        &format!("person `{}` scalar", person.id),
+                        name,
+                        "Adult or Child scope",
+                        input,
+                    );
+                }
+            };
+            if person.role != expected_role {
+                return Err(UnitDerivationError::InvalidRelationshipRole {
+                    relation: "explicit_person_role".to_string(),
+                    person: person.id.clone(),
+                    role: format!("{:?}", person.role),
+                });
             }
         }
     }
+    let mut family_anchors = BTreeSet::new();
+    for family in &request.family_inputs {
+        if family.anchor_person.is_empty()
+            || family.evidence.id.is_empty()
+            || !people.contains_key(&family.anchor_person)
+        {
+            return Err(UnitDerivationError::InvalidPlan(format!(
+                "family input anchor `{}` and its evidence must identify a roster person",
+                family.anchor_person
+            )));
+        }
+        if !family_anchors.insert(family.anchor_person.clone()) {
+            return Err(UnitDerivationError::DuplicateNamespace {
+                namespace: "aggregation family input anchor",
+                id: family.anchor_person.clone(),
+            });
+        }
+        if family.named_people.len() != 1
+            || !family
+                .named_people
+                .contains_key(&plan.partner_presence.entitlement_holder_input)
+        {
+            return Err(UnitDerivationError::InvalidPlan(format!(
+                "family input `{}` must bind exactly the plan input `{}`",
+                family.anchor_person, plan.partner_presence.entitlement_holder_input
+            )));
+        }
+        let holder_knowledge =
+            &family.named_people[&plan.partner_presence.entitlement_holder_input];
+        validate_knowledge_evidence(
+            holder_knowledge,
+            &format!("family `{}` entitlement holder", family.anchor_person),
+        )?;
+        if let Ok(holder) = resolve_knowledge(
+            Some(holder_knowledge),
+            &format!("family:{}:entitlement-holder", family.anchor_person),
+        ) {
+            let Some(person) = people.get(&holder) else {
+                return Err(UnitDerivationError::InvalidPlan(format!(
+                    "entitlement holder `{holder}` is outside the roster"
+                )));
+            };
+            if person.role != AggregationPersonRole::Adult {
+                return Err(UnitDerivationError::InvalidRelationshipRole {
+                    relation: plan.partner_relation.clone(),
+                    person: holder,
+                    role: "entitlement_holder_must_be_adult".to_string(),
+                });
+            }
+        }
+        for name in family.scalars.keys() {
+            let input = declared_inputs.get(name.as_str()).ok_or_else(|| {
+                UnitDerivationError::UnknownReference {
+                    from: format!("aggregation family `{}` scalar", family.anchor_person),
+                    reference: name.clone(),
+                }
+            })?;
+            if input.scope != AggregationInputScope::Family {
+                return invalid_operand(
+                    &format!("aggregation family `{}` scalar", family.anchor_person),
+                    name,
+                    "Family scope",
+                    input,
+                );
+            }
+            validate_knowledge_evidence(
+                &family.scalars[name],
+                &format!("family `{}` scalar `{name}`", family.anchor_person),
+            )?;
+        }
+    }
 
+    let declared_relations = plan
+        .membership_relations
+        .iter()
+        .map(|relation| relation.relation.as_str())
+        .collect::<BTreeSet<_>>();
+    let mut seen_relations = BTreeSet::new();
+    for family in &request.relations {
+        if !declared_relations.contains(family.name.as_str()) {
+            return Err(UnitDerivationError::UnknownReference {
+                from: "aggregation request relation".to_string(),
+                reference: family.name.clone(),
+            });
+        }
+        if !seen_relations.insert(family.name.clone()) {
+            return Err(UnitDerivationError::DuplicateNamespace {
+                namespace: "aggregation request relation family",
+                id: family.name.clone(),
+            });
+        }
+        if family
+            .completeness
+            .as_ref()
+            .is_some_and(|evidence| evidence.id.is_empty())
+        {
+            return Err(UnitDerivationError::InvalidPlan(format!(
+                "relation `{}` completeness evidence id must be non-empty",
+                family.name
+            )));
+        }
+        for fact in &family.facts {
+            if fact.tuple[0] == fact.tuple[1]
+                || !people.contains_key(&fact.tuple[0])
+                || !people.contains_key(&fact.tuple[1])
+            {
+                return Err(UnitDerivationError::InvalidPlan(format!(
+                    "relation `{}` contains invalid roster tuple {:?}",
+                    family.name, fact.tuple
+                )));
+            }
+            validate_knowledge_evidence(
+                &fact.knowledge,
+                &format!("relation `{}` tuple {:?}", family.name, fact.tuple),
+            )?;
+            if family.name == plan.child_relation {
+                if people[&fact.tuple[0]].role != AggregationPersonRole::Adult {
+                    return Err(UnitDerivationError::InvalidRelationshipRole {
+                        relation: family.name.clone(),
+                        person: fact.tuple[0].clone(),
+                        role: "caregiver_must_be_adult".to_string(),
+                    });
+                }
+                if people[&fact.tuple[1]].role != AggregationPersonRole::Child {
+                    return Err(UnitDerivationError::InvalidRelationshipRole {
+                        relation: family.name.clone(),
+                        person: fact.tuple[1].clone(),
+                        role: "child_must_have_child_role".to_string(),
+                    });
+                }
+            }
+            if family.name == plan.partner_relation
+                && (people[&fact.tuple[0]].role != AggregationPersonRole::Adult
+                    || people[&fact.tuple[1]].role != AggregationPersonRole::Adult)
+            {
+                return Err(UnitDerivationError::InvalidRelationshipRole {
+                    relation: family.name.clone(),
+                    person: format!("{}:{}", fact.tuple[0], fact.tuple[1]),
+                    role: "partners_must_be_adults".to_string(),
+                });
+            }
+        }
+    }
+    Ok(people)
+}
+
+fn bind_constitution(
+    artifact: &CompiledAggregationArtifact,
+    request: &AggregationRequest,
+    people: &BTreeMap<String, &AggregationPerson>,
+) -> Result<(super::CompiledConstitution, ConstitutionInput), UnitDerivationError> {
+    let plan = &artifact.plan;
     let mut constitution = ConstitutionPlan {
         id: plan.constitution.id.clone(),
         entity_type: plan.constitution.entity_type.clone(),
@@ -397,57 +1887,64 @@ pub fn execute_aggregation_plan(
             for right_index in (left_index + 1)..person_ids.len() {
                 let left = &person_ids[left_index];
                 let right = &person_ids[right_index];
-                let mut alternatives = vec![BoolExpr::fact(FactRef::Relation {
-                    family: relation.relation.clone(),
-                    tuple: vec![left.clone(), right.clone()],
-                })];
-                // Membership edges are undirected even when the evidence
-                // relation (for example caregiver -> child) is directional.
-                alternatives.push(BoolExpr::fact(FactRef::Relation {
-                    family: relation.relation.clone(),
-                    tuple: vec![right.clone(), left.clone()],
-                }));
+                let when = BoolExpr::Or(vec![
+                    BoolExpr::fact(FactRef::Relation {
+                        family: relation.relation.clone(),
+                        tuple: vec![left.clone(), right.clone()],
+                    }),
+                    BoolExpr::fact(FactRef::Relation {
+                        family: relation.relation.clone(),
+                        tuple: vec![right.clone(), left.clone()],
+                    }),
+                ]);
                 constitution.edges.push(EdgeRule {
                     id: format!("{}:{left}:{right}", relation.relation),
                     kind: EdgeKind::Combination,
                     left: left.clone(),
                     right: right.clone(),
-                    when: BoolExpr::Or(alternatives),
+                    when,
                     citation: (&relation.citation).into(),
                     defeaters: Vec::new(),
                 });
             }
         }
     }
-
     let compiled = super::compile(constitution)?;
+    let request_relations = request
+        .relations
+        .iter()
+        .map(|family| (family.name.as_str(), family))
+        .collect::<BTreeMap<_, _>>();
     let relation_families = plan
         .membership_relations
         .iter()
         .map(|relation| {
-            let facts = request
-                .relations
-                .get(&relation.relation)
+            let supplied = request_relations.get(relation.relation.as_str());
+            let contains_unknown = supplied.is_some_and(|family| {
+                family
+                    .facts
+                    .iter()
+                    .any(|fact| matches!(fact.knowledge, AggregationKnowledge::Unknown { .. }))
+            });
+            let facts = supplied
                 .into_iter()
-                .flatten()
-                .map(|tuple| RelationFact {
-                    tuple: tuple.to_vec(),
-                    observation: ObservedBool {
-                        value: true,
-                        evidence: Evidence {
-                            id: format!("{}:{}:{}", relation.relation, tuple[0], tuple[1]),
-                            citation: (&relation.citation).into(),
-                        },
-                    },
-                })
-                .collect();
+                .flat_map(|family| family.facts.iter())
+                .flat_map(|fact| relation_observations(fact, &relation.citation))
+                .collect::<Vec<_>>();
             RelationFamilyInput {
                 name: relation.relation.clone(),
-                scope: request.scope.clone(),
-                completeness: Some(Evidence {
-                    id: format!("complete:{}:{}", request.scope, relation.relation),
-                    citation: (&relation.citation).into(),
-                }),
+                scope: supplied
+                    .map_or_else(|| request.scope.clone(), |family| family.scope.clone()),
+                completeness: if contains_unknown {
+                    None
+                } else {
+                    supplied
+                        .and_then(|family| family.completeness.as_ref())
+                        .map(|evidence| Evidence {
+                            id: evidence.id.clone(),
+                            citation: (&relation.citation).into(),
+                        })
+                },
                 facts,
             }
         })
@@ -457,245 +1954,1115 @@ pub fn execute_aggregation_plan(
             relation: plan.constitution.roster_relation.clone(),
             scope: request.scope.clone(),
             persons: person_ids,
-            completeness: Some(Evidence {
-                id: format!("complete-roster:{}", request.scope),
-                citation: Citation::new(
-                    "aggregation-plan-roster",
-                    format!("{} explicit roster", plan.id),
-                ),
-            }),
+            completeness: request
+                .roster_completeness
+                .as_ref()
+                .map(|evidence| Evidence {
+                    id: evidence.id.clone(),
+                    citation: Citation::new(
+                        "explicit scenario roster",
+                        format!("{} roster input", plan.id),
+                    ),
+                }),
         },
         segment: request.segment.clone(),
-        segment_complete: true,
+        segment_complete: request.segment_completeness.is_some(),
         relation_families,
         bool_facts: Vec::new(),
-        supplied_entities: Vec::new(),
+        supplied_entities: people
+            .values()
+            .map(|person| SuppliedEntity {
+                entity_type: "Person".to_string(),
+                id: person.id.clone(),
+                evidence: Evidence {
+                    id: person.evidence.id.clone(),
+                    citation: Citation::new(
+                        "explicit scenario person",
+                        format!("{} request", plan.id),
+                    ),
+                },
+            })
+            .collect(),
         integrity_constraints: Vec::new(),
     };
-    let derivation = super::derive_units(&compiled, &input, config)?;
-    if !derivation.indeterminate.is_empty() {
+    Ok((compiled, input))
+}
+
+fn relation_observations(
+    fact: &AggregationRelationFact,
+    citation: &AggregationCitation,
+) -> Vec<RelationFact> {
+    match &fact.knowledge {
+        AggregationKnowledge::Known { value, evidence } => vec![RelationFact {
+            tuple: fact.tuple.to_vec(),
+            observation: ObservedBool {
+                value: *value,
+                evidence: Evidence {
+                    id: evidence.id.clone(),
+                    citation: citation.into(),
+                },
+            },
+        }],
+        AggregationKnowledge::Unknown { .. } => Vec::new(),
+        AggregationKnowledge::Observations { observations }
+        | AggregationKnowledge::Conflict { observations } => observations
+            .iter()
+            .map(|observation| RelationFact {
+                tuple: fact.tuple.to_vec(),
+                observation: ObservedBool {
+                    value: observation.value,
+                    evidence: Evidence {
+                        id: observation.evidence.id.clone(),
+                        citation: citation.into(),
+                    },
+                },
+            })
+            .collect(),
+    }
+}
+
+fn parse_segment_interval(segment: &str) -> Result<crate::model::Interval, UnitDerivationError> {
+    let (start, end) = segment.split_once('/').ok_or_else(|| {
+        UnitDerivationError::InvalidPlan(format!(
+            "aggregation segment `{segment}` is not start/end"
+        ))
+    })?;
+    let start = NaiveDate::parse_from_str(start, "%Y-%m-%d").map_err(|error| {
+        UnitDerivationError::InvalidPlan(format!(
+            "aggregation segment start `{start}` is invalid: {error}"
+        ))
+    })?;
+    let end = NaiveDate::parse_from_str(end, "%Y-%m-%d").map_err(|error| {
+        UnitDerivationError::InvalidPlan(format!(
+            "aggregation segment end `{end}` is invalid: {error}"
+        ))
+    })?;
+    if end < start {
         return Err(UnitDerivationError::InvalidPlan(format!(
-            "aggregation membership is indeterminate: {:?}",
-            derivation.indeterminate
+            "aggregation segment `{segment}` is reversed"
         )));
     }
+    Ok(crate::model::Interval { start, end })
+}
 
-    let child_ids = request
-        .relations
-        .get(&plan.child_relation)
-        .into_iter()
-        .flatten()
-        .map(|tuple| tuple[1].clone())
-        .collect::<BTreeSet<_>>();
-    let partner_pairs = request
-        .relations
-        .get(&plan.partner_relation)
-        .into_iter()
-        .flatten()
-        .map(|tuple| (tuple[0].clone(), tuple[1].clone()))
-        .collect::<BTreeSet<_>>();
+fn bind_aggregation_dataset(
+    plan: &AggregationPlan,
+    request: &AggregationRequest,
+    people: &BTreeMap<String, &AggregationPerson>,
+    units: &[DerivedUnit],
+    interval: &crate::model::Interval,
+) -> Result<(crate::model::DataSet, Vec<InputKnowledgeRecord>), UnitDerivationError> {
+    let mut dataset = crate::model::DataSet::default();
+    let mut unresolved = Vec::new();
 
-    let mut families = Vec::new();
-    for unit in &derivation.units {
-        let member_set = unit.members.iter().cloned().collect::<BTreeSet<_>>();
-        let family_children = child_ids
-            .intersection(&member_set)
-            .cloned()
-            .collect::<BTreeSet<_>>();
-        let adults = member_set
-            .difference(&family_children)
-            .cloned()
-            .collect::<BTreeSet<_>>();
-        let partner_present = partner_pairs.iter().any(|(left, right)| {
-            member_set.contains(left)
-                && member_set.contains(right)
-                && (left == &request.primary_person || right == &request.primary_person)
-        });
-        let mut scalars = BTreeMap::new();
-        for aggregation in &plan.scalar_aggregations {
-            let selected = match aggregation.selector {
-                AggregateSelector::Adults => &adults,
-                AggregateSelector::AllMembers => &member_set,
-            };
-            let mut total = ExactDecimal::zero();
-            for person_id in selected {
-                let raw = people[person_id]
-                    .scalars
-                    .get(&aggregation.input)
-                    .ok_or_else(|| {
-                        UnitDerivationError::InvalidPlan(format!(
-                            "person `{person_id}` lacks scalar `{}`",
-                            aggregation.input
-                        ))
-                    })?;
-                total.add_assign(
-                    parse_decimal(
-                        raw,
-                        &format!("person `{person_id}` scalar `{}`", aggregation.input),
-                    )?,
-                    plan.decimal_precision,
-                );
+    for person in people.values() {
+        dataset.add_input(
+            "__aggregation_person_role",
+            "Person",
+            person.id.clone(),
+            interval.clone(),
+            crate::model::ScalarValue::Text(match person.role {
+                AggregationPersonRole::Adult => "adult".to_string(),
+                AggregationPersonRole::Child => "child".to_string(),
+            }),
+        );
+        if let Some(age) = &person.age_years {
+            bind_known_input(
+                &mut dataset,
+                &mut unresolved,
+                "age_years",
+                "Person",
+                &person.id,
+                interval,
+                age,
+                crate::model::ScalarValue::Integer,
+            );
+        }
+        for (name, value) in &person.scalars {
+            bind_known_input(
+                &mut dataset,
+                &mut unresolved,
+                name,
+                "Person",
+                &person.id,
+                interval,
+                value,
+                crate::model::ScalarValue::Text,
+            );
+        }
+        for (name, value) in &person.facts {
+            bind_known_input(
+                &mut dataset,
+                &mut unresolved,
+                name,
+                "Person",
+                &person.id,
+                interval,
+                value,
+                crate::model::ScalarValue::Bool,
+            );
+        }
+    }
+
+    for relation in &request.relations {
+        for fact in &relation.facts {
+            if resolve_knowledge(
+                Some(&fact.knowledge),
+                &format!(
+                    "relation:{}:{}:{}",
+                    relation.name, fact.tuple[0], fact.tuple[1]
+                ),
+            )
+            .expect("indeterminate relations return before materialization")
+            {
+                dataset.relations.push(crate::model::RelationRecord {
+                    name: relation.name.clone(),
+                    tuple: fact.tuple.to_vec(),
+                    interval: interval.clone(),
+                });
             }
-            scalars.insert(aggregation.output.clone(), decimal_text(total));
         }
+    }
 
-        let mut counts = BTreeMap::new();
-        for count in &plan.child_counts {
-            let value = family_children
-                .iter()
-                .filter(|child| {
-                    people[*child]
-                        .age_years
-                        .is_some_and(|age| age_in_range(age, count.minimum_age, count.maximum_age))
-                })
-                .count() as i64;
-            counts.insert(count.output.clone(), value);
-        }
-        for minimum in &plan.child_minima {
-            if minimum.input != "age_years" {
-                return Err(UnitDerivationError::InvalidPlan(format!(
-                    "child minimum `{}` uses unsupported input `{}`",
-                    minimum.output, minimum.input
-                )));
-            }
-            let value = family_children
-                .iter()
-                .filter_map(|child| people[child].age_years)
-                .min()
-                .unwrap_or(minimum.empty_value);
-            counts.insert(minimum.output.clone(), value);
-        }
-
-        let mut children = Vec::new();
-        for child_id in &family_children {
-            let age = people[child_id].age_years.ok_or_else(|| {
-                UnitDerivationError::InvalidPlan(format!("child `{child_id}` lacks age_years"))
+    let mut claimed_units = BTreeMap::<String, String>::new();
+    for family in &request.family_inputs {
+        let unit = units
+            .iter()
+            .find(|unit| unit.members.contains(&family.anchor_person))
+            .ok_or_else(|| {
+                UnitDerivationError::InvalidPlan(format!(
+                    "family input anchor `{}` was not materialized into a family",
+                    family.anchor_person
+                ))
             })?;
-            let mut child_scalars = BTreeMap::new();
-            let age_bands = plan
-                .child_counts
-                .iter()
-                .map(|count| {
-                    (
-                        count.output.clone(),
-                        age_in_range(age, count.minimum_age, count.maximum_age),
-                    )
-                })
-                .collect();
-            for broadcast in &plan.broadcasts {
-                let raw = request
-                    .family_scalars
-                    .get(&broadcast.family_input)
-                    .ok_or_else(|| {
-                        UnitDerivationError::InvalidPlan(format!(
-                            "family input `{}` required by child broadcast `{}` is missing",
-                            broadcast.family_input, broadcast.output
-                        ))
-                    })?;
-                child_scalars.insert(
-                    broadcast.output.clone(),
-                    decimal_text(parse_decimal(
-                        raw,
-                        &format!("family scalar `{}`", broadcast.family_input),
-                    )?),
-                );
-            }
-            children.push(AggregatedChild {
-                person: child_id.clone(),
-                family: unit.id.clone(),
-                age_years: age,
-                age_bands,
-                scalars: child_scalars,
+        if let Some(first) = claimed_units.insert(unit.id.clone(), family.anchor_person.clone()) {
+            return Err(UnitDerivationError::InvalidPlan(format!(
+                "derived family `{}` contains more than one family-input anchor: {first},{}",
+                unit.id, family.anchor_person
+            )));
+        }
+        if let Ok(holder) = resolve_knowledge(
+            family
+                .named_people
+                .get(&plan.partner_presence.entitlement_holder_input),
+            &format!("family:{}:entitlement-holder", family.anchor_person),
+        ) && !unit.members.contains(&holder)
+        {
+            return Err(UnitDerivationError::InvalidRelationshipRole {
+                relation: plan.partner_relation.clone(),
+                person: holder,
+                role: "entitlement_holder_must_belong_to_anchored_family".to_string(),
             });
         }
-        children.sort_by(|left, right| left.person.cmp(&right.person));
+        for (name, value) in &family.named_people {
+            bind_known_input(
+                &mut dataset,
+                &mut unresolved,
+                name,
+                &plan.constitution.entity_type,
+                &unit.id,
+                interval,
+                value,
+                crate::model::ScalarValue::Text,
+            );
+        }
+        for (name, value) in &family.scalars {
+            bind_known_input(
+                &mut dataset,
+                &mut unresolved,
+                name,
+                &plan.constitution.entity_type,
+                &unit.id,
+                interval,
+                value,
+                crate::model::ScalarValue::Text,
+            );
+        }
+    }
 
-        for reduction in &plan.family_reductions {
-            let eligible = family_children
+    Ok((dataset, unresolved))
+}
+
+fn bind_known_input<T: Clone + Ord>(
+    dataset: &mut crate::model::DataSet,
+    unresolved: &mut Vec<InputKnowledgeRecord>,
+    name: &str,
+    entity: &str,
+    entity_id: &str,
+    interval: &crate::model::Interval,
+    knowledge: &AggregationKnowledge<T>,
+    convert: impl FnOnce(T) -> crate::model::ScalarValue,
+) {
+    match resolve_knowledge(Some(knowledge), &format!("input:{entity_id}:{name}")) {
+        Ok(value) => dataset.add_input(name, entity, entity_id, interval.clone(), convert(value)),
+        Err(reasons) => unresolved.push(InputKnowledgeRecord {
+            name: name.to_string(),
+            entity: entity.to_string(),
+            entity_id: entity_id.to_string(),
+            interval: interval.clone(),
+            reduction: CompleteReduction::Indeterminate { reasons },
+        }),
+    }
+}
+
+fn bound_text(
+    data: &super::PhaseTwoDataSet,
+    name: &str,
+    entity_id: &str,
+    period: &crate::model::Period,
+) -> Result<String, BTreeSet<String>> {
+    match data.input_complete(name, entity_id, period) {
+        CompleteReduction::Determined(crate::model::ScalarValue::Text(value)) => Ok(value),
+        CompleteReduction::Determined(_) => Err(BTreeSet::from([format!(
+            "input:{entity_id}:{name}:expected-text"
+        )])),
+        CompleteReduction::Indeterminate { reasons } => Err(reasons),
+    }
+}
+
+fn bound_integer(
+    data: &super::PhaseTwoDataSet,
+    name: &str,
+    entity_id: &str,
+    period: &crate::model::Period,
+) -> Result<i64, BTreeSet<String>> {
+    match data.input_complete(name, entity_id, period) {
+        CompleteReduction::Determined(crate::model::ScalarValue::Integer(value)) => Ok(value),
+        CompleteReduction::Determined(_) => Err(BTreeSet::from([format!(
+            "input:{entity_id}:{name}:expected-integer"
+        )])),
+        CompleteReduction::Indeterminate { reasons } => Err(reasons),
+    }
+}
+
+fn bound_bool(
+    data: &super::PhaseTwoDataSet,
+    name: &str,
+    entity_id: &str,
+    period: &crate::model::Period,
+) -> Result<bool, BTreeSet<String>> {
+    match data.input_complete(name, entity_id, period) {
+        CompleteReduction::Determined(crate::model::ScalarValue::Bool(value)) => Ok(value),
+        CompleteReduction::Determined(_) => Err(BTreeSet::from([format!(
+            "input:{entity_id}:{name}:expected-bool"
+        )])),
+        CompleteReduction::Indeterminate { reasons } => Err(reasons),
+    }
+}
+
+fn validate_knowledge_evidence<T>(
+    knowledge: &AggregationKnowledge<T>,
+    label: &str,
+) -> Result<(), UnitDerivationError> {
+    let valid = match knowledge {
+        AggregationKnowledge::Known { evidence, .. }
+        | AggregationKnowledge::Unknown { evidence } => !evidence.id.is_empty(),
+        AggregationKnowledge::Observations { observations }
+        | AggregationKnowledge::Conflict { observations } => observations
+            .iter()
+            .all(|observation| !observation.evidence.id.is_empty()),
+    };
+    if valid {
+        Ok(())
+    } else {
+        Err(UnitDerivationError::InvalidPlan(format!(
+            "{label} has an empty evidence id"
+        )))
+    }
+}
+
+fn resolve_knowledge<T: Clone + Ord>(
+    knowledge: Option<&AggregationKnowledge<T>>,
+    label: &str,
+) -> Result<T, BTreeSet<String>> {
+    match knowledge {
+        Some(AggregationKnowledge::Known { value, .. }) => Ok(value.clone()),
+        Some(AggregationKnowledge::Unknown { evidence }) => {
+            Err(BTreeSet::from([format!("{label}:unknown:{}", evidence.id)]))
+        }
+        Some(AggregationKnowledge::Observations { observations }) => {
+            let distinct = observations
                 .iter()
-                .filter(|child| {
-                    people[*child].age_years.is_some_and(|age| {
-                        age_in_range(age, reduction.minimum_age, reduction.maximum_age)
-                    })
+                .map(|observation| &observation.value)
+                .collect::<BTreeSet<_>>();
+            if distinct.len() == 1 {
+                Ok((*distinct.into_iter().next().expect("one observation")).clone())
+            } else {
+                let mut reasons = observations
+                    .iter()
+                    .map(|observation| format!("{label}:conflict:{}", observation.evidence.id))
+                    .collect::<BTreeSet<_>>();
+                if reasons.is_empty() {
+                    reasons.insert(format!("{label}:missing-observations"));
+                }
+                Err(reasons)
+            }
+        }
+        Some(AggregationKnowledge::Conflict { observations }) => {
+            let mut reasons = observations
+                .iter()
+                .map(|observation| format!("{label}:conflict:{}", observation.evidence.id))
+                .collect::<BTreeSet<_>>();
+            if reasons.is_empty() {
+                reasons.insert(format!("{label}:conflict"));
+            }
+            Err(reasons)
+        }
+        None => Err(BTreeSet::from([format!("{label}:missing")])),
+    }
+}
+
+#[derive(Clone, Debug)]
+struct RelationshipRoleIndex {
+    children: BTreeSet<String>,
+    partner_pairs: BTreeSet<(String, String)>,
+}
+
+impl RelationshipRoleIndex {
+    fn new(
+        plan: &AggregationPlan,
+        data: &super::PhaseTwoDataSet,
+        _period: &crate::model::Period,
+    ) -> Result<Self, UnitDerivationError> {
+        let mut children = BTreeSet::new();
+        let mut partner_pairs = BTreeSet::new();
+        for fact in &data.dataset().relations {
+            if fact.tuple.len() != 2 {
+                continue;
+            }
+            if fact.name == plan.child_relation {
+                children.insert(fact.tuple[1].clone());
+            }
+            if fact.name == plan.partner_relation {
+                let (left, right) = if fact.tuple[0] <= fact.tuple[1] {
+                    (fact.tuple[0].clone(), fact.tuple[1].clone())
+                } else {
+                    (fact.tuple[1].clone(), fact.tuple[0].clone())
+                };
+                partner_pairs.insert((left, right));
+            }
+        }
+        Ok(Self {
+            children,
+            partner_pairs,
+        })
+    }
+}
+
+fn aggregate_family(
+    plan: &AggregationPlan,
+    data: &super::PhaseTwoDataSet,
+    period: &crate::model::Period,
+    roles: &RelationshipRoleIndex,
+    unit: &DerivedUnit,
+) -> Result<AggregatedFamily, UnitDerivationError> {
+    let member_set = unit.members.iter().cloned().collect::<BTreeSet<_>>();
+    let family_children = roles
+        .children
+        .intersection(&member_set)
+        .cloned()
+        .collect::<BTreeSet<_>>();
+    let adults = member_set
+        .iter()
+        .filter(|person| {
+            bound_text(data, "__aggregation_person_role", person, period).as_deref() == Ok("adult")
+        })
+        .cloned()
+        .collect::<BTreeSet<_>>();
+
+    let partner_present = family_partner_present(plan, data, period, roles, unit);
+    let mut scalars = BTreeMap::new();
+    for aggregation in &plan.scalar_aggregations {
+        let result = sum_person_scalars(
+            data,
+            period,
+            &adults,
+            &aggregation.input,
+            plan.decimal_precision,
+        )?;
+        scalars.insert(aggregation.output.clone(), result);
+    }
+
+    let mut counts = BTreeMap::new();
+    for count in &plan.child_counts {
+        let mut value = 0_i64;
+        let mut reasons = BTreeSet::new();
+        for child_id in &family_children {
+            match countable_child(plan, data, child_id, period) {
+                Ok(false) => {}
+                Ok(true) => match child_age(data, child_id, period) {
+                    Ok(age) if age_in_range(age, count.minimum_age, count.maximum_age) => {
+                        value += 1;
+                    }
+                    Ok(_) => {}
+                    Err(unresolved) => reasons.extend(unresolved),
+                },
+                Err(unresolved) => reasons.extend(unresolved),
+            }
+        }
+        counts.insert(
+            count.output.clone(),
+            if reasons.is_empty() {
+                AggregationValue::determined(value)
+            } else {
+                AggregationValue::indeterminate(reasons)
+            },
+        );
+    }
+    for minimum in &plan.child_minima {
+        let mut values = Vec::new();
+        let mut reasons = BTreeSet::new();
+        for child_id in &family_children {
+            match countable_child(plan, data, child_id, period) {
+                Ok(false) => {}
+                Ok(true) => match child_age(data, child_id, period) {
+                    Ok(age) => values.push(age),
+                    Err(unresolved) => reasons.extend(unresolved),
+                },
+                Err(unresolved) => reasons.extend(unresolved),
+            }
+        }
+        counts.insert(
+            minimum.output.clone(),
+            if reasons.is_empty() {
+                AggregationValue::determined(
+                    values.into_iter().min().unwrap_or(minimum.empty_value),
+                )
+            } else {
+                AggregationValue::indeterminate(reasons)
+            },
+        );
+    }
+
+    let mut predicates = BTreeMap::new();
+    for predicate in &plan.family_predicates {
+        let value = match &predicate.operation {
+            FamilyPredicateOperation::CountAtLeast { count, minimum } => {
+                map_value(counts.get(count), &predicate.output, |value| {
+                    value >= *minimum
                 })
-                .collect::<Vec<_>>();
-            let mut child_total = ExactDecimal::zero();
-            let mut family_once = None;
-            for child_id in eligible {
-                let person = people[child_id];
-                let before = person.scalars.get(&reduction.child_value).ok_or_else(|| {
-                    UnitDerivationError::InvalidPlan(format!(
-                        "child `{child_id}` lacks reduction scalar `{}`",
-                        reduction.child_value
-                    ))
-                })?;
-                child_total.add_assign(
-                    parse_decimal(
-                        before,
-                        &format!("child `{child_id}` scalar `{}`", reduction.child_value),
-                    )?,
-                    plan.decimal_precision,
-                );
-                let once_raw = person
-                    .scalars
-                    .get(&reduction.family_once_value)
-                    .ok_or_else(|| {
-                        UnitDerivationError::InvalidPlan(format!(
-                            "child `{child_id}` lacks family-once scalar `{}`",
-                            reduction.family_once_value
-                        ))
-                    })?;
-                let once = parse_decimal(
-                    once_raw,
-                    &format!(
-                        "child `{child_id}` scalar `{}`",
-                        reduction.family_once_value
-                    ),
-                )?;
-                match family_once {
-                    None => family_once = Some(once),
-                    Some(ref previous) if previous == &once => {}
-                    Some(previous) => {
-                        return Err(UnitDerivationError::InvalidPlan(format!(
-                            "family-once scalar `{}` disagrees across children: {} != {}",
-                            reduction.family_once_value,
-                            previous.to_text(),
-                            once.to_text()
-                        )));
+            }
+            FamilyPredicateOperation::YoungestAgeAtLeast { youngest, minimum } => {
+                map_value(counts.get(youngest), &predicate.output, |value| {
+                    value >= *minimum
+                })
+            }
+            FamilyPredicateOperation::SoleParentWithChildren { count } => combine_values(
+                counts.get(count),
+                Some(&partner_present),
+                &predicate.output,
+                |count, partnered| count > 0 && !partnered,
+            ),
+            FamilyPredicateOperation::SoleParentYoungestAgeAtLeast {
+                count,
+                youngest,
+                minimum,
+            } => combine_three_values(
+                counts.get(count),
+                counts.get(youngest),
+                Some(&partner_present),
+                &predicate.output,
+                |count, youngest, partnered| count > 0 && youngest >= *minimum && !partnered,
+            ),
+        };
+        predicates.insert(predicate.output.clone(), value);
+    }
+
+    for shape in &plan.family_shape_scalars {
+        let value = match &shape.operation {
+            FamilyShapeScalarOperation::EldestCareUnits { count } => {
+                map_value(counts.get(count), &shape.output, |value| {
+                    if value > 0 {
+                        "1".to_string()
+                    } else {
+                        "0".to_string()
+                    }
+                })
+            }
+            FamilyShapeScalarOperation::SubsequentCareUnits { count } => {
+                map_value(counts.get(count), &shape.output, |value| {
+                    (value - 1).max(0).to_string()
+                })
+            }
+            FamilyShapeScalarOperation::FixedIfChildren {
+                count,
+                present,
+                absent,
+            } => map_value(counts.get(count), &shape.output, |value| {
+                if value > 0 {
+                    present.clone()
+                } else {
+                    absent.clone()
+                }
+            }),
+        };
+        scalars.insert(shape.output.clone(), value);
+    }
+
+    for agreement in &plan.child_agreements {
+        let mut values = BTreeSet::new();
+        let mut reasons = BTreeSet::new();
+        for child_id in &family_children {
+            match countable_child(plan, data, child_id, period) {
+                Ok(false) => {}
+                Ok(true) => {
+                    if let Some(condition) = &agreement.eligible_if {
+                        match bound_bool(data, condition, child_id, period) {
+                            Ok(false) => continue,
+                            Ok(true) => {}
+                            Err(unresolved) => {
+                                reasons.extend(unresolved);
+                                continue;
+                            }
+                        }
+                    }
+                    match bound_text(data, &agreement.input, child_id, period) {
+                        Ok(value) => {
+                            values.insert(value);
+                        }
+                        Err(unresolved) => reasons.extend(unresolved),
                     }
                 }
+                Err(unresolved) => reasons.extend(unresolved),
             }
-            let value = match reduction.operation {
-                FamilyReductionOperation::SumChildrenThenSubtractFamilyOnce => child_total
-                    .clone()
-                    .subtract(family_once.unwrap_or_else(ExactDecimal::zero))
-                    .round_significant(plan.decimal_precision)
-                    .max_zero(),
-            };
-            scalars.insert(reduction.gross_output.clone(), decimal_text(child_total));
-            scalars.insert(reduction.output.clone(), decimal_text(value));
         }
+        if values.len() > 1 {
+            reasons.insert(format!(
+                "child-agreement:{}:values:{}",
+                agreement.output,
+                values.iter().cloned().collect::<Vec<_>>().join(",")
+            ));
+        }
+        scalars.insert(
+            agreement.output.clone(),
+            if reasons.is_empty() {
+                AggregationValue::determined(
+                    values
+                        .into_iter()
+                        .next()
+                        .unwrap_or_else(|| agreement.empty_value.clone()),
+                )
+            } else {
+                AggregationValue::indeterminate(reasons)
+            },
+        );
+    }
 
-        families.push(AggregatedFamily {
-            id: unit.id.clone(),
-            members: unit.members.clone(),
-            partner_present,
-            scalars,
-            counts,
-            children,
+    let mut children = Vec::new();
+    for child_id in &family_children {
+        let age_years = match child_age(data, child_id, period) {
+            Ok(value) => AggregationValue::determined(value),
+            Err(reasons) => AggregationValue::indeterminate(reasons),
+        };
+        let eligibility = countable_child(plan, data, child_id, period);
+        let mut age_bands = BTreeMap::new();
+        for count in &plan.child_counts {
+            let value = match (&eligibility, child_age(data, child_id, period)) {
+                (Ok(false), _) => AggregationValue::determined(false),
+                (Ok(true), Ok(age)) => AggregationValue::determined(age_in_range(
+                    age,
+                    count.minimum_age,
+                    count.maximum_age,
+                )),
+                (Err(left), Err(right)) => {
+                    let mut reasons = left.clone();
+                    reasons.extend(right);
+                    AggregationValue::indeterminate(reasons)
+                }
+                (Err(reasons), _) => AggregationValue::indeterminate(reasons.clone()),
+                (_, Err(reasons)) => AggregationValue::indeterminate(reasons),
+            };
+            age_bands.insert(count.output.clone(), value);
+        }
+        let mut child_scalars = BTreeMap::new();
+        for projection in &plan.child_projections {
+            let value = bound_text(data, &projection.input, child_id, period);
+            child_scalars.insert(projection.output.clone(), result_value(value));
+        }
+        for broadcast in &plan.broadcasts {
+            let value = bound_text(data, &broadcast.family_input, &unit.id, period);
+            child_scalars.insert(broadcast.output.clone(), result_value(value));
+        }
+        children.push(AggregatedChild {
+            person: child_id.clone(),
+            family: unit.id.clone(),
+            age_years,
+            age_bands,
+            scalars: child_scalars,
         });
     }
-    families.sort_by(|left, right| left.id.cmp(&right.id));
-    Ok(AggregationResult {
-        schema: super::EXPERIMENTAL_AGGREGATION_PLAN_SCHEMA.to_string(),
-        plan: plan.id.clone(),
-        families,
-        trace_roots: vec![derivation.trace.root],
+    children.sort_by(|left, right| left.person.cmp(&right.person));
+
+    for reduction in &plan.family_reductions {
+        apply_family_reduction(
+            plan,
+            data,
+            period,
+            &unit.id,
+            &family_children,
+            reduction,
+            &mut scalars,
+        )?;
+    }
+
+    Ok(AggregatedFamily {
+        id: unit.id.clone(),
+        members: unit.members.clone(),
+        partner_present,
+        scalars,
+        counts,
+        predicates,
+        children,
     })
+}
+
+fn family_partner_present(
+    plan: &AggregationPlan,
+    data: &super::PhaseTwoDataSet,
+    period: &crate::model::Period,
+    roles: &RelationshipRoleIndex,
+    unit: &DerivedUnit,
+) -> AggregationValue<bool> {
+    let members = unit.members.iter().collect::<BTreeSet<_>>();
+    let holder = bound_text(
+        data,
+        &plan.partner_presence.entitlement_holder_input,
+        &unit.id,
+        period,
+    );
+    match holder {
+        Ok(holder) => {
+            AggregationValue::determined(roles.partner_pairs.iter().any(|(left, right)| {
+                members.contains(&holder)
+                    && members.contains(left)
+                    && members.contains(right)
+                    && (left == &holder || right == &holder)
+            }))
+        }
+        Err(reasons) => AggregationValue::indeterminate(reasons),
+    }
+}
+
+fn countable_child(
+    plan: &AggregationPlan,
+    data: &super::PhaseTwoDataSet,
+    person_id: &str,
+    period: &crate::model::Period,
+) -> Result<bool, BTreeSet<String>> {
+    let principal_care = bound_bool(data, &plan.care.principal_care_input, person_id, period)?;
+    if !principal_care {
+        return Ok(false);
+    }
+    let age = child_age(data, person_id, period)?;
+    if age != plan.age_18_conditions.age {
+        return Ok(true);
+    }
+    let mut reasons = BTreeSet::new();
+    let mut all_hold = true;
+    for input in [
+        &plan.age_18_conditions.not_financially_independent_input,
+        &plan.age_18_conditions.attending_school_or_tertiary_input,
+        &plan.age_18_conditions.commissioner_period_input,
+    ] {
+        match bound_bool(data, input, person_id, period) {
+            Ok(value) => all_hold &= value,
+            Err(unresolved) => reasons.extend(unresolved),
+        }
+    }
+    if reasons.is_empty() {
+        Ok(all_hold)
+    } else {
+        Err(reasons)
+    }
+}
+
+fn child_age(
+    data: &super::PhaseTwoDataSet,
+    person_id: &str,
+    period: &crate::model::Period,
+) -> Result<i64, BTreeSet<String>> {
+    bound_integer(data, "age_years", person_id, period)
+}
+
+fn sum_person_scalars(
+    data: &super::PhaseTwoDataSet,
+    period: &crate::model::Period,
+    selected: &BTreeSet<String>,
+    input: &str,
+    precision: u32,
+) -> Result<AggregationValue<String>, UnitDerivationError> {
+    let mut total = ExactDecimal::zero();
+    let mut reasons = BTreeSet::new();
+    for person_id in selected {
+        match bound_text(data, input, person_id, period) {
+            Ok(raw) => total.add_assign(
+                parse_decimal(&raw, &format!("person `{person_id}` scalar `{input}`"))?,
+                precision,
+            ),
+            Err(unresolved) => reasons.extend(unresolved),
+        }
+    }
+    Ok(if reasons.is_empty() {
+        AggregationValue::determined(decimal_text(total))
+    } else {
+        AggregationValue::indeterminate(reasons)
+    })
+}
+
+fn map_value<T, U, F>(
+    value: Option<&AggregationValue<T>>,
+    label: &str,
+    map: F,
+) -> AggregationValue<U>
+where
+    T: Clone,
+    F: FnOnce(T) -> U,
+{
+    match value {
+        Some(AggregationValue::Determined { value }) => {
+            AggregationValue::determined(map(value.clone()))
+        }
+        Some(AggregationValue::Indeterminate { reasons }) => {
+            AggregationValue::indeterminate(reasons.clone())
+        }
+        None => AggregationValue::indeterminate(BTreeSet::from([format!(
+            "derived-output:{label}:missing"
+        )])),
+    }
+}
+
+fn combine_values<T, U, V, F>(
+    left: Option<&AggregationValue<T>>,
+    right: Option<&AggregationValue<U>>,
+    label: &str,
+    map: F,
+) -> AggregationValue<V>
+where
+    T: Clone,
+    U: Clone,
+    F: FnOnce(T, U) -> V,
+{
+    match (left, right) {
+        (
+            Some(AggregationValue::Determined { value: left }),
+            Some(AggregationValue::Determined { value: right }),
+        ) => AggregationValue::determined(map(left.clone(), right.clone())),
+        _ => {
+            let mut reasons = BTreeSet::new();
+            for value in [
+                left.and_then(|value| match value {
+                    AggregationValue::Indeterminate { reasons } => Some(reasons),
+                    AggregationValue::Determined { .. } => None,
+                }),
+                right.and_then(|value| match value {
+                    AggregationValue::Indeterminate { reasons } => Some(reasons),
+                    AggregationValue::Determined { .. } => None,
+                }),
+            ]
+            .into_iter()
+            .flatten()
+            {
+                reasons.extend(value.iter().cloned());
+            }
+            if reasons.is_empty() {
+                reasons.insert(format!("derived-output:{label}:missing"));
+            }
+            AggregationValue::indeterminate(reasons)
+        }
+    }
+}
+
+fn combine_three_values<T, U, V, W, F>(
+    first: Option<&AggregationValue<T>>,
+    second: Option<&AggregationValue<U>>,
+    third: Option<&AggregationValue<V>>,
+    label: &str,
+    map: F,
+) -> AggregationValue<W>
+where
+    T: Clone,
+    U: Clone,
+    V: Clone,
+    F: FnOnce(T, U, V) -> W,
+{
+    match (first, second, third) {
+        (
+            Some(AggregationValue::Determined { value: first }),
+            Some(AggregationValue::Determined { value: second }),
+            Some(AggregationValue::Determined { value: third }),
+        ) => AggregationValue::determined(map(first.clone(), second.clone(), third.clone())),
+        _ => {
+            let mut reasons = BTreeSet::new();
+            extend_value_reasons(first, &mut reasons);
+            extend_value_reasons(second, &mut reasons);
+            extend_value_reasons(third, &mut reasons);
+            if reasons.is_empty() {
+                reasons.insert(format!("derived-output:{label}:missing"));
+            }
+            AggregationValue::indeterminate(reasons)
+        }
+    }
+}
+
+fn extend_value_reasons<T>(value: Option<&AggregationValue<T>>, reasons: &mut BTreeSet<String>) {
+    if let Some(AggregationValue::Indeterminate {
+        reasons: unresolved,
+    }) = value
+    {
+        reasons.extend(unresolved.iter().cloned());
+    }
+}
+
+fn result_value<T>(result: Result<T, BTreeSet<String>>) -> AggregationValue<T> {
+    match result {
+        Ok(value) => AggregationValue::determined(value),
+        Err(reasons) => AggregationValue::indeterminate(reasons),
+    }
+}
+
+fn apply_family_reduction(
+    plan: &AggregationPlan,
+    data: &super::PhaseTwoDataSet,
+    period: &crate::model::Period,
+    family_id: &str,
+    children: &BTreeSet<String>,
+    reduction: &FamilyReduction,
+    scalars: &mut BTreeMap<String, AggregationValue<String>>,
+) -> Result<(), UnitDerivationError> {
+    let child_input = reduction.child_gross_input.as_deref().unwrap();
+    let adjustment_input = reduction.family_adjustment_input.as_deref().unwrap();
+    let care_input = reduction.care_fraction_input.as_deref().unwrap();
+    let mut gross = ExactDecimal::zero();
+    let mut reasons = BTreeSet::new();
+    for child_id in children {
+        let eligible = match countable_child(plan, data, child_id, period) {
+            Ok(false) => continue,
+            Ok(true) => match child_age(data, child_id, period) {
+                Ok(age) => age_in_range(age, reduction.minimum_age, reduction.maximum_age),
+                Err(unresolved) => {
+                    reasons.extend(unresolved);
+                    continue;
+                }
+            },
+            Err(unresolved) => {
+                reasons.extend(unresolved);
+                continue;
+            }
+        };
+        if !eligible {
+            continue;
+        }
+        let raw = bound_text(data, child_input, child_id, period);
+        let care = bound_text(data, care_input, child_id, period);
+        match (raw, care) {
+            (Ok(raw), Ok(care)) => {
+                let raw =
+                    parse_decimal(&raw, &format!("child `{child_id}` scalar `{child_input}`"))?;
+                let care =
+                    parse_decimal(&care, &format!("child `{child_id}` scalar `{care_input}`"))?;
+                if !care.is_fraction() {
+                    return Err(UnitDerivationError::InvalidPlan(format!(
+                        "child `{child_id}` care fraction `{care_input}` must be between 0 and 1"
+                    )));
+                }
+                gross.add_assign(
+                    raw.multiply(care, plan.decimal_precision),
+                    plan.decimal_precision,
+                );
+            }
+            (Err(left), Err(right)) => {
+                reasons.extend(left);
+                reasons.extend(right);
+            }
+            (Err(unresolved), _) | (_, Err(unresolved)) => reasons.extend(unresolved),
+        }
+    }
+    let adjustment = bound_text(data, adjustment_input, family_id, period);
+    let adjustment = match adjustment {
+        Ok(raw) => Some(parse_decimal(
+            &raw,
+            &format!("family scalar `{adjustment_input}`"),
+        )?),
+        Err(unresolved) => {
+            reasons.extend(unresolved);
+            None
+        }
+    };
+    if !reasons.is_empty() {
+        scalars.insert(
+            reduction.gross_output.clone(),
+            AggregationValue::indeterminate(reasons.clone()),
+        );
+        scalars.insert(
+            reduction.output.clone(),
+            AggregationValue::indeterminate(reasons.clone()),
+        );
+        if let Some(continuous) = &reduction.continuous {
+            scalars.insert(
+                continuous.output.clone(),
+                AggregationValue::indeterminate(reasons),
+            );
+        }
+        return Ok(());
+    }
+    let adjustment = adjustment.expect("known adjustment when no unresolved reasons");
+    let reduced = match reduction.operation {
+        FamilyReductionOperation::SumChildrenThenSubtractFamilyOnce => gross
+            .clone()
+            .subtract(adjustment)
+            .round_significant(plan.decimal_precision)
+            .max_zero(),
+    };
+    scalars.insert(
+        reduction.gross_output.clone(),
+        AggregationValue::determined(decimal_text(gross.clone())),
+    );
+    scalars.insert(
+        reduction.output.clone(),
+        AggregationValue::determined(decimal_text(reduced)),
+    );
+    if let Some(continuous) = &reduction.continuous {
+        let continuous_value =
+            continuous_reduction(plan, data, period, family_id, &gross, continuous)?;
+        scalars.insert(continuous.output.clone(), continuous_value);
+    }
+    Ok(())
+}
+
+fn continuous_reduction(
+    plan: &AggregationPlan,
+    data: &super::PhaseTwoDataSet,
+    period: &crate::model::Period,
+    family_id: &str,
+    gross: &ExactDecimal,
+    continuous: &ContinuousFamilyReduction,
+) -> Result<AggregationValue<String>, UnitDerivationError> {
+    let mut reasons = BTreeSet::new();
+    let mut read = |name: &str| -> Result<Option<ExactDecimal>, UnitDerivationError> {
+        match bound_text(data, name, family_id, period) {
+            Ok(raw) => Ok(Some(parse_decimal(
+                &raw,
+                &format!("family scalar `{name}`"),
+            )?)),
+            Err(unresolved) => {
+                reasons.extend(unresolved);
+                Ok(None)
+            }
+        }
+    };
+    let income = read(&continuous.family_income_input)?;
+    let threshold = read(&continuous.threshold_input)?;
+    let rate = read(&continuous.rate_input)?;
+    if !reasons.is_empty() {
+        return Ok(AggregationValue::indeterminate(reasons));
+    }
+    let excess = income.unwrap().subtract(threshold.unwrap()).max_zero();
+    let abatement = excess.multiply(rate.unwrap(), plan.decimal_precision);
+    Ok(AggregationValue::determined(decimal_text(
+        gross
+            .clone()
+            .subtract(abatement)
+            .round_significant(plan.decimal_precision)
+            .max_zero(),
+    )))
 }
 
 fn age_in_range(age: i64, minimum: Option<i64>, maximum: Option<i64>) -> bool {
     minimum.is_none_or(|minimum| age >= minimum) && maximum.is_none_or(|maximum| age <= maximum)
+}
+
+fn aggregation_trace_root(
+    artifact: &CompiledAggregationArtifact,
+    request: &AggregationRequest,
+    constitution_trace: &str,
+    families: &AggregationValue<Vec<AggregatedFamily>>,
+) -> Result<String, UnitDerivationError> {
+    let request = normalized_request(request);
+    let mut preimage = b"axiom.unit-aggregation.trace.stage3\0".to_vec();
+    push_len_prefixed(&mut preimage, artifact.plan_digest.as_bytes());
+    push_len_prefixed(&mut preimage, constitution_trace.as_bytes());
+    let request_bytes = serde_json::to_vec(&request).map_err(|error| {
+        UnitDerivationError::InvalidAggregationArtifact(format!(
+            "could not encode aggregation request trace: {error}"
+        ))
+    })?;
+    let result_bytes = serde_json::to_vec(families).map_err(|error| {
+        UnitDerivationError::InvalidAggregationArtifact(format!(
+            "could not encode aggregation result trace: {error}"
+        ))
+    })?;
+    push_len_prefixed(&mut preimage, &request_bytes);
+    push_len_prefixed(&mut preimage, &result_bytes);
+    Ok(digest_text(&preimage))
+}
+
+fn normalized_request(request: &AggregationRequest) -> AggregationRequest {
+    let mut normalized = request.clone();
+    normalized
+        .persons
+        .sort_by(|left, right| left.id.cmp(&right.id));
+    for person in &mut normalized.persons {
+        if let Some(age) = &mut person.age_years {
+            normalize_knowledge(age);
+        }
+        for value in person.scalars.values_mut() {
+            normalize_knowledge(value);
+        }
+        for value in person.facts.values_mut() {
+            normalize_knowledge(value);
+        }
+    }
+    normalized
+        .relations
+        .sort_by(|left, right| left.name.cmp(&right.name));
+    for family in &mut normalized.relations {
+        for fact in &mut family.facts {
+            normalize_knowledge(&mut fact.knowledge);
+        }
+        family.facts.sort_by(|left, right| {
+            left.tuple.cmp(&right.tuple).then_with(|| {
+                serde_json::to_vec(&left.knowledge)
+                    .expect("relation Knowledge is serializable")
+                    .cmp(
+                        &serde_json::to_vec(&right.knowledge)
+                            .expect("relation Knowledge is serializable"),
+                    )
+            })
+        });
+        family
+            .facts
+            .dedup_by(|left, right| left.tuple == right.tuple && left.knowledge == right.knowledge);
+    }
+    normalized
+        .family_inputs
+        .sort_by(|left, right| left.anchor_person.cmp(&right.anchor_person));
+    for family in &mut normalized.family_inputs {
+        for value in family.named_people.values_mut() {
+            normalize_knowledge(value);
+        }
+        for value in family.scalars.values_mut() {
+            normalize_knowledge(value);
+        }
+    }
+    normalized
+}
+
+fn normalize_knowledge<T: Ord>(knowledge: &mut AggregationKnowledge<T>) {
+    if let AggregationKnowledge::Observations { observations }
+    | AggregationKnowledge::Conflict { observations } = knowledge
+    {
+        observations.sort_by(|left, right| {
+            (&left.value, &left.evidence.id).cmp(&(&right.value, &right.evidence.id))
+        });
+        observations.dedup_by(|left, right| {
+            left.value == right.value && left.evidence.id == right.evidence.id
+        });
+    }
+}
+
+fn push_len_prefixed(output: &mut Vec<u8>, value: &[u8]) {
+    output.extend_from_slice(&(value.len() as u32).to_be_bytes());
+    output.extend_from_slice(value);
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -708,6 +3075,13 @@ impl ExactDecimal {
     fn zero() -> Self {
         Self {
             coefficient: BigInt::from(0),
+            scale: 0,
+        }
+    }
+
+    fn one() -> Self {
+        Self {
+            coefficient: BigInt::from(1),
             scale: 0,
         }
     }
@@ -745,12 +3119,31 @@ impl ExactDecimal {
         )
     }
 
+    fn multiply(self, other: Self, precision: u32) -> Self {
+        Self::new(
+            self.coefficient * other.coefficient,
+            self.scale.saturating_add(other.scale),
+        )
+        .round_significant(precision)
+    }
+
     fn max_zero(self) -> Self {
         if self.coefficient < BigInt::from(0) {
             Self::zero()
         } else {
             self
         }
+    }
+
+    fn compare(&self, other: &Self) -> std::cmp::Ordering {
+        let scale = self.scale.max(other.scale);
+        self.aligned_coefficient(scale)
+            .cmp(&other.aligned_coefficient(scale))
+    }
+
+    fn is_fraction(&self) -> bool {
+        self.compare(&Self::zero()) != std::cmp::Ordering::Less
+            && self.compare(&Self::one()) != std::cmp::Ordering::Greater
     }
 
     /// Apply a finite significant-digit context with round-half-even. The NZ

--- a/src/unit_derivation/aggregation.rs
+++ b/src/unit_derivation/aggregation.rs
@@ -1,0 +1,875 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use num_bigint::BigInt;
+use serde::{Deserialize, Serialize};
+
+use super::types::*;
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AggregationPlan {
+    pub schema: String,
+    pub id: String,
+    pub decimal_precision: u32,
+    pub constitution: AggregationConstitution,
+    pub membership_relations: Vec<AggregationMembershipRelation>,
+    pub partner_relation: String,
+    pub child_relation: String,
+    #[serde(default)]
+    pub scalar_aggregations: Vec<ScalarAggregation>,
+    #[serde(default)]
+    pub child_counts: Vec<ChildCount>,
+    #[serde(default)]
+    pub child_minima: Vec<ChildMinimum>,
+    #[serde(default)]
+    pub broadcasts: Vec<ChildBroadcast>,
+    #[serde(default)]
+    pub family_reductions: Vec<FamilyReduction>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AggregationConstitution {
+    pub id: String,
+    pub entity_type: String,
+    pub roster_relation: String,
+    pub unit_constituent_relation: String,
+    pub participating_member_relation: String,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AggregationMembershipRelation {
+    pub relation: String,
+    #[serde(default)]
+    pub symmetric: bool,
+    pub citation: AggregationCitation,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AggregationCitation {
+    pub provision: String,
+    pub authority: String,
+}
+
+impl From<&AggregationCitation> for Citation {
+    fn from(value: &AggregationCitation) -> Self {
+        Citation::new(value.provision.clone(), value.authority.clone())
+    }
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AggregateSelector {
+    Adults,
+    AllMembers,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ScalarAggregation {
+    pub output: String,
+    pub input: String,
+    pub selector: AggregateSelector,
+    pub citation: AggregationCitation,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ChildCount {
+    pub output: String,
+    #[serde(default)]
+    pub minimum_age: Option<i64>,
+    #[serde(default)]
+    pub maximum_age: Option<i64>,
+    pub citation: AggregationCitation,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ChildMinimum {
+    pub output: String,
+    pub input: String,
+    pub empty_value: i64,
+    pub citation: AggregationCitation,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ChildBroadcast {
+    pub output: String,
+    pub family_input: String,
+    pub citation: AggregationCitation,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct FamilyReduction {
+    pub output: String,
+    pub gross_output: String,
+    pub operation: FamilyReductionOperation,
+    pub child_value: String,
+    pub family_once_value: String,
+    #[serde(default)]
+    pub minimum_age: Option<i64>,
+    #[serde(default)]
+    pub maximum_age: Option<i64>,
+    pub citation: AggregationCitation,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum FamilyReductionOperation {
+    /// Sum per-child gross credits, require every child-carried family value
+    /// to agree, and subtract that value exactly once from the family total.
+    SumChildrenThenSubtractFamilyOnce,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AggregationRequest {
+    pub scope: String,
+    pub segment: String,
+    pub primary_person: String,
+    pub persons: Vec<AggregationPerson>,
+    #[serde(default)]
+    pub relations: BTreeMap<String, Vec<[String; 2]>>,
+    #[serde(default)]
+    pub family_scalars: BTreeMap<String, String>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct AggregationPerson {
+    pub id: String,
+    #[serde(default)]
+    pub age_years: Option<i64>,
+    #[serde(default)]
+    pub scalars: BTreeMap<String, String>,
+}
+
+#[derive(Clone, Debug, Serialize, PartialEq, Eq)]
+pub struct AggregationResult {
+    pub schema: String,
+    pub plan: String,
+    pub families: Vec<AggregatedFamily>,
+    pub trace_roots: Vec<String>,
+}
+
+#[derive(Clone, Debug, Serialize, PartialEq, Eq)]
+pub struct AggregatedFamily {
+    pub id: String,
+    pub members: Vec<String>,
+    pub partner_present: bool,
+    pub scalars: BTreeMap<String, String>,
+    pub counts: BTreeMap<String, i64>,
+    pub children: Vec<AggregatedChild>,
+}
+
+#[derive(Clone, Debug, Serialize, PartialEq, Eq)]
+pub struct AggregatedChild {
+    pub person: String,
+    pub family: String,
+    pub age_years: i64,
+    pub age_bands: BTreeMap<String, bool>,
+    pub scalars: BTreeMap<String, String>,
+}
+
+pub fn parse_aggregation_plan(source: &str) -> Result<AggregationPlan, UnitDerivationError> {
+    let plan: AggregationPlan = serde_yaml::from_str(source).map_err(|error| {
+        UnitDerivationError::InvalidPlan(format!("invalid aggregation plan YAML: {error}"))
+    })?;
+    validate_aggregation_plan(&plan)?;
+    Ok(plan)
+}
+
+fn validate_aggregation_plan(plan: &AggregationPlan) -> Result<(), UnitDerivationError> {
+    if plan.schema != super::EXPERIMENTAL_AGGREGATION_PLAN_SCHEMA {
+        return Err(UnitDerivationError::InvalidPlan(format!(
+            "aggregation plan schema `{}` is unsupported",
+            plan.schema
+        )));
+    }
+    if plan.id.is_empty()
+        || plan.constitution.id.is_empty()
+        || plan.constitution.entity_type.is_empty()
+        || plan.constitution.roster_relation.is_empty()
+    {
+        return Err(UnitDerivationError::InvalidPlan(
+            "aggregation plan and constitution identities must be non-empty".to_string(),
+        ));
+    }
+    if plan.decimal_precision == 0 {
+        return Err(UnitDerivationError::InvalidPlan(
+            "aggregation decimal_precision must be positive".to_string(),
+        ));
+    }
+    let mut relations = BTreeSet::new();
+    for relation in &plan.membership_relations {
+        if relation.relation.is_empty() || !relations.insert(relation.relation.clone()) {
+            return Err(UnitDerivationError::DuplicateNamespace {
+                namespace: "aggregation membership relation",
+                id: relation.relation.clone(),
+            });
+        }
+        if relation.citation.provision.is_empty() || relation.citation.authority.is_empty() {
+            return Err(UnitDerivationError::InvalidPlan(format!(
+                "membership relation `{}` needs a complete citation",
+                relation.relation
+            )));
+        }
+    }
+    for required in [&plan.partner_relation, &plan.child_relation] {
+        if !relations.contains(required) {
+            return Err(UnitDerivationError::UnknownReference {
+                from: plan.id.clone(),
+                reference: required.clone(),
+            });
+        }
+    }
+
+    let mut outputs = BTreeSet::new();
+    for aggregation in &plan.scalar_aggregations {
+        validate_citation(&aggregation.citation, &aggregation.output)?;
+        insert_output(&mut outputs, &aggregation.output)?;
+    }
+    for count in &plan.child_counts {
+        validate_citation(&count.citation, &count.output)?;
+        validate_age_range(count.minimum_age, count.maximum_age, &count.output)?;
+        insert_output(&mut outputs, &count.output)?;
+    }
+    for minimum in &plan.child_minima {
+        validate_citation(&minimum.citation, &minimum.output)?;
+        insert_output(&mut outputs, &minimum.output)?;
+    }
+    for broadcast in &plan.broadcasts {
+        validate_citation(&broadcast.citation, &broadcast.output)?;
+        insert_output(&mut outputs, &broadcast.output)?;
+    }
+    for reduction in &plan.family_reductions {
+        validate_citation(&reduction.citation, &reduction.output)?;
+        validate_age_range(
+            reduction.minimum_age,
+            reduction.maximum_age,
+            &reduction.output,
+        )?;
+        insert_output(&mut outputs, &reduction.output)?;
+        insert_output(&mut outputs, &reduction.gross_output)?;
+        if plan.scalar_aggregations.iter().any(|aggregation| {
+            aggregation.input == reduction.child_value
+                || aggregation.input == reduction.family_once_value
+                || aggregation.output == reduction.output
+                || aggregation.output == reduction.gross_output
+        }) {
+            return Err(UnitDerivationError::InvalidPlan(format!(
+                "family-once reduction `{}` reserves its child, abatement, and output fields from ordinary scalar aggregation",
+                reduction.output
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn validate_citation(
+    citation: &AggregationCitation,
+    operation: &str,
+) -> Result<(), UnitDerivationError> {
+    if citation.provision.is_empty() || citation.authority.is_empty() {
+        return Err(UnitDerivationError::InvalidPlan(format!(
+            "aggregation operation `{operation}` needs a complete citation"
+        )));
+    }
+    Ok(())
+}
+
+fn insert_output(outputs: &mut BTreeSet<String>, output: &str) -> Result<(), UnitDerivationError> {
+    if output.is_empty() || !outputs.insert(output.to_string()) {
+        return Err(UnitDerivationError::DuplicateNamespace {
+            namespace: "aggregation output",
+            id: output.to_string(),
+        });
+    }
+    Ok(())
+}
+
+fn validate_age_range(
+    minimum: Option<i64>,
+    maximum: Option<i64>,
+    output: &str,
+) -> Result<(), UnitDerivationError> {
+    if minimum
+        .zip(maximum)
+        .is_some_and(|(minimum, maximum)| minimum > maximum)
+    {
+        return Err(UnitDerivationError::InvalidPlan(format!(
+            "age range for `{output}` is reversed"
+        )));
+    }
+    Ok(())
+}
+
+pub fn execute_aggregation_plan(
+    plan: &AggregationPlan,
+    request: &AggregationRequest,
+    config: &UnitDerivationConfig,
+) -> Result<AggregationResult, UnitDerivationError> {
+    validate_aggregation_plan(plan)?;
+    let people = request
+        .persons
+        .iter()
+        .map(|person| (person.id.clone(), person))
+        .collect::<BTreeMap<_, _>>();
+    if people.len() != request.persons.len() {
+        return Err(UnitDerivationError::DuplicateNamespace {
+            namespace: "aggregation person",
+            id: request
+                .persons
+                .iter()
+                .find(|person| {
+                    request
+                        .persons
+                        .iter()
+                        .filter(|other| other.id == person.id)
+                        .count()
+                        > 1
+                })
+                .map(|person| person.id.clone())
+                .unwrap_or_default(),
+        });
+    }
+    if !people.contains_key(&request.primary_person) {
+        return Err(UnitDerivationError::InvalidPlan(format!(
+            "primary person `{}` is outside the roster",
+            request.primary_person
+        )));
+    }
+    if request.scope.is_empty() || request.segment.is_empty() || people.is_empty() {
+        return Err(UnitDerivationError::InvalidPlan(
+            "aggregation scope, segment, and roster must be non-empty".to_string(),
+        ));
+    }
+
+    let relation_plans = plan
+        .membership_relations
+        .iter()
+        .map(|relation| (relation.relation.as_str(), relation))
+        .collect::<BTreeMap<_, _>>();
+    for (name, tuples) in &request.relations {
+        if !relation_plans.contains_key(name.as_str()) {
+            return Err(UnitDerivationError::UnknownReference {
+                from: "aggregation request relation".to_string(),
+                reference: name.clone(),
+            });
+        }
+        for tuple in tuples {
+            if tuple[0] == tuple[1]
+                || !people.contains_key(&tuple[0])
+                || !people.contains_key(&tuple[1])
+            {
+                return Err(UnitDerivationError::InvalidPlan(format!(
+                    "relation `{name}` contains invalid roster tuple {:?}",
+                    tuple
+                )));
+            }
+        }
+    }
+
+    let mut constitution = ConstitutionPlan {
+        id: plan.constitution.id.clone(),
+        entity_type: plan.constitution.entity_type.clone(),
+        roster_relation: plan.constitution.roster_relation.clone(),
+        relations: EmissionRelations {
+            unit_constituent: plan.constitution.unit_constituent_relation.clone(),
+            participating_member: plan.constitution.participating_member_relation.clone(),
+        },
+        derived_bools: Vec::new(),
+        edges: Vec::new(),
+        cuts: Vec::new(),
+        attachments: Vec::new(),
+        bars: Vec::new(),
+        statuses: Vec::new(),
+        base_chain_policy: None,
+    };
+    let person_ids = people.keys().cloned().collect::<Vec<_>>();
+    for relation in &plan.membership_relations {
+        for left_index in 0..person_ids.len() {
+            for right_index in (left_index + 1)..person_ids.len() {
+                let left = &person_ids[left_index];
+                let right = &person_ids[right_index];
+                let mut alternatives = vec![BoolExpr::fact(FactRef::Relation {
+                    family: relation.relation.clone(),
+                    tuple: vec![left.clone(), right.clone()],
+                })];
+                // Membership edges are undirected even when the evidence
+                // relation (for example caregiver -> child) is directional.
+                alternatives.push(BoolExpr::fact(FactRef::Relation {
+                    family: relation.relation.clone(),
+                    tuple: vec![right.clone(), left.clone()],
+                }));
+                constitution.edges.push(EdgeRule {
+                    id: format!("{}:{left}:{right}", relation.relation),
+                    kind: EdgeKind::Combination,
+                    left: left.clone(),
+                    right: right.clone(),
+                    when: BoolExpr::Or(alternatives),
+                    citation: (&relation.citation).into(),
+                    defeaters: Vec::new(),
+                });
+            }
+        }
+    }
+
+    let compiled = super::compile(constitution)?;
+    let relation_families = plan
+        .membership_relations
+        .iter()
+        .map(|relation| {
+            let facts = request
+                .relations
+                .get(&relation.relation)
+                .into_iter()
+                .flatten()
+                .map(|tuple| RelationFact {
+                    tuple: tuple.to_vec(),
+                    observation: ObservedBool {
+                        value: true,
+                        evidence: Evidence {
+                            id: format!("{}:{}:{}", relation.relation, tuple[0], tuple[1]),
+                            citation: (&relation.citation).into(),
+                        },
+                    },
+                })
+                .collect();
+            RelationFamilyInput {
+                name: relation.relation.clone(),
+                scope: request.scope.clone(),
+                completeness: Some(Evidence {
+                    id: format!("complete:{}:{}", request.scope, relation.relation),
+                    citation: (&relation.citation).into(),
+                }),
+                facts,
+            }
+        })
+        .collect();
+    let input = ConstitutionInput {
+        roster: RosterInput {
+            relation: plan.constitution.roster_relation.clone(),
+            scope: request.scope.clone(),
+            persons: person_ids,
+            completeness: Some(Evidence {
+                id: format!("complete-roster:{}", request.scope),
+                citation: Citation::new(
+                    "aggregation-plan-roster",
+                    format!("{} explicit roster", plan.id),
+                ),
+            }),
+        },
+        segment: request.segment.clone(),
+        segment_complete: true,
+        relation_families,
+        bool_facts: Vec::new(),
+        supplied_entities: Vec::new(),
+        integrity_constraints: Vec::new(),
+    };
+    let derivation = super::derive_units(&compiled, &input, config)?;
+    if !derivation.indeterminate.is_empty() {
+        return Err(UnitDerivationError::InvalidPlan(format!(
+            "aggregation membership is indeterminate: {:?}",
+            derivation.indeterminate
+        )));
+    }
+
+    let child_ids = request
+        .relations
+        .get(&plan.child_relation)
+        .into_iter()
+        .flatten()
+        .map(|tuple| tuple[1].clone())
+        .collect::<BTreeSet<_>>();
+    let partner_pairs = request
+        .relations
+        .get(&plan.partner_relation)
+        .into_iter()
+        .flatten()
+        .map(|tuple| (tuple[0].clone(), tuple[1].clone()))
+        .collect::<BTreeSet<_>>();
+
+    let mut families = Vec::new();
+    for unit in &derivation.units {
+        let member_set = unit.members.iter().cloned().collect::<BTreeSet<_>>();
+        let family_children = child_ids
+            .intersection(&member_set)
+            .cloned()
+            .collect::<BTreeSet<_>>();
+        let adults = member_set
+            .difference(&family_children)
+            .cloned()
+            .collect::<BTreeSet<_>>();
+        let partner_present = partner_pairs.iter().any(|(left, right)| {
+            member_set.contains(left)
+                && member_set.contains(right)
+                && (left == &request.primary_person || right == &request.primary_person)
+        });
+        let mut scalars = BTreeMap::new();
+        for aggregation in &plan.scalar_aggregations {
+            let selected = match aggregation.selector {
+                AggregateSelector::Adults => &adults,
+                AggregateSelector::AllMembers => &member_set,
+            };
+            let mut total = ExactDecimal::zero();
+            for person_id in selected {
+                let raw = people[person_id]
+                    .scalars
+                    .get(&aggregation.input)
+                    .ok_or_else(|| {
+                        UnitDerivationError::InvalidPlan(format!(
+                            "person `{person_id}` lacks scalar `{}`",
+                            aggregation.input
+                        ))
+                    })?;
+                total.add_assign(
+                    parse_decimal(
+                        raw,
+                        &format!("person `{person_id}` scalar `{}`", aggregation.input),
+                    )?,
+                    plan.decimal_precision,
+                );
+            }
+            scalars.insert(aggregation.output.clone(), decimal_text(total));
+        }
+
+        let mut counts = BTreeMap::new();
+        for count in &plan.child_counts {
+            let value = family_children
+                .iter()
+                .filter(|child| {
+                    people[*child]
+                        .age_years
+                        .is_some_and(|age| age_in_range(age, count.minimum_age, count.maximum_age))
+                })
+                .count() as i64;
+            counts.insert(count.output.clone(), value);
+        }
+        for minimum in &plan.child_minima {
+            if minimum.input != "age_years" {
+                return Err(UnitDerivationError::InvalidPlan(format!(
+                    "child minimum `{}` uses unsupported input `{}`",
+                    minimum.output, minimum.input
+                )));
+            }
+            let value = family_children
+                .iter()
+                .filter_map(|child| people[child].age_years)
+                .min()
+                .unwrap_or(minimum.empty_value);
+            counts.insert(minimum.output.clone(), value);
+        }
+
+        let mut children = Vec::new();
+        for child_id in &family_children {
+            let age = people[child_id].age_years.ok_or_else(|| {
+                UnitDerivationError::InvalidPlan(format!("child `{child_id}` lacks age_years"))
+            })?;
+            let mut child_scalars = BTreeMap::new();
+            let age_bands = plan
+                .child_counts
+                .iter()
+                .map(|count| {
+                    (
+                        count.output.clone(),
+                        age_in_range(age, count.minimum_age, count.maximum_age),
+                    )
+                })
+                .collect();
+            for broadcast in &plan.broadcasts {
+                let raw = request
+                    .family_scalars
+                    .get(&broadcast.family_input)
+                    .ok_or_else(|| {
+                        UnitDerivationError::InvalidPlan(format!(
+                            "family input `{}` required by child broadcast `{}` is missing",
+                            broadcast.family_input, broadcast.output
+                        ))
+                    })?;
+                child_scalars.insert(
+                    broadcast.output.clone(),
+                    decimal_text(parse_decimal(
+                        raw,
+                        &format!("family scalar `{}`", broadcast.family_input),
+                    )?),
+                );
+            }
+            children.push(AggregatedChild {
+                person: child_id.clone(),
+                family: unit.id.clone(),
+                age_years: age,
+                age_bands,
+                scalars: child_scalars,
+            });
+        }
+        children.sort_by(|left, right| left.person.cmp(&right.person));
+
+        for reduction in &plan.family_reductions {
+            let eligible = family_children
+                .iter()
+                .filter(|child| {
+                    people[*child].age_years.is_some_and(|age| {
+                        age_in_range(age, reduction.minimum_age, reduction.maximum_age)
+                    })
+                })
+                .collect::<Vec<_>>();
+            let mut child_total = ExactDecimal::zero();
+            let mut family_once = None;
+            for child_id in eligible {
+                let person = people[child_id];
+                let before = person.scalars.get(&reduction.child_value).ok_or_else(|| {
+                    UnitDerivationError::InvalidPlan(format!(
+                        "child `{child_id}` lacks reduction scalar `{}`",
+                        reduction.child_value
+                    ))
+                })?;
+                child_total.add_assign(
+                    parse_decimal(
+                        before,
+                        &format!("child `{child_id}` scalar `{}`", reduction.child_value),
+                    )?,
+                    plan.decimal_precision,
+                );
+                let once_raw = person
+                    .scalars
+                    .get(&reduction.family_once_value)
+                    .ok_or_else(|| {
+                        UnitDerivationError::InvalidPlan(format!(
+                            "child `{child_id}` lacks family-once scalar `{}`",
+                            reduction.family_once_value
+                        ))
+                    })?;
+                let once = parse_decimal(
+                    once_raw,
+                    &format!(
+                        "child `{child_id}` scalar `{}`",
+                        reduction.family_once_value
+                    ),
+                )?;
+                match family_once {
+                    None => family_once = Some(once),
+                    Some(ref previous) if previous == &once => {}
+                    Some(previous) => {
+                        return Err(UnitDerivationError::InvalidPlan(format!(
+                            "family-once scalar `{}` disagrees across children: {} != {}",
+                            reduction.family_once_value,
+                            previous.to_text(),
+                            once.to_text()
+                        )));
+                    }
+                }
+            }
+            let value = match reduction.operation {
+                FamilyReductionOperation::SumChildrenThenSubtractFamilyOnce => child_total
+                    .clone()
+                    .subtract(family_once.unwrap_or_else(ExactDecimal::zero))
+                    .round_significant(plan.decimal_precision)
+                    .max_zero(),
+            };
+            scalars.insert(reduction.gross_output.clone(), decimal_text(child_total));
+            scalars.insert(reduction.output.clone(), decimal_text(value));
+        }
+
+        families.push(AggregatedFamily {
+            id: unit.id.clone(),
+            members: unit.members.clone(),
+            partner_present,
+            scalars,
+            counts,
+            children,
+        });
+    }
+    families.sort_by(|left, right| left.id.cmp(&right.id));
+    Ok(AggregationResult {
+        schema: super::EXPERIMENTAL_AGGREGATION_PLAN_SCHEMA.to_string(),
+        plan: plan.id.clone(),
+        families,
+        trace_roots: vec![derivation.trace.root],
+    })
+}
+
+fn age_in_range(age: i64, minimum: Option<i64>, maximum: Option<i64>) -> bool {
+    minimum.is_none_or(|minimum| age >= minimum) && maximum.is_none_or(|maximum| age <= maximum)
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct ExactDecimal {
+    coefficient: BigInt,
+    scale: u32,
+}
+
+impl ExactDecimal {
+    fn zero() -> Self {
+        Self {
+            coefficient: BigInt::from(0),
+            scale: 0,
+        }
+    }
+
+    fn new(mut coefficient: BigInt, mut scale: u32) -> Self {
+        while scale > 0 && (&coefficient % 10_u8) == BigInt::from(0) {
+            coefficient /= 10_u8;
+            scale -= 1;
+        }
+        Self { coefficient, scale }
+    }
+
+    fn ten_to(power: u32) -> BigInt {
+        BigInt::from(10_u8).pow(power)
+    }
+
+    fn aligned_coefficient(&self, scale: u32) -> BigInt {
+        &self.coefficient * Self::ten_to(scale - self.scale)
+    }
+
+    fn add_assign(&mut self, other: Self, precision: u32) {
+        let scale = self.scale.max(other.scale);
+        *self = Self::new(
+            self.aligned_coefficient(scale) + other.aligned_coefficient(scale),
+            scale,
+        )
+        .round_significant(precision);
+    }
+
+    fn subtract(self, other: Self) -> Self {
+        let scale = self.scale.max(other.scale);
+        Self::new(
+            self.aligned_coefficient(scale) - other.aligned_coefficient(scale),
+            scale,
+        )
+    }
+
+    fn max_zero(self) -> Self {
+        if self.coefficient < BigInt::from(0) {
+            Self::zero()
+        } else {
+            self
+        }
+    }
+
+    /// Apply a finite significant-digit context with round-half-even. The NZ
+    /// comparison records 40 as an explicit reproducibility input.
+    fn round_significant(self, precision: u32) -> Self {
+        let negative = self.coefficient < BigInt::from(0);
+        let absolute = if negative {
+            -self.coefficient.clone()
+        } else {
+            self.coefficient.clone()
+        };
+        let digits = absolute.to_string().len() as u32;
+        if digits <= precision {
+            return self;
+        }
+        let dropped = digits - precision;
+        let divisor = Self::ten_to(dropped);
+        let mut quotient = &absolute / &divisor;
+        let remainder = &absolute % &divisor;
+        let doubled = remainder * 2_u8;
+        let odd = (&quotient % 2_u8) != BigInt::from(0);
+        if doubled > divisor || (doubled == divisor && odd) {
+            quotient += 1_u8;
+        }
+        if negative {
+            quotient = -quotient;
+        }
+        if dropped <= self.scale {
+            Self::new(quotient, self.scale - dropped)
+        } else {
+            Self::new(quotient * Self::ten_to(dropped - self.scale), 0)
+        }
+    }
+
+    fn to_text(&self) -> String {
+        if self.coefficient == BigInt::from(0) {
+            return "0".to_string();
+        }
+        let signed = self.coefficient.to_string();
+        let (sign, digits) = signed
+            .strip_prefix('-')
+            .map_or(("", signed.as_str()), |digits| ("-", digits));
+        if self.scale == 0 {
+            return format!("{sign}{digits}");
+        }
+        let scale = self.scale as usize;
+        if digits.len() <= scale {
+            format!("{sign}0.{}{digits}", "0".repeat(scale - digits.len()))
+        } else {
+            let split = digits.len() - scale;
+            format!("{sign}{}.{}", &digits[..split], &digits[split..])
+        }
+    }
+}
+
+fn parse_decimal(raw: &str, label: &str) -> Result<ExactDecimal, UnitDerivationError> {
+    let raw = raw.trim();
+    let (mantissa, exponent) = match raw.find(['e', 'E']) {
+        Some(index) => {
+            if raw[index + 1..].contains(['e', 'E']) {
+                return Err(UnitDerivationError::InvalidPlan(format!(
+                    "{label} is not a decimal: repeated exponent"
+                )));
+            }
+            let exponent = raw[index + 1..].parse::<i64>().map_err(|error| {
+                UnitDerivationError::InvalidPlan(format!(
+                    "{label} is not a decimal: invalid exponent: {error}"
+                ))
+            })?;
+            (&raw[..index], exponent)
+        }
+        None => (raw, 0),
+    };
+    let (negative, unsigned) = match mantissa.as_bytes().first() {
+        Some(b'-') => (true, &mantissa[1..]),
+        Some(b'+') => (false, &mantissa[1..]),
+        _ => (false, mantissa),
+    };
+    let mut parts = unsigned.split('.');
+    let integer = parts.next().unwrap_or_default();
+    let fraction = parts.next().unwrap_or_default();
+    if parts.next().is_some()
+        || (integer.is_empty() && fraction.is_empty())
+        || !integer
+            .bytes()
+            .chain(fraction.bytes())
+            .all(|byte| byte.is_ascii_digit())
+    {
+        return Err(UnitDerivationError::InvalidPlan(format!(
+            "{label} is not a decimal: invalid digits"
+        )));
+    }
+    let digits = format!("{integer}{fraction}");
+    let mut coefficient = BigInt::parse_bytes(digits.as_bytes(), 10).ok_or_else(|| {
+        UnitDerivationError::InvalidPlan(format!("{label} is not a decimal: invalid coefficient"))
+    })?;
+    if negative {
+        coefficient = -coefficient;
+    }
+    let scale = i64::try_from(fraction.len())
+        .ok()
+        .and_then(|fraction| fraction.checked_sub(exponent))
+        .ok_or_else(|| {
+            UnitDerivationError::InvalidPlan(format!("{label} is not a decimal: scale overflow"))
+        })?;
+    if scale < 0 {
+        let power = u32::try_from(-scale).map_err(|_| {
+            UnitDerivationError::InvalidPlan(format!("{label} is not a decimal: scale overflow"))
+        })?;
+        coefficient *= ExactDecimal::ten_to(power);
+        Ok(ExactDecimal::new(coefficient, 0))
+    } else {
+        let scale = u32::try_from(scale).map_err(|_| {
+            UnitDerivationError::InvalidPlan(format!("{label} is not a decimal: scale overflow"))
+        })?;
+        Ok(ExactDecimal::new(coefficient, scale))
+    }
+}
+
+fn decimal_text(value: ExactDecimal) -> String {
+    value.to_text()
+}

--- a/src/unit_derivation/aggregation.rs
+++ b/src/unit_derivation/aggregation.rs
@@ -93,7 +93,23 @@ pub struct AggregationInput {
     pub kind: AggregationInputKind,
     #[serde(default)]
     pub reduction_key: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub engine_computation: Option<EngineComputationBinding>,
     pub citation: AggregationCitation,
+}
+
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub struct EngineComputationBinding {
+    pub rule_id: String,
+}
+
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum EngineComputationStage {
+    Gross,
 }
 
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
@@ -147,7 +163,7 @@ impl AggregationMembershipRelation {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct PartnerPresenceRule {
-    pub entitlement_holder_input: String,
+    pub reference_person_input: String,
     pub citation: AggregationCitation,
     pub caller_determination: String,
 }
@@ -155,7 +171,7 @@ pub struct PartnerPresenceRule {
 impl Default for PartnerPresenceRule {
     fn default() -> Self {
         Self {
-            entitlement_holder_input: String::new(),
+            reference_person_input: String::new(),
             citation: AggregationCitation::default(),
             caller_determination: String::new(),
         }
@@ -510,6 +526,15 @@ pub struct AggregationPerson {
     pub scalars: BTreeMap<String, AggregationKnowledge<String>>,
     #[serde(default)]
     pub facts: BTreeMap<String, AggregationKnowledge<bool>>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub engine_computations: BTreeMap<String, EngineComputationRequest>,
+}
+
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct EngineComputationRequest {
+    pub dataset: crate::spec::DatasetSpec,
 }
 
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
@@ -551,13 +576,47 @@ impl<T> AggregationValue<T> {
 
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "status", rename_all = "snake_case", deny_unknown_fields)]
+pub enum AggregationFamilyKnowledge {
+    Determined {
+        value: Vec<AggregatedFamily>,
+    },
+    Indeterminate {
+        reasons: BTreeSet<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        value: Option<Vec<AggregatedFamily>>,
+    },
+}
+
+impl AggregationFamilyKnowledge {
+    fn determined(value: Vec<AggregatedFamily>) -> Self {
+        Self::Determined { value }
+    }
+
+    fn indeterminate(reasons: BTreeSet<String>) -> Self {
+        Self::Indeterminate {
+            reasons,
+            value: None,
+        }
+    }
+
+    fn indeterminate_with_value(reasons: BTreeSet<String>, value: Vec<AggregatedFamily>) -> Self {
+        Self::Indeterminate {
+            reasons,
+            value: Some(value),
+        }
+    }
+}
+
+#[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
 pub struct AggregationResult {
     pub schema: String,
     pub plan: String,
     pub plan_digest: String,
     pub trace_root: String,
-    pub families: AggregationValue<Vec<AggregatedFamily>>,
+    pub families: AggregationFamilyKnowledge,
 }
 
 #[cfg_attr(feature = "schema", derive(schemars::JsonSchema))]
@@ -592,7 +651,9 @@ pub struct CompiledAggregationArtifact {
     pub semantics_version: String,
     pub plan_digest: String,
     pub constitution_digest: String,
+    pub source_artifact_digest: String,
     pub plan: AggregationPlan,
+    pub source_artifact: crate::compile::CompiledProgramArtifact,
     pub phase_two_artifact: crate::compile::CompiledProgramArtifact,
 }
 
@@ -632,8 +693,9 @@ impl UnitDerivationDocumentRegistry {
     pub fn register_aggregation_source(
         &mut self,
         source: &str,
+        source_artifact: &crate::compile::CompiledProgramArtifact,
     ) -> Result<&CompiledAggregationArtifact, UnitDerivationError> {
-        let artifact = compile_aggregation_plan(source)?;
+        let artifact = compile_aggregation_plan(source, source_artifact)?;
         self.register_aggregation_artifact(artifact)
     }
 
@@ -684,32 +746,38 @@ impl UnitDerivationDocumentRegistry {
 
 pub(crate) fn compile_aggregation_plan(
     source: &str,
+    source_artifact: &crate::compile::CompiledProgramArtifact,
 ) -> Result<CompiledAggregationArtifact, UnitDerivationError> {
     let plan: AggregationPlan = serde_yaml::from_str(source).map_err(|error| {
         UnitDerivationError::InvalidPlan(format!("invalid aggregation plan YAML: {error}"))
     })?;
-    compile_aggregation_plan_value(plan)
+    compile_aggregation_plan_value(plan, source_artifact)
 }
 
 fn compile_aggregation_plan_value(
     plan: AggregationPlan,
+    source_artifact: &crate::compile::CompiledProgramArtifact,
 ) -> Result<CompiledAggregationArtifact, UnitDerivationError> {
-    validate_aggregation_plan(&plan)?;
+    let source_artifact = validate_source_artifact(source_artifact.clone())?;
+    validate_aggregation_plan(&plan, &source_artifact)?;
+    let source_artifact_digest = source_artifact_digest(&source_artifact)?;
     let phase_two_artifact = compile_phase_two_artifact(&plan)?;
-    let plan_digest = digest_text(&canonical_plan_bytes(&plan)?);
+    let plan_digest = aggregation_plan_digest(&plan, &source_artifact_digest)?;
     let constitution_digest = digest_text(&canonical_constitution_bytes(&plan)?);
     Ok(CompiledAggregationArtifact {
         format: COMPILED_AGGREGATION_ARTIFACT_FORMAT.to_string(),
         semantics_version: super::EXPERIMENTAL_SEMANTICS_VERSION.to_string(),
         plan_digest,
         constitution_digest,
+        source_artifact_digest,
         plan,
+        source_artifact,
         phase_two_artifact,
     })
 }
 
 fn validate_compiled_artifact(
-    artifact: CompiledAggregationArtifact,
+    mut artifact: CompiledAggregationArtifact,
 ) -> Result<CompiledAggregationArtifact, UnitDerivationError> {
     if artifact.format != COMPILED_AGGREGATION_ARTIFACT_FORMAT {
         return Err(UnitDerivationError::InvalidAggregationArtifact(format!(
@@ -723,7 +791,16 @@ fn validate_compiled_artifact(
             artifact.semantics_version
         )));
     }
-    let expected = compile_aggregation_plan_value(artifact.plan.clone())?;
+    artifact.source_artifact = validate_source_artifact(artifact.source_artifact)?;
+    let actual_source_digest = source_artifact_digest(&artifact.source_artifact)?;
+    if artifact.source_artifact_digest != actual_source_digest {
+        return Err(UnitDerivationError::InvalidAggregationArtifact(
+            "advertised source artifact digest does not match the embedded source artifact"
+                .to_string(),
+        ));
+    }
+    let expected =
+        compile_aggregation_plan_value(artifact.plan.clone(), &artifact.source_artifact)?;
     if artifact.plan_digest != expected.plan_digest {
         return Err(UnitDerivationError::InvalidAggregationArtifact(
             "advertised plan digest does not match the embedded plan".to_string(),
@@ -732,6 +809,11 @@ fn validate_compiled_artifact(
     if artifact.constitution_digest != expected.constitution_digest {
         return Err(UnitDerivationError::InvalidAggregationArtifact(
             "advertised constitution digest does not match the embedded plan".to_string(),
+        ));
+    }
+    if artifact.source_artifact_digest != expected.source_artifact_digest {
+        return Err(UnitDerivationError::InvalidAggregationArtifact(
+            "embedded source artifact does not match the registered plan binding".to_string(),
         ));
     }
     let actual_phase = serde_json::to_value(&artifact.phase_two_artifact).map_err(|error| {
@@ -762,6 +844,32 @@ fn validate_compiled_artifact(
         ))
     })?;
     Ok(artifact)
+}
+
+fn validate_source_artifact(
+    artifact: crate::compile::CompiledProgramArtifact,
+) -> Result<crate::compile::CompiledProgramArtifact, UnitDerivationError> {
+    let source = serde_json::to_string(&artifact).map_err(|error| {
+        UnitDerivationError::InvalidAggregationArtifact(format!(
+            "could not serialize embedded source artifact: {error}"
+        ))
+    })?;
+    crate::compile::CompiledProgramArtifact::from_json_str(&source).map_err(|error| {
+        UnitDerivationError::InvalidAggregationArtifact(format!(
+            "production source artifact validation failed: {error}"
+        ))
+    })
+}
+
+fn source_artifact_digest(
+    artifact: &crate::compile::CompiledProgramArtifact,
+) -> Result<String, UnitDerivationError> {
+    let bytes = serde_json::to_vec(artifact).map_err(|error| {
+        UnitDerivationError::InvalidAggregationArtifact(format!(
+            "could not canonically encode embedded source artifact: {error}"
+        ))
+    })?;
+    Ok(digest_text(&bytes))
 }
 
 fn compile_phase_two_artifact(
@@ -811,7 +919,10 @@ fn compile_phase_two_artifact(
     })
 }
 
-fn validate_aggregation_plan(plan: &AggregationPlan) -> Result<(), UnitDerivationError> {
+fn validate_aggregation_plan(
+    plan: &AggregationPlan,
+    source_artifact: &crate::compile::CompiledProgramArtifact,
+) -> Result<(), UnitDerivationError> {
     if plan.schema != super::EXPERIMENTAL_AGGREGATION_PLAN_SCHEMA {
         return Err(UnitDerivationError::InvalidPlan(format!(
             "aggregation plan schema `{}` is unsupported",
@@ -857,11 +968,11 @@ fn validate_aggregation_plan(plan: &AggregationPlan) -> Result<(), UnitDerivatio
     validate_citation(&plan.adult_selection.citation, "adult selection")?;
     validate_citation(&plan.age_18_conditions.citation, "age-18 conditions")?;
     validate_citation(&plan.care.citation, "care semantics")?;
-    if plan.partner_presence.entitlement_holder_input.is_empty()
+    if plan.partner_presence.reference_person_input.is_empty()
         || plan.partner_presence.caller_determination.is_empty()
     {
         return Err(UnitDerivationError::InvalidPlan(
-            "partner presence requires an explicit entitlement-holder input and caller-determination statement"
+            "partner presence requires an explicit family-unit reference-person input and caller-determination statement"
                 .to_string(),
         ));
     }
@@ -916,6 +1027,28 @@ fn validate_aggregation_plan(plan: &AggregationPlan) -> Result<(), UnitDerivatio
                 "typed reduction input `{}` needs a non-empty reduction_key",
                 input.name
             )));
+        }
+        match (&input.kind, &input.engine_computation) {
+            (AggregationInputKind::ChildGrossAmount, Some(binding)) => {
+                validate_engine_computation_binding(input, binding, source_artifact)?;
+            }
+            (AggregationInputKind::ChildGrossAmount, None) => {
+                return Err(UnitDerivationError::InvalidAggregationOperand {
+                    operation: input.name.clone(),
+                    input: input.name.clone(),
+                    expected: "engine-computed gross binding".to_string(),
+                    found: "plan-authored ChildGrossAmount without upstream binding".to_string(),
+                });
+            }
+            (_, Some(_)) => {
+                return Err(UnitDerivationError::InvalidAggregationOperand {
+                    operation: input.name.clone(),
+                    input: input.name.clone(),
+                    expected: "engine computation only on ChildGrossAmount".to_string(),
+                    found: format!("{:?}/{:?}", input.scope, input.kind),
+                });
+            }
+            (_, None) => {}
         }
     }
 
@@ -1284,6 +1417,51 @@ fn validate_aggregation_plan(plan: &AggregationPlan) -> Result<(), UnitDerivatio
     Ok(())
 }
 
+fn validate_engine_computation_binding(
+    input: &AggregationInput,
+    binding: &EngineComputationBinding,
+    source_artifact: &crate::compile::CompiledProgramArtifact,
+) -> Result<(), UnitDerivationError> {
+    if binding.rule_id.is_empty() {
+        return Err(UnitDerivationError::InvalidAggregationOperand {
+            operation: input.name.clone(),
+            input: input.name.clone(),
+            expected: "non-empty public upstream rule id at gross stage".to_string(),
+            found: "empty engine-computation rule id".to_string(),
+        });
+    }
+    let Some(rule) = source_artifact
+        .program
+        .derived
+        .iter()
+        .find(|rule| rule.id.as_deref() == Some(binding.rule_id.as_str()))
+    else {
+        return Err(UnitDerivationError::UnknownReference {
+            from: format!("engine computation for `{}`", input.name),
+            reference: binding.rule_id.clone(),
+        });
+    };
+    if input.scope != AggregationInputScope::Child
+        || rule.entity != "Child"
+        || !matches!(
+            rule.semantics,
+            crate::spec::DerivedSemanticsSpec::Scalar { .. }
+        )
+        || !matches!(
+            rule.dtype,
+            crate::spec::DTypeSpec::Decimal | crate::spec::DTypeSpec::Integer
+        )
+    {
+        return Err(UnitDerivationError::InvalidAggregationOperand {
+            operation: input.name.clone(),
+            input: binding.rule_id.clone(),
+            expected: "Child-scoped numeric upstream rule for engine-computed gross".to_string(),
+            found: format!("{:?}/{}/{:?}", input.scope, rule.entity, rule.dtype),
+        });
+    }
+    Ok(())
+}
+
 fn validate_input_ref(
     inputs: &BTreeMap<String, &AggregationInput>,
     name: &str,
@@ -1407,6 +1585,16 @@ fn canonical_plan_bytes(plan: &AggregationPlan) -> Result<Vec<u8>, UnitDerivatio
     Ok(bytes)
 }
 
+fn aggregation_plan_digest(
+    plan: &AggregationPlan,
+    source_artifact_digest: &str,
+) -> Result<String, UnitDerivationError> {
+    let mut preimage = b"axiom.unit-aggregation.bound-plan.stage3\0".to_vec();
+    push_len_prefixed(&mut preimage, &canonical_plan_bytes(plan)?);
+    push_len_prefixed(&mut preimage, source_artifact_digest.as_bytes());
+    Ok(digest_text(&preimage))
+}
+
 fn canonical_constitution_bytes(plan: &AggregationPlan) -> Result<Vec<u8>, UnitDerivationError> {
     let normalized = normalized_plan(plan);
     let value = serde_json::json!({
@@ -1495,7 +1683,7 @@ pub(crate) fn execute_aggregation_plan(
         })
         .collect::<BTreeSet<_>>();
     if !relation_reasons.is_empty() {
-        let families = AggregationValue::indeterminate(relation_reasons);
+        let families = AggregationFamilyKnowledge::indeterminate(relation_reasons);
         let trace_root = aggregation_trace_root(&artifact, request, "", &families)?;
         return Ok(AggregationResult {
             schema: super::EXPERIMENTAL_AGGREGATION_PLAN_SCHEMA.to_string(),
@@ -1508,7 +1696,7 @@ pub(crate) fn execute_aggregation_plan(
 
     if request.segment_completeness.is_none() {
         let reasons = BTreeSet::from([format!("segment-completeness:{}", request.segment)]);
-        let families = AggregationValue::indeterminate(reasons);
+        let families = AggregationFamilyKnowledge::indeterminate(reasons);
         let trace_root = aggregation_trace_root(&artifact, request, "", &families)?;
         return Ok(AggregationResult {
             schema: super::EXPERIMENTAL_AGGREGATION_PLAN_SCHEMA.to_string(),
@@ -1536,7 +1724,7 @@ pub(crate) fn execute_aggregation_plan(
             .iter()
             .flat_map(|item| item.unresolved_facts.iter().cloned())
             .collect::<BTreeSet<_>>();
-        let families = AggregationValue::indeterminate(if reasons.is_empty() {
+        let families = AggregationFamilyKnowledge::indeterminate(if reasons.is_empty() {
             BTreeSet::from(["indeterminate-family-membership".to_string()])
         } else {
             reasons
@@ -1562,8 +1750,13 @@ pub(crate) fn execute_aggregation_plan(
             ))
         })?;
     let interval = parse_segment_interval(&request.segment)?;
-    let (base, input_knowledge) =
-        bind_aggregation_dataset(plan, request, &people, &run.derivation.units, &interval)?;
+    let (base, input_knowledge, provenance) = bind_aggregation_dataset(
+        &artifact,
+        request,
+        &people,
+        &run.derivation.units,
+        &interval,
+    )?;
     let phase_two = super::materialize_phase_two_dataset_with_knowledge(
         &base,
         input_knowledge,
@@ -1598,10 +1791,28 @@ pub(crate) fn execute_aggregation_plan(
         .derivation
         .units
         .iter()
-        .map(|unit| aggregate_family(plan, &phase_two, &period, &role_index, unit))
+        .map(|unit| {
+            aggregate_family(
+                plan,
+                &phase_two,
+                &period,
+                &role_index,
+                &provenance,
+                &artifact.source_artifact_digest,
+                unit,
+            )
+        })
         .collect::<Result<Vec<_>, _>>()?;
     families.sort_by(|left, right| left.id.cmp(&right.id));
-    let families = AggregationValue::determined(families);
+    let reasons = families
+        .iter()
+        .flat_map(aggregated_family_reasons)
+        .collect::<BTreeSet<_>>();
+    let families = if reasons.is_empty() {
+        AggregationFamilyKnowledge::determined(families)
+    } else {
+        AggregationFamilyKnowledge::indeterminate_with_value(reasons, families)
+    };
     let trace_root =
         aggregation_trace_root(&artifact, request, &run.derivation.trace.root, &families)?;
     Ok(AggregationResult {
@@ -1651,6 +1862,26 @@ fn validate_request<'a>(
                     from: format!("aggregation person `{}`", person.id),
                     reference: name.clone(),
                 });
+            }
+        }
+        for name in person.engine_computations.keys() {
+            let input = declared_inputs.get(name.as_str()).ok_or_else(|| {
+                UnitDerivationError::UnknownReference {
+                    from: format!("aggregation person `{}` engine computation", person.id),
+                    reference: name.clone(),
+                }
+            })?;
+            if person.role != AggregationPersonRole::Child
+                || input.scope != AggregationInputScope::Child
+                || input.kind != AggregationInputKind::ChildGrossAmount
+                || input.engine_computation.is_none()
+            {
+                return invalid_operand(
+                    &format!("person `{}` engine computation", person.id),
+                    name,
+                    "bound ChildGrossAmount on an explicit child role",
+                    input,
+                );
             }
         }
         for name in person.facts.keys() {
@@ -1733,33 +1964,32 @@ fn validate_request<'a>(
         if family.named_people.len() != 1
             || !family
                 .named_people
-                .contains_key(&plan.partner_presence.entitlement_holder_input)
+                .contains_key(&plan.partner_presence.reference_person_input)
         {
             return Err(UnitDerivationError::InvalidPlan(format!(
                 "family input `{}` must bind exactly the plan input `{}`",
-                family.anchor_person, plan.partner_presence.entitlement_holder_input
+                family.anchor_person, plan.partner_presence.reference_person_input
             )));
         }
-        let holder_knowledge =
-            &family.named_people[&plan.partner_presence.entitlement_holder_input];
+        let holder_knowledge = &family.named_people[&plan.partner_presence.reference_person_input];
         validate_knowledge_evidence(
             holder_knowledge,
-            &format!("family `{}` entitlement holder", family.anchor_person),
+            &format!("family `{}` reference person", family.anchor_person),
         )?;
         if let Ok(holder) = resolve_knowledge(
             Some(holder_knowledge),
-            &format!("family:{}:entitlement-holder", family.anchor_person),
+            &format!("family:{}:reference-person", family.anchor_person),
         ) {
             let Some(person) = people.get(&holder) else {
                 return Err(UnitDerivationError::InvalidPlan(format!(
-                    "entitlement holder `{holder}` is outside the roster"
+                    "family-unit reference person `{holder}` is outside the roster"
                 )));
             };
             if person.role != AggregationPersonRole::Adult {
                 return Err(UnitDerivationError::InvalidRelationshipRole {
                     relation: plan.partner_relation.clone(),
                     person: holder,
-                    role: "entitlement_holder_must_be_adult".to_string(),
+                    role: "reference_person_must_be_adult".to_string(),
                 });
             }
         }
@@ -2045,15 +2275,54 @@ fn parse_segment_interval(segment: &str) -> Result<crate::model::Interval, UnitD
     Ok(crate::model::Interval { start, end })
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum OperandProvenance {
+    RequestSupplied,
+    EngineComputed {
+        source_artifact_digest: String,
+        rule_id: String,
+        stage: EngineComputationStage,
+    },
+}
+
+impl OperandProvenance {
+    fn label(&self) -> String {
+        match self {
+            Self::RequestSupplied => "request_supplied".to_string(),
+            Self::EngineComputed {
+                source_artifact_digest,
+                rule_id,
+                stage,
+            } => format!(
+                "engine_computed(source_artifact={source_artifact_digest},rule_id={rule_id},stage={})",
+                match stage {
+                    EngineComputationStage::Gross => "gross",
+                }
+            ),
+        }
+    }
+}
+
+type OperandProvenanceIndex = BTreeMap<(String, String), OperandProvenance>;
+
 fn bind_aggregation_dataset(
-    plan: &AggregationPlan,
+    artifact: &CompiledAggregationArtifact,
     request: &AggregationRequest,
     people: &BTreeMap<String, &AggregationPerson>,
     units: &[DerivedUnit],
     interval: &crate::model::Interval,
-) -> Result<(crate::model::DataSet, Vec<InputKnowledgeRecord>), UnitDerivationError> {
+) -> Result<
+    (
+        crate::model::DataSet,
+        Vec<InputKnowledgeRecord>,
+        OperandProvenanceIndex,
+    ),
+    UnitDerivationError,
+> {
+    let plan = &artifact.plan;
     let mut dataset = crate::model::DataSet::default();
     let mut unresolved = Vec::new();
+    let mut provenance = OperandProvenanceIndex::new();
 
     for person in people.values() {
         dataset.add_input(
@@ -2079,6 +2348,10 @@ fn bind_aggregation_dataset(
             );
         }
         for (name, value) in &person.scalars {
+            provenance.insert(
+                (name.clone(), person.id.clone()),
+                OperandProvenance::RequestSupplied,
+            );
             bind_known_input(
                 &mut dataset,
                 &mut unresolved,
@@ -2088,6 +2361,42 @@ fn bind_aggregation_dataset(
                 interval,
                 value,
                 crate::model::ScalarValue::Text,
+            );
+        }
+        for (name, recipe) in &person.engine_computations {
+            // An asserted scalar never gains computed provenance merely because
+            // the same request also supplies a computation recipe. The sole
+            // family-reduction guard below will reject that request value.
+            if person.scalars.contains_key(name) {
+                continue;
+            }
+            let input = plan
+                .inputs
+                .iter()
+                .find(|input| input.name == *name)
+                .expect("request engine-computation names were validated");
+            let binding = input
+                .engine_computation
+                .as_ref()
+                .expect("request engine computations require plan bindings");
+            let value =
+                execute_engine_computation(artifact, input, binding, &person.id, recipe, interval)?;
+            dataset.add_input(
+                name,
+                "Person",
+                person.id.clone(),
+                interval.clone(),
+                crate::model::ScalarValue::Text(value),
+            );
+            provenance.insert(
+                (name.clone(), person.id.clone()),
+                OperandProvenance::EngineComputed {
+                    source_artifact_digest: artifact.source_artifact_digest.clone(),
+                    rule_id: binding.rule_id.clone(),
+                    // The stage is assigned by this materialization path, not
+                    // deserialized from either the plan or the request.
+                    stage: EngineComputationStage::Gross,
+                },
             );
         }
         for (name, value) in &person.facts {
@@ -2144,14 +2453,14 @@ fn bind_aggregation_dataset(
         if let Ok(holder) = resolve_knowledge(
             family
                 .named_people
-                .get(&plan.partner_presence.entitlement_holder_input),
-            &format!("family:{}:entitlement-holder", family.anchor_person),
+                .get(&plan.partner_presence.reference_person_input),
+            &format!("family:{}:reference-person", family.anchor_person),
         ) && !unit.members.contains(&holder)
         {
             return Err(UnitDerivationError::InvalidRelationshipRole {
                 relation: plan.partner_relation.clone(),
                 person: holder,
-                role: "entitlement_holder_must_belong_to_anchored_family".to_string(),
+                role: "reference_person_must_belong_to_anchored_family".to_string(),
             });
         }
         for (name, value) in &family.named_people {
@@ -2180,7 +2489,64 @@ fn bind_aggregation_dataset(
         }
     }
 
-    Ok((dataset, unresolved))
+    Ok((dataset, unresolved, provenance))
+}
+
+fn execute_engine_computation(
+    artifact: &CompiledAggregationArtifact,
+    input: &AggregationInput,
+    binding: &EngineComputationBinding,
+    person_id: &str,
+    recipe: &EngineComputationRequest,
+    interval: &crate::model::Interval,
+) -> Result<String, UnitDerivationError> {
+    let request = crate::api::CompiledExecutionRequest {
+        mode: crate::api::ExecutionMode::Explain,
+        dataset: recipe.dataset.clone(),
+        queries: vec![crate::api::ExecutionQuery {
+            entity_id: person_id.to_string(),
+            period: crate::spec::PeriodSpec {
+                kind: crate::spec::PeriodKindSpec::TaxYear,
+                start: interval.start,
+                end: interval.end,
+            },
+            outputs: vec![binding.rule_id.clone()],
+            assessment_date: None,
+        }],
+    };
+    let response = crate::api::execute_compiled_request(artifact.source_artifact.clone(), request)
+        .map_err(|error| {
+            UnitDerivationError::InvalidPlan(format!(
+                "engine computation `{}` for child `{person_id}` failed: {error}",
+                binding.rule_id
+            ))
+        })?;
+    let output = response
+        .results
+        .first()
+        .and_then(|result| result.outputs.get(&binding.rule_id))
+        .ok_or_else(|| {
+            UnitDerivationError::InvalidPlan(format!(
+                "engine computation `{}` for child `{person_id}` returned no bound output",
+                binding.rule_id
+            ))
+        })?;
+    match output {
+        crate::api::OutputValue::Scalar {
+            value: crate::spec::ScalarValueSpec::Decimal { value },
+            ..
+        } => Ok(value.clone()),
+        crate::api::OutputValue::Scalar {
+            value: crate::spec::ScalarValueSpec::Integer { value },
+            ..
+        } => Ok(value.to_string()),
+        _ => Err(UnitDerivationError::InvalidAggregationOperand {
+            operation: input.name.clone(),
+            input: binding.rule_id.clone(),
+            expected: "engine-computed decimal or integer gross amount".to_string(),
+            found: "non-numeric upstream output".to_string(),
+        }),
+    }
 }
 
 fn bind_known_input<T: Clone + Ord>(
@@ -2354,6 +2720,8 @@ fn aggregate_family(
     data: &super::PhaseTwoDataSet,
     period: &crate::model::Period,
     roles: &RelationshipRoleIndex,
+    provenance: &OperandProvenanceIndex,
+    source_artifact_digest: &str,
     unit: &DerivedUnit,
 ) -> Result<AggregatedFamily, UnitDerivationError> {
     let member_set = unit.members.iter().cloned().collect::<BTreeSet<_>>();
@@ -2600,6 +2968,8 @@ fn aggregate_family(
             period,
             &unit.id,
             &family_children,
+            provenance,
+            source_artifact_digest,
             reduction,
             &mut scalars,
         )?;
@@ -2626,7 +2996,7 @@ fn family_partner_present(
     let members = unit.members.iter().collect::<BTreeSet<_>>();
     let holder = bound_text(
         data,
-        &plan.partner_presence.entitlement_holder_input,
+        &plan.partner_presence.reference_person_input,
         &unit.id,
         period,
     );
@@ -2813,6 +3183,30 @@ fn extend_value_reasons<T>(value: Option<&AggregationValue<T>>, reasons: &mut BT
     }
 }
 
+fn aggregated_family_reasons(family: &AggregatedFamily) -> BTreeSet<String> {
+    let mut reasons = BTreeSet::new();
+    extend_value_reasons(Some(&family.partner_present), &mut reasons);
+    for value in family.scalars.values() {
+        extend_value_reasons(Some(value), &mut reasons);
+    }
+    for value in family.counts.values() {
+        extend_value_reasons(Some(value), &mut reasons);
+    }
+    for value in family.predicates.values() {
+        extend_value_reasons(Some(value), &mut reasons);
+    }
+    for child in &family.children {
+        extend_value_reasons(Some(&child.age_years), &mut reasons);
+        for value in child.age_bands.values() {
+            extend_value_reasons(Some(value), &mut reasons);
+        }
+        for value in child.scalars.values() {
+            extend_value_reasons(Some(value), &mut reasons);
+        }
+    }
+    reasons
+}
+
 fn result_value<T>(result: Result<T, BTreeSet<String>>) -> AggregationValue<T> {
     match result {
         Ok(value) => AggregationValue::determined(value),
@@ -2826,15 +3220,40 @@ fn apply_family_reduction(
     period: &crate::model::Period,
     family_id: &str,
     children: &BTreeSet<String>,
+    provenance: &OperandProvenanceIndex,
+    source_artifact_digest: &str,
     reduction: &FamilyReduction,
     scalars: &mut BTreeMap<String, AggregationValue<String>>,
 ) -> Result<(), UnitDerivationError> {
     let child_input = reduction.child_gross_input.as_deref().unwrap();
     let adjustment_input = reduction.family_adjustment_input.as_deref().unwrap();
     let care_input = reduction.care_fraction_input.as_deref().unwrap();
+    let binding = plan
+        .inputs
+        .iter()
+        .find(|input| input.name == child_input)
+        .and_then(|input| input.engine_computation.as_ref())
+        .expect("validated child-gross inputs have an engine computation binding");
+    let expected_provenance = OperandProvenance::EngineComputed {
+        source_artifact_digest: source_artifact_digest.to_string(),
+        rule_id: binding.rule_id.clone(),
+        stage: EngineComputationStage::Gross,
+    };
     let mut gross = ExactDecimal::zero();
     let mut reasons = BTreeSet::new();
     for child_id in children {
+        let observed_provenance = provenance.get(&(child_input.to_string(), child_id.clone()));
+        if observed_provenance != Some(&expected_provenance) {
+            return Err(UnitDerivationError::InvalidChildGrossProvenance {
+                operation: reduction.output.clone(),
+                input: child_input.to_string(),
+                child: child_id.clone(),
+                expected: expected_provenance.label(),
+                found: observed_provenance
+                    .map(OperandProvenance::label)
+                    .unwrap_or_else(|| "missing".to_string()),
+            });
+        }
         let eligible = match countable_child(plan, data, child_id, period) {
             Ok(false) => continue,
             Ok(true) => match child_age(data, child_id, period) {
@@ -2975,11 +3394,12 @@ fn aggregation_trace_root(
     artifact: &CompiledAggregationArtifact,
     request: &AggregationRequest,
     constitution_trace: &str,
-    families: &AggregationValue<Vec<AggregatedFamily>>,
+    families: &AggregationFamilyKnowledge,
 ) -> Result<String, UnitDerivationError> {
     let request = normalized_request(request);
     let mut preimage = b"axiom.unit-aggregation.trace.stage3\0".to_vec();
     push_len_prefixed(&mut preimage, artifact.plan_digest.as_bytes());
+    push_len_prefixed(&mut preimage, artifact.source_artifact_digest.as_bytes());
     push_len_prefixed(&mut preimage, constitution_trace.as_bytes());
     let request_bytes = serde_json::to_vec(&request).map_err(|error| {
         UnitDerivationError::InvalidAggregationArtifact(format!(

--- a/src/unit_derivation/evaluate.rs
+++ b/src/unit_derivation/evaluate.rs
@@ -1239,7 +1239,12 @@ fn assemble_result(
         .id
         .clone();
     for person in persons {
-        registry.bind_supplied("person", person.clone(), roster_evidence.clone())?;
+        let entity_type = input
+            .supplied_entities
+            .iter()
+            .find(|entity| entity.id == *person)
+            .map_or("person", |entity| entity.entity_type.as_str());
+        registry.bind_supplied(entity_type, person.clone(), roster_evidence.clone())?;
     }
 
     let mut units = Vec::new();
@@ -1461,15 +1466,335 @@ fn trace_root(
     worlds: usize,
     events: &BTreeSet<TraceEvent>,
 ) -> String {
-    let mut preimage = b"axiom.unit-derivation.trace.stage2\0".to_vec();
-    push_len_prefixed(&mut preimage, compiled.plan.id.as_bytes());
-    push_len_prefixed(&mut preimage, input.roster.scope.as_bytes());
-    push_len_prefixed(&mut preimage, input.segment.as_bytes());
-    preimage.extend_from_slice(&(worlds as u64).to_be_bytes());
-    for event in events {
-        push_len_prefixed(&mut preimage, format!("{event:?}").as_bytes());
+    let mut encoder = TraceEncoder::new(b"axiom.unit-derivation.trace.stage2\0");
+    encoder.fixed_bytes(&compiled.semantics_digest);
+    encoder.string(&compiled.plan.id);
+    encoder.constitution_input(input);
+    encoder.usize(worlds);
+    encoder.sorted_blobs(
+        events
+            .iter()
+            .map(|event| trace_blob(|encoder| encoder.trace_event(event)))
+            .collect(),
+    );
+    format!("sha256:{}", hex(&sha256(&encoder.finish())))
+}
+
+/// Structural, canonical encoding for the stage-2 trace commitment. Set-like
+/// request collections are sorted by their encoded bytes and exact duplicate
+/// records are removed, matching the binder's normalization. Tuple slots and
+/// expression children retain their authored order because that order is
+/// semantically meaningful. No `Debug` representation enters the preimage.
+struct TraceEncoder {
+    bytes: Vec<u8>,
+}
+
+impl TraceEncoder {
+    fn new(domain: &[u8]) -> Self {
+        Self {
+            bytes: domain.to_vec(),
+        }
     }
-    format!("sha256:{}", hex(&sha256(&preimage)))
+
+    fn finish(self) -> Vec<u8> {
+        self.bytes
+    }
+
+    fn byte(&mut self, value: u8) {
+        self.bytes.push(value);
+    }
+
+    fn bool(&mut self, value: bool) {
+        self.byte(u8::from(value));
+    }
+
+    fn usize(&mut self, value: usize) {
+        self.bytes.extend_from_slice(
+            &u64::try_from(value)
+                .expect("usize always fits into the trace encoding's u64 length")
+                .to_be_bytes(),
+        );
+    }
+
+    fn fixed_bytes(&mut self, value: &[u8]) {
+        self.bytes.extend_from_slice(value);
+    }
+
+    fn bytes(&mut self, value: &[u8]) {
+        self.usize(value.len());
+        self.fixed_bytes(value);
+    }
+
+    fn string(&mut self, value: &str) {
+        self.bytes(value.as_bytes());
+    }
+
+    fn strings_in_order<'a>(&mut self, values: impl IntoIterator<Item = &'a String>) {
+        let values = values.into_iter().collect::<Vec<_>>();
+        self.usize(values.len());
+        for value in values {
+            self.string(value);
+        }
+    }
+
+    fn sorted_strings<'a>(&mut self, values: impl IntoIterator<Item = &'a String>) {
+        let mut values = values.into_iter().collect::<Vec<_>>();
+        values.sort();
+        values.dedup();
+        self.usize(values.len());
+        for value in values {
+            self.string(value);
+        }
+    }
+
+    fn sorted_blobs(&mut self, mut values: Vec<Vec<u8>>) {
+        values.sort();
+        values.dedup();
+        self.usize(values.len());
+        for value in values {
+            self.bytes(&value);
+        }
+    }
+
+    fn option_string(&mut self, value: Option<&String>) {
+        match value {
+            Some(value) => {
+                self.byte(1);
+                self.string(value);
+            }
+            None => self.byte(0),
+        }
+    }
+
+    fn citation(&mut self, citation: &Citation) {
+        self.string(&citation.provision);
+        self.string(&citation.authority);
+    }
+
+    fn evidence(&mut self, evidence: &Evidence) {
+        self.string(&evidence.id);
+        self.citation(&evidence.citation);
+    }
+
+    fn option_evidence(&mut self, evidence: Option<&Evidence>) {
+        match evidence {
+            Some(evidence) => {
+                self.byte(1);
+                self.evidence(evidence);
+            }
+            None => self.byte(0),
+        }
+    }
+
+    fn observed_bool(&mut self, observation: &ObservedBool) {
+        self.bool(observation.value);
+        self.evidence(&observation.evidence);
+    }
+
+    fn bool_expr(&mut self, expr: &BoolExpr) {
+        match expr {
+            BoolExpr::Literal(value) => {
+                self.byte(0);
+                self.bool(*value);
+            }
+            BoolExpr::Fact(FactRef::Bool(name)) => {
+                self.byte(1);
+                self.string(name);
+            }
+            BoolExpr::Fact(FactRef::Relation { family, tuple }) => {
+                self.byte(2);
+                self.string(family);
+                self.strings_in_order(tuple);
+            }
+            BoolExpr::Derived(name) => {
+                self.byte(3);
+                self.string(name);
+            }
+            BoolExpr::And(items) => {
+                self.byte(4);
+                self.usize(items.len());
+                for item in items {
+                    self.bool_expr(item);
+                }
+            }
+            BoolExpr::Or(items) => {
+                self.byte(5);
+                self.usize(items.len());
+                for item in items {
+                    self.bool_expr(item);
+                }
+            }
+            BoolExpr::Not(item) => {
+                self.byte(6);
+                self.bool_expr(item);
+            }
+        }
+    }
+
+    fn constitution_input(&mut self, input: &ConstitutionInput) {
+        self.string(&input.roster.relation);
+        self.string(&input.roster.scope);
+        self.sorted_strings(&input.roster.persons);
+        self.option_evidence(input.roster.completeness.as_ref());
+        self.string(&input.segment);
+        self.bool(input.segment_complete);
+
+        self.sorted_blobs(
+            input
+                .relation_families
+                .iter()
+                .map(|family| {
+                    trace_blob(|encoder| {
+                        encoder.string(&family.name);
+                        encoder.string(&family.scope);
+                        encoder.option_evidence(family.completeness.as_ref());
+                        encoder.sorted_blobs(
+                            family
+                                .facts
+                                .iter()
+                                .map(|fact| {
+                                    trace_blob(|encoder| {
+                                        encoder.strings_in_order(&fact.tuple);
+                                        encoder.observed_bool(&fact.observation);
+                                    })
+                                })
+                                .collect(),
+                        );
+                    })
+                })
+                .collect(),
+        );
+
+        self.sorted_blobs(
+            input
+                .bool_facts
+                .iter()
+                .map(|fact| {
+                    trace_blob(|encoder| {
+                        encoder.string(&fact.name);
+                        encoder.sorted_blobs(
+                            fact.observations
+                                .iter()
+                                .map(|observation| {
+                                    trace_blob(|encoder| encoder.observed_bool(observation))
+                                })
+                                .collect(),
+                        );
+                        encoder.option_evidence(fact.explicit_unknown.as_ref());
+                    })
+                })
+                .collect(),
+        );
+
+        self.sorted_blobs(
+            input
+                .supplied_entities
+                .iter()
+                .map(|entity| {
+                    trace_blob(|encoder| {
+                        encoder.string(&entity.entity_type);
+                        encoder.string(&entity.id);
+                        encoder.evidence(&entity.evidence);
+                    })
+                })
+                .collect(),
+        );
+
+        self.sorted_blobs(
+            input
+                .integrity_constraints
+                .iter()
+                .map(|constraint| {
+                    trace_blob(|encoder| {
+                        encoder.string(&constraint.id);
+                        encoder.bool_expr(&constraint.expr);
+                        encoder.citation(&constraint.citation);
+                    })
+                })
+                .collect(),
+        );
+    }
+
+    fn trace_event(&mut self, event: &TraceEvent) {
+        match event {
+            TraceEvent::FrozenEdge { rule, left, right } => {
+                self.byte(0);
+                self.string(rule);
+                self.string(left);
+                self.string(right);
+            }
+            TraceEvent::CutApplied {
+                rule,
+                actor,
+                request_evidence,
+            } => {
+                self.byte(1);
+                self.string(rule);
+                self.option_string(actor.as_ref());
+                self.sorted_strings(request_evidence);
+            }
+            TraceEvent::CutBlocked {
+                cut,
+                edge_rule,
+                actor,
+                request_evidence,
+            } => {
+                self.byte(2);
+                self.string(cut);
+                self.string(edge_rule);
+                self.option_string(actor.as_ref());
+                self.sorted_strings(request_evidence);
+            }
+            TraceEvent::CutOverlapConflict { left, right } => {
+                self.byte(3);
+                self.string(left);
+                self.string(right);
+            }
+            TraceEvent::Attachment {
+                rule,
+                target_anchor,
+                actor,
+                request_evidence,
+            } => {
+                self.byte(4);
+                self.string(rule);
+                self.string(target_anchor);
+                self.string(actor);
+                self.sorted_strings(request_evidence);
+            }
+            TraceEvent::IndependentBar { rule } => {
+                self.byte(5);
+                self.string(rule);
+            }
+            TraceEvent::StatusExcluded { rule, person } => {
+                self.byte(6);
+                self.string(rule);
+                self.string(person);
+            }
+            TraceEvent::ElectionDefault {
+                fact,
+                actor,
+                value,
+                citation,
+            } => {
+                self.byte(7);
+                self.string(fact);
+                self.string(actor);
+                self.bool(*value);
+                self.citation(citation);
+            }
+            TraceEvent::DiscretionNotEncoded { persons } => {
+                self.byte(8);
+                self.sorted_strings(persons);
+            }
+        }
+    }
+}
+
+fn trace_blob(encode: impl FnOnce(&mut TraceEncoder)) -> Vec<u8> {
+    let mut encoder = TraceEncoder::new(&[]);
+    encode(&mut encoder);
+    encoder.finish()
 }
 
 /// Content-derived identity from the fixed stage-2 preimage:

--- a/src/unit_derivation/interface.rs
+++ b/src/unit_derivation/interface.rs
@@ -77,6 +77,7 @@ impl EntityRegistry {
 #[derive(Clone, Debug)]
 pub struct PhaseTwoDataSet {
     dataset: crate::model::DataSet,
+    input_knowledge: Vec<InputKnowledgeRecord>,
     relation_knowledge: Vec<RelationKnowledgeRecord>,
     registry: EntityRegistry,
 }
@@ -88,6 +89,12 @@ pub struct PhaseTwoEngine<'a> {
     ordinary: crate::engine::Engine<'a>,
     program: &'a crate::model::Program,
     relation_knowledge: &'a [RelationKnowledgeRecord],
+}
+
+#[derive(Default)]
+struct ReductionReasonTraversal {
+    derived: BTreeSet<String>,
+    relations: BTreeSet<String>,
 }
 
 impl<'a> PhaseTwoEngine<'a> {
@@ -102,7 +109,7 @@ impl<'a> PhaseTwoEngine<'a> {
             derived_name,
             entity_id,
             period,
-            &mut BTreeSet::new(),
+            &mut ReductionReasonTraversal::default(),
             &mut reasons,
         );
         if !reasons.is_empty() {
@@ -118,10 +125,10 @@ impl<'a> PhaseTwoEngine<'a> {
         name: &str,
         entity_id: &str,
         period: &crate::model::Period,
-        visiting: &mut BTreeSet<String>,
+        visiting: &mut ReductionReasonTraversal,
         reasons: &mut BTreeSet<String>,
     ) {
-        if !visiting.insert(name.to_string()) {
+        if !visiting.derived.insert(name.to_string()) {
             return;
         }
         if let Some(derived) = self.program.derived.get(name)
@@ -134,7 +141,7 @@ impl<'a> PhaseTwoEngine<'a> {
                     .collect_judgment_reduction_reasons(expr, entity_id, period, visiting, reasons),
             }
         }
-        visiting.remove(name);
+        visiting.derived.remove(name);
     }
 
     fn collect_scalar_reduction_reasons(
@@ -142,7 +149,7 @@ impl<'a> PhaseTwoEngine<'a> {
         expr: &crate::model::ScalarExpr,
         entity_id: &str,
         period: &crate::model::Period,
-        visiting: &mut BTreeSet<String>,
+        visiting: &mut ReductionReasonTraversal,
         reasons: &mut BTreeSet<String>,
     ) {
         use crate::model::ScalarExpr;
@@ -193,7 +200,7 @@ impl<'a> PhaseTwoEngine<'a> {
                     *current_slot,
                     entity_id,
                     period,
-                    &mut BTreeSet::new(),
+                    visiting,
                     reasons,
                 );
                 if let Some(predicate) = where_clause {
@@ -236,7 +243,7 @@ impl<'a> PhaseTwoEngine<'a> {
         expr: &crate::model::JudgmentExpr,
         entity_id: &str,
         period: &crate::model::Period,
-        visiting: &mut BTreeSet<String>,
+        visiting: &mut ReductionReasonTraversal,
         reasons: &mut BTreeSet<String>,
     ) {
         use crate::model::JudgmentExpr;
@@ -258,7 +265,18 @@ impl<'a> PhaseTwoEngine<'a> {
             JudgmentExpr::Not(item) => {
                 self.collect_judgment_reduction_reasons(item, entity_id, period, visiting, reasons)
             }
-            JudgmentExpr::RelationMember { .. } => {}
+            JudgmentExpr::RelationMember {
+                relation,
+                current_slot,
+                ..
+            } => self.collect_relation_reasons(
+                relation,
+                *current_slot,
+                entity_id,
+                period,
+                visiting,
+                reasons,
+            ),
         }
     }
 
@@ -268,10 +286,10 @@ impl<'a> PhaseTwoEngine<'a> {
         current_slot: usize,
         entity_id: &str,
         period: &crate::model::Period,
-        visiting: &mut BTreeSet<String>,
+        visiting: &mut ReductionReasonTraversal,
         reasons: &mut BTreeSet<String>,
     ) {
-        if !visiting.insert(relation.to_string()) {
+        if !visiting.relations.insert(relation.to_string()) {
             return;
         }
         for record in self.relation_knowledge.iter().filter(|record| {
@@ -306,8 +324,15 @@ impl<'a> PhaseTwoEngine<'a> {
                 visiting,
                 reasons,
             );
+            self.collect_judgment_reduction_reasons(
+                &derivation.predicate,
+                entity_id,
+                period,
+                visiting,
+                reasons,
+            );
         }
-        visiting.remove(relation);
+        visiting.relations.remove(relation);
     }
 }
 
@@ -318,6 +343,42 @@ impl PhaseTwoDataSet {
 
     pub fn relation_knowledge(&self) -> &[RelationKnowledgeRecord] {
         &self.relation_knowledge
+    }
+
+    pub fn input_complete(
+        &self,
+        name: &str,
+        entity_id: &str,
+        period: &crate::model::Period,
+    ) -> CompleteReduction<crate::model::ScalarValue> {
+        if let Some(record) = self.input_knowledge.iter().find(|record| {
+            record.name == name
+                && record.entity_id == entity_id
+                && record.interval.contains_period(period)
+        }) {
+            return record.reduction.clone();
+        }
+        let mut values = self
+            .dataset
+            .inputs
+            .iter()
+            .filter(|record| {
+                record.name == name
+                    && record.entity_id == entity_id
+                    && record.interval.contains_period(period)
+            })
+            .map(|record| record.value.clone());
+        let Some(first) = values.next() else {
+            return CompleteReduction::Indeterminate {
+                reasons: BTreeSet::from([format!("input:{entity_id}:{name}:missing")]),
+            };
+        };
+        if values.any(|value| value != first) {
+            return CompleteReduction::Indeterminate {
+                reasons: BTreeSet::from([format!("input:{entity_id}:{name}:conflict")]),
+            };
+        }
+        CompleteReduction::Determined(first)
     }
 
     pub fn registry(&self) -> &EntityRegistry {
@@ -696,6 +757,27 @@ pub fn materialize_phase_two_dataset(
     run: &PrototypeRun,
     interval: crate::model::Interval,
 ) -> Result<PhaseTwoDataSet, UnitDerivationError> {
+    materialize_phase_two_dataset_with_knowledge(
+        base,
+        Vec::new(),
+        phase_two_program,
+        input,
+        run,
+        interval,
+    )
+}
+
+/// Materialization barrier variant for callers that have explicit
+/// Knowledge-valued scalar inputs. Only unresolved inputs belong in
+/// `input_knowledge`; determined values must be present in `base.inputs`.
+pub fn materialize_phase_two_dataset_with_knowledge(
+    base: &crate::model::DataSet,
+    mut input_knowledge: Vec<InputKnowledgeRecord>,
+    phase_two_program: &crate::model::Program,
+    input: &ConstitutionInput,
+    run: &PrototypeRun,
+    interval: crate::model::Interval,
+) -> Result<PhaseTwoDataSet, UnitDerivationError> {
     let derived_relations = BTreeSet::from([
         run.derivation.relations.unit_constituent.as_str(),
         run.derivation.relations.participating_member.as_str(),
@@ -729,13 +811,61 @@ pub fn materialize_phase_two_dataset(
             evidence.id.as_str()
         });
     for person in &input.roster.persons {
-        registry.bind_supplied("person", person.clone(), roster_evidence)?;
+        let entity_type = input
+            .supplied_entities
+            .iter()
+            .find(|entity| entity.id == *person)
+            .map_or("person", |entity| entity.entity_type.as_str());
+        registry.bind_supplied(entity_type, person.clone(), roster_evidence)?;
+    }
+    for unit in &run.derivation.units {
+        registry.insert_derived(unit)?;
     }
     for record in &base.inputs {
-        registry.bind_supplied(
-            record.entity.clone(),
-            record.entity_id.clone(),
-            format!("dataset-input:{}", record.name),
+        bind_materialized_entity(
+            &mut registry,
+            &record.entity,
+            &record.entity_id,
+            &format!("dataset-input:{}", record.name),
+        )?;
+    }
+    input_knowledge.sort_by(|left, right| {
+        (
+            left.entity_id.as_str(),
+            left.name.as_str(),
+            &left.interval.start,
+            &left.interval.end,
+        )
+            .cmp(&(
+                right.entity_id.as_str(),
+                right.name.as_str(),
+                &right.interval.start,
+                &right.interval.end,
+            ))
+    });
+    for window in input_knowledge.windows(2) {
+        if window[0].name == window[1].name
+            && window[0].entity_id == window[1].entity_id
+            && window[0].interval == window[1].interval
+        {
+            return Err(UnitDerivationError::InvalidPlan(format!(
+                "duplicate Knowledge input `{}` for `{}`",
+                window[0].name, window[0].entity_id
+            )));
+        }
+    }
+    for record in &input_knowledge {
+        if matches!(record.reduction, CompleteReduction::Determined(_)) {
+            return Err(UnitDerivationError::InvalidPlan(format!(
+                "determined Knowledge input `{}` for `{}` must use the ordinary dataset",
+                record.name, record.entity_id
+            )));
+        }
+        bind_materialized_entity(
+            &mut registry,
+            &record.entity,
+            &record.entity_id,
+            &format!("knowledge-input:{}", record.name),
         )?;
     }
     for record in &base.relations {
@@ -762,10 +892,6 @@ pub fn materialize_phase_two_dataset(
             )?;
         }
     }
-    for unit in &run.derivation.units {
-        registry.insert_derived(unit)?;
-    }
-
     let mut materialized = base.clone();
     let records = run
         .derivation
@@ -836,9 +962,29 @@ pub fn materialize_phase_two_dataset(
 
     Ok(PhaseTwoDataSet {
         dataset: materialized,
+        input_knowledge,
         relation_knowledge,
         registry,
     })
+}
+
+fn bind_materialized_entity(
+    registry: &mut EntityRegistry,
+    entity_type: &str,
+    id: &str,
+    evidence_id: &str,
+) -> Result<(), UnitDerivationError> {
+    if let Some(existing) = registry.get(id) {
+        if existing.entity_type != entity_type {
+            return Err(UnitDerivationError::EntityCollision {
+                id: id.to_string(),
+                existing_type: existing.entity_type.clone(),
+                incoming_type: entity_type.to_string(),
+            });
+        }
+        return Ok(());
+    }
+    registry.bind_supplied(entity_type, id, evidence_id)
 }
 
 fn projection_name(projection: Projection) -> &'static str {

--- a/src/unit_derivation/mod.rs
+++ b/src/unit_derivation/mod.rs
@@ -14,14 +14,20 @@ mod tests;
 mod types;
 
 pub use aggregation::{
-    AggregationPerson, AggregationPlan, AggregationRequest, AggregationResult,
-    execute_aggregation_plan, parse_aggregation_plan,
+    AggregatedChild, AggregatedFamily, AggregationEvidence, AggregationFamilyInput,
+    AggregationKnowledge, AggregationObservation, AggregationPerson, AggregationPersonRole,
+    AggregationPlan, AggregationRelationFact, AggregationRelationFamily, AggregationRequest,
+    AggregationResult, AggregationValue, COMPILED_AGGREGATION_ARTIFACT_FORMAT,
+    CompiledAggregationArtifact, UnitDerivationDocumentRegistry,
 };
+#[cfg(test)]
+pub(crate) use aggregation::{compile_aggregation_plan, execute_aggregation_plan};
 pub use compile::{CompiledConstitution, compile};
 pub use evaluate::{derive_units, unit_id};
 pub use interface::{
     EntityRegistry, FrozenLedger, PhaseTwoDataSet, PhaseTwoEngine, Prototype, ShadowChannel,
-    lift_derived_relation, materialize_phase_two_dataset, serialize_experimental_run,
+    lift_derived_relation, materialize_phase_two_dataset,
+    materialize_phase_two_dataset_with_knowledge, serialize_experimental_run,
 };
 pub use types::*;
 

--- a/src/unit_derivation/mod.rs
+++ b/src/unit_derivation/mod.rs
@@ -5,6 +5,7 @@
 //! deliberately does not change RuleSpec, artifact v2, the ordinary engine,
 //! or any release/launch surface.
 
+mod aggregation;
 mod compile;
 mod evaluate;
 mod interface;
@@ -12,6 +13,10 @@ mod interface;
 mod tests;
 mod types;
 
+pub use aggregation::{
+    AggregationPerson, AggregationPlan, AggregationRequest, AggregationResult,
+    execute_aggregation_plan, parse_aggregation_plan,
+};
 pub use compile::{CompiledConstitution, compile};
 pub use evaluate::{derive_units, unit_id};
 pub use interface::{
@@ -23,3 +28,8 @@ pub use types::*;
 /// Experimental identity required by the prototype interface. This value is
 /// intentionally not an artifact-format or release-line version.
 pub const EXPERIMENTAL_SEMANTICS_VERSION: &str = "unit-derivation-stage2/1";
+
+/// Separate experimental document identity for the stage-3 projection layer.
+/// It is not an artifact-format version and is unavailable without the
+/// off-by-default `unit-derivation` Cargo feature.
+pub const EXPERIMENTAL_AGGREGATION_PLAN_SCHEMA: &str = "axiom/unit-aggregation-plan-stage3/1";

--- a/src/unit_derivation/mod.rs
+++ b/src/unit_derivation/mod.rs
@@ -15,10 +15,11 @@ mod types;
 
 pub use aggregation::{
     AggregatedChild, AggregatedFamily, AggregationEvidence, AggregationFamilyInput,
-    AggregationKnowledge, AggregationObservation, AggregationPerson, AggregationPersonRole,
-    AggregationPlan, AggregationRelationFact, AggregationRelationFamily, AggregationRequest,
-    AggregationResult, AggregationValue, COMPILED_AGGREGATION_ARTIFACT_FORMAT,
-    CompiledAggregationArtifact, UnitDerivationDocumentRegistry,
+    AggregationFamilyKnowledge, AggregationKnowledge, AggregationObservation, AggregationPerson,
+    AggregationPersonRole, AggregationPlan, AggregationRelationFact, AggregationRelationFamily,
+    AggregationRequest, AggregationResult, AggregationValue, COMPILED_AGGREGATION_ARTIFACT_FORMAT,
+    CompiledAggregationArtifact, EngineComputationBinding, EngineComputationRequest,
+    EngineComputationStage, UnitDerivationDocumentRegistry,
 };
 #[cfg(test)]
 pub(crate) use aggregation::{compile_aggregation_plan, execute_aggregation_plan};

--- a/src/unit_derivation/tests.rs
+++ b/src/unit_derivation/tests.rs
@@ -1353,9 +1353,67 @@ fn nz_known<T>(value: T, id: &str) -> AggregationKnowledge<T> {
     }
 }
 
+const NZ_GROSS_RULE_ID: &str =
+    "nz:statutes/income_tax/family_scheme/tax_credits#best_start_tax_credit_before_abatement";
+
+struct NzGrossModuleSource(String);
+
+impl crate::source::ModuleSource for NzGrossModuleSource {
+    fn load(&self, target: &str) -> Result<Option<String>, crate::source::SourceError> {
+        Ok((target == "nz:statutes/income_tax/family_scheme/tax_credits").then(|| self.0.clone()))
+    }
+}
+
+fn nz_source_artifact() -> crate::compile::CompiledProgramArtifact {
+    compile_nz_source_artifact(include_str!(
+        "../../tests/fixtures/unit_derivation/nz_best_start_gross.rulespec.yaml"
+    ))
+}
+
+fn compile_nz_source_artifact(source: &str) -> crate::compile::CompiledProgramArtifact {
+    crate::compile::CompiledProgramArtifact::from_rulespec_with_source(
+        "nz:statutes/income_tax/family_scheme/tax_credits",
+        &NzGrossModuleSource(source.to_string()),
+    )
+    .unwrap()
+}
+
+fn nz_gross_computation(person_id: &str, gross: &str) -> EngineComputationRequest {
+    let entitlement_days = match gross {
+        "4041" => 365,
+        "0" => 0,
+        other => panic!("unsupported fixture gross `{other}`"),
+    };
+    EngineComputationRequest {
+        dataset: serde_json::from_value(serde_json::json!({
+            "inputs": [
+                {
+                    "name": "nz:statutes/income_tax/family_scheme/tax_credits#input.best_start_entitlement_days",
+                    "entity": "Child",
+                    "entity_id": person_id,
+                    "interval": {"start": "2026-04-01", "end": "2027-03-31"},
+                    "value": {"kind": "integer", "value": entitlement_days}
+                },
+                {
+                    "name": "nz:statutes/income_tax/family_scheme/tax_credits#input.best_start_child_care_fraction",
+                    "entity": "Child",
+                    "entity_id": person_id,
+                    "interval": {"start": "2026-04-01", "end": "2027-03-31"},
+                    "value": {"kind": "decimal", "value": "1"}
+                }
+            ]
+        }))
+        .unwrap(),
+    }
+}
+
 fn nz_person(id: &str, age_years: i64, values: &[(&str, &str)], child: bool) -> AggregationPerson {
+    let gross = values.iter().find_map(|(name, value)| {
+        (*name == "best_start_before_care_and_abatement").then_some(*value)
+    });
     let mut scalars = values
         .iter()
+        .filter(|(name, _)| *name != "best_start_before_care_and_abatement")
         .map(|(name, value)| {
             (
                 (*name).to_string(),
@@ -1404,6 +1462,14 @@ fn nz_person(id: &str, age_years: i64, values: &[(&str, &str)], child: bool) -> 
         } else {
             BTreeMap::new()
         },
+        engine_computations: gross
+            .map(|gross| {
+                BTreeMap::from([(
+                    "best_start_before_care_and_abatement".to_string(),
+                    nz_gross_computation(id, gross),
+                )])
+            })
+            .unwrap_or_default(),
     }
 }
 
@@ -1521,8 +1587,8 @@ fn nz_request() -> AggregationRequest {
             anchor_person: "primary".to_string(),
             evidence: nz_evidence("family-input:primary"),
             named_people: BTreeMap::from([(
-                "mc7_entitlement_holder".to_string(),
-                nz_known("primary".to_string(), "mc7:primary"),
+                "family_unit_reference_person".to_string(),
+                nz_known("primary".to_string(), "family-reference:primary"),
             )]),
             scalars: BTreeMap::from([
                 (
@@ -1555,13 +1621,46 @@ fn determined<T>(value: &AggregationValue<T>) -> &T {
     }
 }
 
+fn indeterminate_reasons<T>(value: &AggregationValue<T>) -> &BTreeSet<String> {
+    match value {
+        AggregationValue::Indeterminate { reasons } => reasons,
+        AggregationValue::Determined { .. } => panic!("expected Indeterminate value"),
+    }
+}
+
+fn determined_families(value: &AggregationFamilyKnowledge) -> &[AggregatedFamily] {
+    match value {
+        AggregationFamilyKnowledge::Determined { value } => value,
+        AggregationFamilyKnowledge::Indeterminate { reasons, .. } => {
+            panic!("expected Determined families, found {reasons:?}")
+        }
+    }
+}
+
+fn indeterminate_families(value: &AggregationFamilyKnowledge) -> &[AggregatedFamily] {
+    match value {
+        AggregationFamilyKnowledge::Indeterminate {
+            value: Some(value), ..
+        } => value,
+        AggregationFamilyKnowledge::Indeterminate {
+            reasons,
+            value: None,
+        } => panic!("expected retained family topology, found only {reasons:?}"),
+        AggregationFamilyKnowledge::Determined { .. } => {
+            panic!("expected Indeterminate families")
+        }
+    }
+}
+
 #[test]
 fn nz_family_fixture_uses_registered_artifact_and_asserts_every_output() {
     let mut registry = UnitDerivationDocumentRegistry::default();
+    let source_artifact = nz_source_artifact();
     let artifact = registry
-        .register_aggregation_source(include_str!(
-            "../../tests/fixtures/unit_derivation/nz_income_explorer_family.yaml"
-        ))
+        .register_aggregation_source(
+            include_str!("../../tests/fixtures/unit_derivation/nz_income_explorer_family.yaml"),
+            &source_artifact,
+        )
         .unwrap();
     let artifact_json = artifact.to_json_pretty().unwrap();
     let mut reloaded = UnitDerivationDocumentRegistry::default();
@@ -1578,7 +1677,7 @@ fn nz_family_fixture_uses_registered_artifact_and_asserts_every_output() {
     assert_eq!(result.plan, "nz:incomeexplorer:family-aggregation-2026-27");
     assert!(result.plan_digest.starts_with("sha256:"));
     assert!(result.trace_root.starts_with("sha256:"));
-    let families = determined(&result.families);
+    let families = determined_families(&result.families);
     assert_eq!(families.len(), 1);
     let family = &families[0];
     assert_eq!(
@@ -1688,8 +1787,14 @@ fn nz_tier_b_legal_choices_are_explicit_cited_inputs_and_limitations() {
     let artifact = nz_artifact();
     let plan = &artifact.plan;
     assert_eq!(
-        plan.partner_presence.citation.provision,
-        "Income Tax Act 2007 s MC 7"
+        plan.partner_presence.reference_person_input,
+        "family_unit_reference_person"
+    );
+    assert!(
+        plan.partner_presence
+            .citation
+            .provision
+            .contains("MC 7(1) chapeau")
     );
     assert_eq!(
         plan.partner_presence.citation.authority,
@@ -1706,10 +1811,23 @@ fn nz_tier_b_legal_choices_are_explicit_cited_inputs_and_limitations() {
             .contains("Caller-evidenced")
     );
     assert_eq!(plan.age_18_conditions.age, 18);
-    for input in [
-        &plan.age_18_conditions.not_financially_independent_input,
-        &plan.age_18_conditions.attending_school_or_tertiary_input,
-        &plan.age_18_conditions.commissioner_period_input,
+    assert_eq!(
+        plan.age_18_conditions.citation.provision,
+        "Income Tax Act 2007 s MC 9(1)(a)-(b) and (2)-(3)"
+    );
+    for (input, provision) in [
+        (
+            &plan.age_18_conditions.not_financially_independent_input,
+            "Income Tax Act 2007 s MC 9(1)(a)",
+        ),
+        (
+            &plan.age_18_conditions.attending_school_or_tertiary_input,
+            "Income Tax Act 2007 s MC 9(1)(b)",
+        ),
+        (
+            &plan.age_18_conditions.commissioner_period_input,
+            "Income Tax Act 2007 s MC 9(2)-(3)",
+        ),
     ] {
         let declaration = plan
             .inputs
@@ -1720,7 +1838,35 @@ fn nz_tier_b_legal_choices_are_explicit_cited_inputs_and_limitations() {
             declaration.citation.authority,
             "nz/statute/act/public/2007/0097/section/MC-9"
         );
+        assert_eq!(declaration.citation.provision, provision);
     }
+    let age_14_18 = plan
+        .child_counts
+        .iter()
+        .find(|count| count.output == "child_count_age_14_18")
+        .unwrap();
+    assert!(
+        age_14_18
+            .citation
+            .provision
+            .contains("para (a) for ages 14-15")
+    );
+    assert!(
+        age_14_18
+            .citation
+            .provision
+            .contains("para (b), including not financially independent, for ages 16-17")
+    );
+    assert!(
+        age_14_18
+            .citation
+            .provision
+            .contains("para (c) with s MC 9(1)(a)-(b), (2)-(3) applies at age 18")
+    );
+    assert_eq!(
+        age_14_18.citation.authority,
+        "nz/statute/act/public/2007/0097/section/YA-1"
+    );
     let best_start_care = plan
         .inputs
         .iter()
@@ -1737,7 +1883,27 @@ fn nz_tier_b_legal_choices_are_explicit_cited_inputs_and_limitations() {
         .unwrap();
     assert_eq!(
         iwtc_care.citation.provision,
+        "Income Tax Act 2007 ss MC 10(4) and MD 10(2), (3)(d)"
+    );
+    let iwtc_principal = plan
+        .inputs
+        .iter()
+        .find(|input| input.name == "in_work_tax_credit_principal_caregiver")
+        .unwrap();
+    assert_eq!(
+        iwtc_principal.citation.provision,
         "Income Tax Act 2007 s MC 10(3)"
+    );
+    assert_eq!(
+        plan.child_agreements
+            .iter()
+            .find(|agreement| {
+                agreement.output == "in_work_tax_credit_child_exclusive_care_fraction"
+            })
+            .unwrap()
+            .citation
+            .provision,
+        "Income Tax Act 2007 ss MC 10(4) and MD 10(2), (3)(d)"
     );
     let limitation_ids = plan
         .limitations
@@ -1745,7 +1911,7 @@ fn nz_tier_b_legal_choices_are_explicit_cited_inputs_and_limitations() {
         .map(|limitation| limitation.id.as_str())
         .collect::<BTreeSet<_>>();
     for required in [
-        "mc7-entitlement-selection",
+        "mc7-applicability-and-selection-out-of-scope",
         "mc9-commissioner-period",
         "mg2-care-fact",
         "relationship-and-role-classification",
@@ -1755,6 +1921,39 @@ fn nz_tier_b_legal_choices_are_explicit_cited_inputs_and_limitations() {
     ] {
         assert!(limitation_ids.contains(required));
     }
+    let mc7_limitation = plan
+        .limitations
+        .iter()
+        .find(|limitation| limitation.id == "mc7-applicability-and-selection-out-of-scope")
+        .unwrap();
+    assert!(mc7_limitation.statement.contains("MC 7(1) applicability"));
+    assert!(
+        mc7_limitation
+            .statement
+            .contains("MC 7(2) allocation or Commissioner selection")
+    );
+    assert_eq!(
+        mc7_limitation.citation.provision,
+        "Income Tax Act 2007 s MC 7(1)-(2)"
+    );
+    assert_eq!(
+        plan.limitations
+            .iter()
+            .find(|limitation| limitation.id == "mc9-commissioner-period")
+            .unwrap()
+            .citation
+            .provision,
+        "Income Tax Act 2007 s MC 9(2)-(3)"
+    );
+    assert_eq!(
+        plan.limitations
+            .iter()
+            .find(|limitation| limitation.id == "mc10-iwtc-care")
+            .unwrap()
+            .citation
+            .provision,
+        "Income Tax Act 2007 ss MC 10(3)-(4) and MD 10(2), (3)(d)"
+    );
 }
 
 #[test]
@@ -1764,7 +1963,7 @@ fn reviewer_best_start_plan_is_rejected_by_named_family_scope_guard() {
         include_str!("../../tests/fixtures/unit_derivation/per_child_request.json")
             .contains("\"two_child_abatement\": \"2000\"")
     );
-    let error = compile_aggregation_plan(source)
+    let error = compile_aggregation_plan(source, &nz_source_artifact())
         .expect_err("the exact accepted reviewer plan must now fail semantic validation");
     assert_eq!(
         error,
@@ -1777,10 +1976,76 @@ fn reviewer_best_start_plan_is_rejected_by_named_family_scope_guard() {
 }
 
 #[test]
-fn unknown_scalar_and_missing_relation_completeness_never_become_zero() {
-    let artifact = compile_aggregation_plan(include_str!(
-        "../../tests/fixtures/unit_derivation/nz_income_explorer_family.yaml"
+fn relabelled_request_scalar_is_rejected_by_named_engine_provenance_guard() {
+    let artifact = compile_aggregation_plan(
+        include_str!("../../tests/fixtures/unit_derivation/renamed_child_gross_plan.yaml"),
+        &nz_source_artifact(),
+    )
+    .unwrap();
+    let request: AggregationRequest = serde_json::from_str(include_str!(
+        "../../tests/fixtures/unit_derivation/renamed_child_gross_request.json"
     ))
+    .unwrap();
+
+    let error = execute_aggregation_plan(&artifact, &request, &enabled())
+        .expect_err("a request scalar cannot acquire engine-computed provenance by relabelling");
+    match error {
+        UnitDerivationError::InvalidChildGrossProvenance {
+            operation,
+            input,
+            child,
+            expected,
+            found,
+        } => {
+            assert_eq!(operation, "best_start_total");
+            assert_eq!(input, "best_start_after_per_child_abatement");
+            assert_eq!(child, "child-0");
+            assert_eq!(found, "request_supplied");
+            assert!(expected.contains(&format!("rule_id={NZ_GROSS_RULE_ID}")));
+            assert!(expected.contains("stage=gross"));
+            assert!(expected.contains(&artifact.source_artifact_digest));
+        }
+        other => panic!("expected InvalidChildGrossProvenance, found {other:?}"),
+    }
+}
+
+#[test]
+fn request_scalar_cannot_launder_through_a_same_name_engine_recipe() {
+    let artifact = nz_artifact();
+    let mut request = nz_request();
+    let child = request
+        .persons
+        .iter_mut()
+        .find(|person| person.id == "child-0")
+        .unwrap();
+    child.scalars.insert(
+        "best_start_before_care_and_abatement".to_string(),
+        nz_known("3041".to_string(), "laundered-request-scalar"),
+    );
+
+    let error = execute_aggregation_plan(&artifact, &request, &enabled())
+        .expect_err("an asserted scalar must retain request-supplied provenance");
+    assert!(matches!(
+        error,
+        UnitDerivationError::InvalidChildGrossProvenance {
+            operation,
+            input,
+            child,
+            found,
+            ..
+        } if operation == "best_start_total"
+            && input == "best_start_before_care_and_abatement"
+            && child == "child-0"
+            && found == "request_supplied"
+    ));
+}
+
+#[test]
+fn unknown_scalar_and_missing_relation_completeness_never_become_zero() {
+    let artifact = compile_aggregation_plan(
+        include_str!("../../tests/fixtures/unit_derivation/nz_income_explorer_family.yaml"),
+        &nz_source_artifact(),
+    )
     .unwrap();
     let mut scalar_unknown = nz_request();
     scalar_unknown.persons[0].scalars.insert(
@@ -1790,7 +2055,7 @@ fn unknown_scalar_and_missing_relation_completeness_never_become_zero() {
         },
     );
     let result = execute_aggregation_plan(&artifact, &scalar_unknown, &enabled()).unwrap();
-    let family = &determined(&result.families)[0];
+    let family = &indeterminate_families(&result.families)[0];
     assert!(matches!(
         family.scalars["weekly_wages"],
         AggregationValue::Indeterminate { .. }
@@ -1814,7 +2079,7 @@ fn unknown_scalar_and_missing_relation_completeness_never_become_zero() {
     );
     let result = execute_aggregation_plan(&artifact, &scalar_conflict, &enabled()).unwrap();
     assert!(matches!(
-        determined(&result.families)[0].scalars["weekly_wages"],
+        indeterminate_families(&result.families)[0].scalars["weekly_wages"],
         AggregationValue::Indeterminate { .. }
     ));
 
@@ -1823,7 +2088,7 @@ fn unknown_scalar_and_missing_relation_completeness_never_become_zero() {
         .scalars
         .remove("family_scheme_income");
     let result = execute_aggregation_plan(&artifact, &missing_family_scalar, &enabled()).unwrap();
-    let family = &determined(&result.families)[0];
+    let family = &indeterminate_families(&result.families)[0];
     assert!(matches!(
         family.scalars["best_start_total_continuous_abatement"],
         AggregationValue::Indeterminate { .. }
@@ -1844,8 +2109,105 @@ fn unknown_scalar_and_missing_relation_completeness_never_become_zero() {
     let result = execute_aggregation_plan(&artifact, &missing_completeness, &enabled()).unwrap();
     assert!(matches!(
         result.families,
-        AggregationValue::Indeterminate { .. }
+        AggregationFamilyKnowledge::Indeterminate { value: None, .. }
     ));
+}
+
+#[test]
+fn mixed_conflict_care_and_unknown_age_indetermines_family_without_losing_topology() {
+    let artifact = nz_artifact();
+    let mut request = nz_request();
+    request
+        .persons
+        .iter_mut()
+        .find(|person| person.id == "child-0")
+        .unwrap()
+        .scalars
+        .insert(
+            "best_start_claimant_care_fraction".to_string(),
+            AggregationKnowledge::Conflict {
+                observations: vec![
+                    AggregationObservation {
+                        value: "1".to_string(),
+                        evidence: nz_evidence("mixed:care:full"),
+                    },
+                    AggregationObservation {
+                        value: "0.5".to_string(),
+                        evidence: nz_evidence("mixed:care:half"),
+                    },
+                ],
+            },
+        );
+    let child_1 = request
+        .persons
+        .iter_mut()
+        .find(|person| person.id == "child-1")
+        .unwrap();
+    child_1.age_years = Some(AggregationKnowledge::Unknown {
+        evidence: nz_evidence("mixed:age:unknown"),
+    });
+
+    let result = execute_aggregation_plan(&artifact, &request, &enabled()).unwrap();
+    let care_reasons = BTreeSet::from([
+        "input:child-0:best_start_claimant_care_fraction:conflict:mixed:care:full".to_string(),
+        "input:child-0:best_start_claimant_care_fraction:conflict:mixed:care:half".to_string(),
+    ]);
+    let age_reasons =
+        BTreeSet::from(["input:child-1:age_years:unknown:mixed:age:unknown".to_string()]);
+    let mut all_reasons = care_reasons.clone();
+    all_reasons.extend(age_reasons.iter().cloned());
+    let families = match &result.families {
+        AggregationFamilyKnowledge::Indeterminate {
+            reasons,
+            value: Some(value),
+        } => {
+            assert_eq!(reasons, &all_reasons);
+            value
+        }
+        other => panic!("expected Indeterminate families with retained topology, found {other:?}"),
+    };
+
+    assert_eq!(families.len(), 1);
+    let family = &families[0];
+    assert_eq!(
+        family.members,
+        vec!["child-0", "child-1", "partner", "primary"]
+    );
+    assert_eq!(
+        family
+            .children
+            .iter()
+            .map(|child| child.person.as_str())
+            .collect::<Vec<_>>(),
+        vec!["child-0", "child-1"]
+    );
+    let child_0 = family
+        .children
+        .iter()
+        .find(|child| child.person == "child-0")
+        .unwrap();
+    let child_1 = family
+        .children
+        .iter()
+        .find(|child| child.person == "child-1")
+        .unwrap();
+    assert_eq!(
+        indeterminate_reasons(&child_0.scalars["best_start_claimant_care_fraction"]),
+        &care_reasons
+    );
+    assert_eq!(
+        indeterminate_reasons(&family.scalars["best_start_total"]),
+        &all_reasons
+    );
+    assert_eq!(
+        indeterminate_reasons(&family.counts["dependent_child_count"]),
+        &age_reasons
+    );
+    assert_eq!(
+        indeterminate_reasons(&family.counts["youngest_child_age"]),
+        &age_reasons
+    );
+    assert_eq!(indeterminate_reasons(&child_1.age_years), &age_reasons);
 }
 
 #[test]
@@ -1888,7 +2250,10 @@ fn indeterminate_relation_knowledge_cannot_produce_a_smaller_determined_family()
             .knowledge = knowledge;
         let result = execute_aggregation_plan(&artifact, &request, &enabled()).unwrap();
         assert!(
-            matches!(result.families, AggregationValue::Indeterminate { .. }),
+            matches!(
+                result.families,
+                AggregationFamilyKnowledge::Indeterminate { value: None, .. }
+            ),
             "an unresolved child relation must not become a determined smaller count"
         );
     }
@@ -1904,7 +2269,7 @@ fn omitted_relation_is_unknown_but_evidenced_complete_empty_is_known_empty() {
     let result = execute_aggregation_plan(&artifact, &omitted, &enabled()).unwrap();
     assert!(matches!(
         result.families,
-        AggregationValue::Indeterminate { .. }
+        AggregationFamilyKnowledge::Indeterminate { value: None, .. }
     ));
 
     let mut complete_empty = nz_request();
@@ -1916,7 +2281,7 @@ fn omitted_relation_is_unknown_but_evidenced_complete_empty_is_known_empty() {
         .facts
         .clear();
     let result = execute_aggregation_plan(&artifact, &complete_empty, &enabled()).unwrap();
-    let primary = determined(&result.families)
+    let primary = indeterminate_families(&result.families)
         .iter()
         .find(|family| family.members.contains(&"primary".to_string()))
         .unwrap();
@@ -1928,9 +2293,10 @@ fn omitted_relation_is_unknown_but_evidenced_complete_empty_is_known_empty() {
 }
 
 fn nz_artifact() -> CompiledAggregationArtifact {
-    compile_aggregation_plan(include_str!(
-        "../../tests/fixtures/unit_derivation/nz_income_explorer_family.yaml"
-    ))
+    compile_aggregation_plan(
+        include_str!("../../tests/fixtures/unit_derivation/nz_income_explorer_family.yaml"),
+        &nz_source_artifact(),
+    )
     .unwrap()
 }
 
@@ -1968,7 +2334,7 @@ fn child_age_boundaries_and_every_mc9_condition_are_operational() {
     let mut request = nz_request();
     replace_children(&mut request, &[0, 2, 3, 13, 14, 18, 19]);
     let result = execute_aggregation_plan(&artifact, &request, &enabled()).unwrap();
-    let family = &determined(&result.families)[0];
+    let family = &determined_families(&result.families)[0];
     assert_eq!(*determined(&family.counts["dependent_child_count"]), 6);
     assert_eq!(
         *determined(&family.counts["best_start_eligible_child_count"]),
@@ -2012,7 +2378,7 @@ fn child_age_boundaries_and_every_mc9_condition_are_operational() {
             .facts
             .insert(fact.to_string(), nz_known(false, &format!("false:{fact}")));
         let result = execute_aggregation_plan(&artifact, &false_request, &enabled()).unwrap();
-        let family = &determined(&result.families)[0];
+        let family = &determined_families(&result.families)[0];
         assert_eq!(*determined(&family.counts["dependent_child_count"]), 5);
         assert_eq!(*determined(&family.counts["child_count_age_14_18"]), 1);
     }
@@ -2031,7 +2397,7 @@ fn child_age_boundaries_and_every_mc9_condition_are_operational() {
             },
         );
     let result = execute_aggregation_plan(&artifact, &unknown, &enabled()).unwrap();
-    let family = &determined(&result.families)[0];
+    let family = &indeterminate_families(&result.families)[0];
     assert!(matches!(
         family.counts["dependent_child_count"],
         AggregationValue::Indeterminate { .. }
@@ -2071,7 +2437,7 @@ fn missing_unknown_and_conflicting_child_inputs_never_reduce_to_zero_or_false() 
             .unwrap()
             .age_years = age;
         let result = execute_aggregation_plan(&artifact, &request, &enabled()).unwrap();
-        let family = &determined(&result.families)[0];
+        let family = &indeterminate_families(&result.families)[0];
         assert!(matches!(
             family.counts["dependent_child_count"],
             AggregationValue::Indeterminate { .. }
@@ -2108,7 +2474,7 @@ fn missing_unknown_and_conflicting_child_inputs_never_reduce_to_zero_or_false() 
             .facts
             .insert("principal_care_for_family_scheme".to_string(), knowledge);
         let result = execute_aggregation_plan(&artifact, &request, &enabled()).unwrap();
-        let family = &determined(&result.families)[0];
+        let family = &indeterminate_families(&result.families)[0];
         assert!(matches!(
             family.counts["dependent_child_count"],
             AggregationValue::Indeterminate { .. }
@@ -2141,7 +2507,7 @@ fn mg2_care_fraction_and_principal_care_are_not_defaulted() {
             nz_known("0".to_string(), "no-adjustment"),
         );
         let result = execute_aggregation_plan(&artifact, &request, &enabled()).unwrap();
-        let family = &determined(&result.families)[0];
+        let family = &determined_families(&result.families)[0];
         assert_eq!(
             determined(&family.scalars["best_start_total_before_abatement"]),
             expected_gross
@@ -2161,7 +2527,7 @@ fn mg2_care_fraction_and_principal_care_are_not_defaulted() {
             nz_known(false, "no-principal-care"),
         );
     let result = execute_aggregation_plan(&artifact, &no_principal_care, &enabled()).unwrap();
-    let family = &determined(&result.families)[0];
+    let family = &determined_families(&result.families)[0];
     assert_eq!(*determined(&family.counts["dependent_child_count"]), 0);
     assert_eq!(
         determined(&family.scalars["best_start_total_before_abatement"]),
@@ -2190,7 +2556,7 @@ fn mg2_care_fraction_and_principal_care_are_not_defaulted() {
             .scalars
             .insert("best_start_claimant_care_fraction".to_string(), knowledge);
         let result = execute_aggregation_plan(&artifact, &request, &enabled()).unwrap();
-        let family = &determined(&result.families)[0];
+        let family = &indeterminate_families(&result.families)[0];
         assert!(matches!(
             family.scalars["best_start_total"],
             AggregationValue::Indeterminate { .. }
@@ -2216,8 +2582,9 @@ fn mg2_care_fraction_and_principal_care_are_not_defaulted() {
         nz_known("0.5".to_string(), "iwtc-care-half"),
     );
     let result = execute_aggregation_plan(&artifact, &inconsistent_iwtc, &enabled()).unwrap();
+    let family = &indeterminate_families(&result.families)[0];
     assert!(matches!(
-        determined(&result.families)[0].scalars["in_work_tax_credit_child_exclusive_care_fraction"],
+        family.scalars["in_work_tax_credit_child_exclusive_care_fraction"],
         AggregationValue::Indeterminate { .. }
     ));
 }
@@ -2284,7 +2651,7 @@ fn direction_partner_anchor_unpartnered_and_actual_shape_predicates_are_checked(
         .tuple = ["partner".to_string(), "primary".to_string()];
     let result = execute_aggregation_plan(&artifact, &reversed_partner, &enabled()).unwrap();
     assert!(*determined(
-        &determined(&result.families)[0].partner_present
+        &determined_families(&result.families)[0].partner_present
     ));
 
     let mut unpartnered = nz_request();
@@ -2298,7 +2665,7 @@ fn direction_partner_anchor_unpartnered_and_actual_shape_predicates_are_checked(
         .clear();
     replace_children(&mut unpartnered, &[14]);
     let result = execute_aggregation_plan(&artifact, &unpartnered, &enabled()).unwrap();
-    let family = &determined(&result.families)[0];
+    let family = &determined_families(&result.families)[0];
     assert!(!*determined(&family.partner_present));
     assert!(*determined(
         &family.predicates["sole_parent_with_dependent_children"]
@@ -2313,20 +2680,20 @@ fn direction_partner_anchor_unpartnered_and_actual_shape_predicates_are_checked(
 
     let mut unknown_holder = nz_request();
     unknown_holder.family_inputs[0].named_people.insert(
-        "mc7_entitlement_holder".to_string(),
+        "family_unit_reference_person".to_string(),
         AggregationKnowledge::Unknown {
-            evidence: nz_evidence("mc7-holder-unknown"),
+            evidence: nz_evidence("family-reference-unknown"),
         },
     );
     let result = execute_aggregation_plan(&artifact, &unknown_holder, &enabled()).unwrap();
     assert!(matches!(
-        determined(&result.families)[0].partner_present,
+        indeterminate_families(&result.families)[0].partner_present,
         AggregationValue::Indeterminate { .. }
     ));
 
     let mut child_holder = nz_request();
     child_holder.family_inputs[0].named_people.insert(
-        "mc7_entitlement_holder".to_string(),
+        "family_unit_reference_person".to_string(),
         nz_known("child-0".to_string(), "invalid-child-holder"),
     );
     assert!(matches!(
@@ -2341,7 +2708,7 @@ fn unrelated_family_preserves_family_id_but_changes_bound_trace() {
     let artifact = nz_artifact();
     let base_request = nz_request();
     let base = execute_aggregation_plan(&artifact, &base_request, &enabled()).unwrap();
-    let base_family = &determined(&base.families)[0];
+    let base_family = &determined_families(&base.families)[0];
     let base_id = base_family.id.clone();
 
     let mut expanded = base_request.clone();
@@ -2374,8 +2741,8 @@ fn unrelated_family_preserves_family_id_but_changes_bound_trace() {
         anchor_person: "other-adult".to_string(),
         evidence: nz_evidence("family-input:other-adult"),
         named_people: BTreeMap::from([(
-            "mc7_entitlement_holder".to_string(),
-            nz_known("other-adult".to_string(), "mc7:other-adult"),
+            "family_unit_reference_person".to_string(),
+            nz_known("other-adult".to_string(), "family-reference:other-adult"),
         )]),
         scalars: BTreeMap::from([
             (
@@ -2397,7 +2764,7 @@ fn unrelated_family_preserves_family_id_but_changes_bound_trace() {
         ]),
     });
     let expanded_result = execute_aggregation_plan(&artifact, &expanded, &enabled()).unwrap();
-    let families = determined(&expanded_result.families);
+    let families = determined_families(&expanded_result.families);
     assert_eq!(families.len(), 2);
     let unchanged = families
         .iter()
@@ -2517,10 +2884,8 @@ fn conflicting_family_adjustment_is_indeterminate_and_order_invariant() {
         },
     );
     let agreeing_result = execute_aggregation_plan(&artifact, &agreeing, &enabled()).unwrap();
-    assert_eq!(
-        determined(&determined(&agreeing_result.families)[0].scalars["best_start_total"]),
-        "7082"
-    );
+    let family = &determined_families(&agreeing_result.families)[0];
+    assert_eq!(determined(&family.scalars["best_start_total"]), "7082");
 
     let mut disagreeing = agreeing;
     if let AggregationKnowledge::Observations { observations } = disagreeing.family_inputs[0]
@@ -2532,7 +2897,7 @@ fn conflicting_family_adjustment_is_indeterminate_and_order_invariant() {
     }
     let disagreeing_result = execute_aggregation_plan(&artifact, &disagreeing, &enabled()).unwrap();
     assert!(matches!(
-        determined(&disagreeing_result.families)[0].scalars["best_start_total"],
+        indeterminate_families(&disagreeing_result.families)[0].scalars["best_start_total"],
         AggregationValue::Indeterminate { .. }
     ));
 
@@ -2553,7 +2918,7 @@ fn conflicting_family_adjustment_is_indeterminate_and_order_invariant() {
         },
     );
     let first = execute_aggregation_plan(&artifact, &request, &enabled()).unwrap();
-    let family = &determined(&first.families)[0];
+    let family = &indeterminate_families(&first.families)[0];
     assert!(matches!(
         family.scalars["best_start_total"],
         AggregationValue::Indeterminate { .. }
@@ -2575,7 +2940,7 @@ fn decimal_context_uses_half_even_at_both_midpoint_parities() {
     let source =
         include_str!("../../tests/fixtures/unit_derivation/nz_income_explorer_family.yaml")
             .replace("decimal_precision: 40", "decimal_precision: 2");
-    let artifact = compile_aggregation_plan(&source).unwrap();
+    let artifact = compile_aggregation_plan(&source, &nz_source_artifact()).unwrap();
     for (input, expected) in [("1.25", "1.2"), ("1.35", "1.4")] {
         let mut request = nz_request();
         request.persons.retain(|person| person.id == "primary");
@@ -2592,7 +2957,7 @@ fn decimal_context_uses_half_even_at_both_midpoint_parities() {
             nz_known("0".to_string(), "zero-adjustment"),
         );
         let result = execute_aggregation_plan(&artifact, &request, &enabled()).unwrap();
-        let family = &determined(&result.families)[0];
+        let family = &determined_families(&result.families)[0];
         assert_eq!(determined(&family.scalars["weekly_wages"]), expected);
     }
 }
@@ -2616,12 +2981,30 @@ fn compiled_artifact_digest_tampering_and_plan_semantic_mutations_are_detected()
 
     let source =
         include_str!("../../tests/fixtures/unit_derivation/nz_income_explorer_family.yaml");
-    let citation_edit = compile_aggregation_plan(&source.replace(
-        "Income Tax Act 2007 s LC 13",
-        "Income Tax Act 2007 s LC 13 (citation mutation)",
-    ))
+    let citation_edit = compile_aggregation_plan(
+        &source.replace(
+            "Income Tax Act 2007 s LC 13",
+            "Income Tax Act 2007 s LC 13 (citation mutation)",
+        ),
+        &nz_source_artifact(),
+    )
     .unwrap();
     assert_ne!(artifact.plan_digest, citation_edit.plan_digest);
+
+    let source_edit = compile_aggregation_plan(
+        source,
+        &compile_nz_source_artifact(
+            include_str!("../../tests/fixtures/unit_derivation/nz_best_start_gross.rulespec.yaml")
+                .replace("formula: '4041'", "formula: '9999'")
+                .as_str(),
+        ),
+    )
+    .unwrap();
+    assert_ne!(
+        artifact.source_artifact_digest,
+        source_edit.source_artifact_digest
+    );
+    assert_ne!(artifact.plan_digest, source_edit.plan_digest);
 
     for (pointer, replacement) in [
         ("/format", serde_json::json!("wrong-format")),
@@ -2634,6 +3017,16 @@ fn compiled_artifact_digest_tampering_and_plan_semantic_mutations_are_detected()
         ),
         (
             "/phase_two_artifact/engine_version",
+            serde_json::json!("tampered-engine"),
+        ),
+        (
+            "/source_artifact_digest",
+            serde_json::json!(
+                "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+            ),
+        ),
+        (
+            "/source_artifact/engine_version",
             serde_json::json!("tampered-engine"),
         ),
     ] {
@@ -2744,7 +3137,7 @@ fn every_stage3_structural_guard_kills_its_isolated_plan_mutant() {
     for (name, mutant) in mutants {
         assert_ne!(mutant, source, "mutant `{name}` must change the fixture");
         assert!(
-            compile_aggregation_plan(&mutant).is_err(),
+            compile_aggregation_plan(&mutant, &nz_source_artifact()).is_err(),
             "plan validator accepted `{name}` mutant"
         );
     }

--- a/src/unit_derivation/tests.rs
+++ b/src/unit_derivation/tests.rs
@@ -142,6 +142,114 @@ fn participant_count_program() -> crate::model::Program {
     phase_two
 }
 
+fn derived_relation_gate_program() -> crate::model::Program {
+    use crate::model::{
+        DType, Derived, DerivedSemantics, JudgmentExpr, RelatedValueRef, RelationDerivation,
+        RelationSchema, ScalarExpr,
+    };
+
+    let constituent = "us:test#member_of_household";
+    let participating = "us:test#snap_unit_member";
+    let filtered = "us:test#known_snap_unit_member";
+    let mut phase_two = crate::model::Program::default();
+    for relation in [constituent, participating] {
+        phase_two
+            .add_relation_schema(RelationSchema {
+                name: relation.to_string(),
+                arity: 2,
+                slot_entities: vec!["snap_household".to_string(), "person".to_string()],
+                derivation: None,
+            })
+            .unwrap();
+    }
+    phase_two
+        .add_relation_schema(RelationSchema {
+            name: filtered.to_string(),
+            arity: 2,
+            slot_entities: vec!["snap_household".to_string(), "person".to_string()],
+            derivation: Some(RelationDerivation {
+                source_relation: constituent.to_string(),
+                current_slot: 0,
+                related_slot: 1,
+                entity: Some("person".to_string()),
+                member_relation: Some(participating.to_string()),
+                slot_entities: vec!["snap_household".to_string(), "person".to_string()],
+                // Keep the membership check nested so the regression proves
+                // the whole predicate tree is traversed, not just a top-level
+                // RelationMember special case.
+                predicate: JudgmentExpr::And(vec![JudgmentExpr::Not(Box::new(JudgmentExpr::Not(
+                    Box::new(JudgmentExpr::RelationMember {
+                        relation: participating.to_string(),
+                        current_slot: 0,
+                        related_slot: 1,
+                    }),
+                )))]),
+            }),
+        })
+        .unwrap();
+
+    let derived = |name: &str, dtype, semantics| Derived {
+        id: None,
+        name: name.to_string(),
+        entity: "snap_household".to_string(),
+        dtype,
+        unit: None,
+        rounding: None,
+        source: None,
+        source_url: None,
+        corpus_citation_path: None,
+        semantics,
+        versions: Vec::new(),
+    };
+    for item in [
+        derived(
+            "direct_count",
+            DType::Integer,
+            DerivedSemantics::Scalar(ScalarExpr::CountRelated {
+                relation: participating.to_string(),
+                current_slot: 0,
+                related_slot: 1,
+                where_clause: None,
+            }),
+        ),
+        derived(
+            "direct_sum",
+            DType::Decimal,
+            DerivedSemantics::Scalar(ScalarExpr::SumRelated {
+                relation: participating.to_string(),
+                current_slot: 0,
+                related_slot: 1,
+                value: RelatedValueRef::Input("amount".to_string()),
+                where_clause: None,
+            }),
+        ),
+        derived(
+            "gated_count",
+            DType::Integer,
+            DerivedSemantics::Scalar(ScalarExpr::CountRelated {
+                relation: filtered.to_string(),
+                current_slot: 0,
+                related_slot: 1,
+                where_clause: None,
+            }),
+        ),
+        derived(
+            "gated_sum",
+            DType::Decimal,
+            DerivedSemantics::Scalar(ScalarExpr::SumRelated {
+                relation: filtered.to_string(),
+                current_slot: 0,
+                related_slot: 1,
+                value: RelatedValueRef::Input("amount".to_string()),
+                where_clause: None,
+            }),
+        ),
+    ] {
+        phase_two.add_derived(item).unwrap();
+    }
+    phase_two
+}
+
 #[test]
 fn runtime_flag_is_independently_off_by_default() {
     let compiled = compile(base_plan(&["a"])).unwrap();
@@ -333,6 +441,92 @@ fn unknown_status_survives_materialization_and_indeterminates_phase_two_count() 
         CompleteReduction::Indeterminate { ref reasons }
             if reasons == &set(&["bool:status_b"])
     ));
+}
+
+#[test]
+fn unknown_and_conflict_survive_derived_relation_gates_for_counts_and_sums() {
+    for conflict in [false, true] {
+        let label = if conflict { "Conflict" } else { "Unknown" };
+        let mut plan = base_plan(&["a", "b"]);
+        plan.edges.push(edge(
+            "known-family-edge",
+            EdgeKind::Base,
+            "a",
+            "b",
+            BoolExpr::Literal(true),
+        ));
+        plan.statuses.push(StatusRule {
+            id: "status-b".to_string(),
+            person: "b".to_string(),
+            when: BoolExpr::fact(FactRef::Bool("status_b".to_string())),
+            citation: citation("review:S-E-derived-relation-gate"),
+        });
+        let mut input = complete_input(&["a", "b"]);
+        if conflict {
+            input.bool_facts.push(BoolFactInput {
+                name: "status_b".to_string(),
+                observations: vec![
+                    observed(true, "status-source-true"),
+                    observed(false, "status-source-false"),
+                ],
+                explicit_unknown: None,
+            });
+        }
+
+        let derivation = derive_units(&compile(plan).unwrap(), &input, &enabled()).unwrap();
+        assert!(derivation.indeterminate.iter().any(|item| {
+            item.person == "b"
+                && item.kind == IndeterminateKind::Role(Projection::ParticipatingMember)
+                && item.unresolved_facts == set(&["bool:status_b"])
+        }));
+        let unit = derivation.units[0].id.clone();
+        let run = PrototypeRun {
+            derivation,
+            comparisons: Vec::new(),
+        };
+        let period = crate::model::Period::month(2026, 7);
+        let interval = crate::model::Interval::covering(&period);
+        let phase_two = derived_relation_gate_program();
+        let mut base = crate::model::DataSet::default();
+        base.add_input(
+            "amount",
+            "person",
+            "a",
+            interval.clone(),
+            crate::model::ScalarValue::Integer(10),
+        );
+        base.add_input(
+            "amount",
+            "person",
+            "b",
+            interval.clone(),
+            crate::model::ScalarValue::Integer(20),
+        );
+        let materialized =
+            materialize_phase_two_dataset(&base, &phase_two, &input, &run, interval).unwrap();
+        assert_eq!(materialized.relation_knowledge().len(), 1);
+        let unresolved = &materialized.relation_knowledge()[0];
+        assert_eq!(unresolved.name, "us:test#snap_unit_member");
+        assert_eq!(unresolved.tuple, vec![unit.clone(), "b".to_string()]);
+        match (&unresolved.truth, conflict) {
+            (LiftedTruth::Unknown { reasons }, false)
+            | (LiftedTruth::Conflict { reasons }, true) => {
+                assert_eq!(reasons, &set(&["bool:status_b"]));
+            }
+            (truth, _) => panic!("{label} materialized as {truth:?}"),
+        }
+
+        let mut engine = materialized.engine(&phase_two);
+        for name in ["direct_count", "direct_sum", "gated_count", "gated_sum"] {
+            assert_eq!(
+                engine.evaluate_scalar(name, &unit, &period).unwrap(),
+                CompleteReduction::Indeterminate {
+                    reasons: set(&["bool:status_b"]),
+                },
+                "{label} was silently dropped by `{name}`"
+            );
+        }
+    }
 }
 
 fn simultaneous_cut_plan(decision: CutEdgeDecision) -> ConstitutionPlan {
@@ -1148,133 +1342,1412 @@ fn invariant_normalized_input_conflict_is_classified_per_affected_projection() {
     );
 }
 
-fn nz_person(id: &str, age_years: i64, values: &[(&str, &str)]) -> AggregationPerson {
-    AggregationPerson {
-        id: id.to_string(),
-        age_years: Some(age_years),
-        scalars: values
-            .iter()
-            .map(|(name, value)| ((*name).to_string(), (*value).to_string()))
-            .collect(),
+fn nz_evidence(id: &str) -> AggregationEvidence {
+    AggregationEvidence { id: id.to_string() }
+}
+
+fn nz_known<T>(value: T, id: &str) -> AggregationKnowledge<T> {
+    AggregationKnowledge::Known {
+        value,
+        evidence: nz_evidence(id),
     }
 }
 
-fn nz_values<'a>(
+fn nz_person(id: &str, age_years: i64, values: &[(&str, &str)], child: bool) -> AggregationPerson {
+    let mut scalars = values
+        .iter()
+        .map(|(name, value)| {
+            (
+                (*name).to_string(),
+                nz_known((*value).to_string(), &format!("scalar:{id}:{name}")),
+            )
+        })
+        .collect::<BTreeMap<_, _>>();
+    if child {
+        scalars
+            .entry("in_work_tax_credit_child_exclusive_care_fraction".to_string())
+            .or_insert_with(|| nz_known("1".to_string(), &format!("iwtc-care:{id}")));
+    }
+    AggregationPerson {
+        id: id.to_string(),
+        role: if child {
+            AggregationPersonRole::Child
+        } else {
+            AggregationPersonRole::Adult
+        },
+        evidence: nz_evidence(&format!("person:{id}")),
+        age_years: Some(nz_known(age_years, &format!("age:{id}"))),
+        scalars,
+        facts: if child {
+            BTreeMap::from([
+                (
+                    "principal_care_for_family_scheme".to_string(),
+                    nz_known(true, &format!("principal-care:{id}")),
+                ),
+                (
+                    "in_work_tax_credit_principal_caregiver".to_string(),
+                    nz_known(true, &format!("iwtc-principal-care:{id}")),
+                ),
+                (
+                    "not_financially_independent_at_age_18".to_string(),
+                    nz_known(true, &format!("financial-dependence:{id}")),
+                ),
+                (
+                    "attending_school_or_tertiary_at_age_18".to_string(),
+                    nz_known(true, &format!("education:{id}")),
+                ),
+                (
+                    "commissioner_period_contains_segment_at_age_18".to_string(),
+                    nz_known(true, &format!("mc9-period:{id}")),
+                ),
+            ])
+        } else {
+            BTreeMap::new()
+        },
+    }
+}
+
+fn nz_adult_values<'a>(
     weekly_wage: &'a str,
     annual_wage: &'a str,
     base_income: &'a str,
-    before: &'a str,
-    abatement: &'a str,
+    net_benefit: &'a str,
+    gross_benefit: &'a str,
+    tax: &'a str,
+    net_wage: &'a str,
+    hours: &'a str,
+    ietc: &'a str,
+    ietc_continuous: &'a str,
 ) -> Vec<(&'static str, &'a str)> {
     vec![
         ("weekly_wage", weekly_wage),
         ("annual_wage", annual_wage),
         ("annual_family_scheme_base_income", base_income),
-        ("weekly_net_benefit", "0"),
-        ("weekly_gross_benefit", "0"),
-        ("weekly_wage_tax", "0"),
-        ("weekly_net_wage", weekly_wage),
-        ("weekly_hours", "40"),
-        ("ietc_weekly", "0"),
-        ("ietc_continuous_weekly", "0"),
-        ("best_start_before_abatement", before),
-        ("best_start_family_abatement", abatement),
+        ("weekly_net_benefit", net_benefit),
+        ("weekly_gross_benefit", gross_benefit),
+        ("weekly_wage_tax", tax),
+        ("weekly_net_wage", net_wage),
+        ("weekly_hours", hours),
+        ("ietc_weekly", ietc),
+        ("ietc_continuous_weekly", ietc_continuous),
     ]
 }
 
-#[test]
-fn nz_family_fixture_moves_person_child_aggregation_behind_the_barrier() {
-    let plan = parse_aggregation_plan(include_str!(
-        "../../tests/fixtures/unit_derivation/nz_income_explorer_family.yaml"
-    ))
-    .unwrap();
-    let primary_values = nz_values(
-        "1000.12345678901234567890123456789012345",
-        "52000",
-        "52000",
-        "0",
-        "0",
-    );
-    let partner_values = nz_values(
-        "740.87654321098765432109876543210987655",
-        "38480",
-        "38480",
-        "0",
-        "0",
-    );
-    let child_one_values = nz_values("0", "0", "0", "4041", "1000");
-    let child_two_values = nz_values("0", "0", "0", "4041", "1000");
-    let request = AggregationRequest {
-        scope: "scenario:binding-best-start".to_string(),
-        segment: "2026-04-01/2027-03-31".to_string(),
-        primary_person: "primary".to_string(),
-        persons: vec![
-            nz_person("primary", 25, &primary_values),
-            nz_person("partner", 25, &partner_values),
-            nz_person("child-0", 1, &child_one_values),
-            nz_person("child-1", 2, &child_two_values),
-        ],
-        relations: BTreeMap::from([
-            (
-                "partner_of".to_string(),
-                vec![["primary".to_string(), "partner".to_string()]],
-            ),
-            (
-                "dependent_child_of".to_string(),
-                vec![
-                    ["primary".to_string(), "child-0".to_string()],
-                    ["primary".to_string(), "child-1".to_string()],
-                ],
-            ),
-        ]),
-        family_scalars: BTreeMap::from([("family_scheme_income".to_string(), "90480".to_string())]),
-    };
-    let result = execute_aggregation_plan(&plan, &request, &enabled()).unwrap();
-    assert_eq!(result.families.len(), 1);
-    let family = &result.families[0];
-    assert!(family.partner_present);
-    assert_eq!(family.counts["dependent_child_count"], 2);
-    assert_eq!(family.counts["best_start_eligible_child_count"], 2);
-    assert_eq!(family.counts["youngest_child_age"], 1);
-    assert_eq!(family.scalars["weekly_wages"], "1741");
-    assert_eq!(family.scalars["annual_family_scheme_base_income"], "90480");
-    assert_eq!(family.scalars["best_start_total"], "7082");
-    assert_eq!(family.scalars["best_start_total_before_abatement"], "8082");
-    assert!(family.children.iter().all(|child| {
-        child.scalars["family_scheme_income"] == "90480"
-            && child.age_bands["best_start_eligible_child_count"]
-            && child.family == family.id
-    }));
+fn nz_relation(name: &str, tuples: &[(&str, &str)], scope: &str) -> AggregationRelationFamily {
+    AggregationRelationFamily {
+        name: name.to_string(),
+        scope: scope.to_string(),
+        completeness: Some(nz_evidence(&format!("complete:{scope}:{name}"))),
+        facts: tuples
+            .iter()
+            .map(|(left, right)| AggregationRelationFact {
+                tuple: [(*left).to_string(), (*right).to_string()],
+                knowledge: nz_known(true, &format!("relation:{name}:{left}:{right}")),
+            })
+            .collect(),
+    }
+}
 
-    let disabled = execute_aggregation_plan(&plan, &request, &Default::default())
+fn nz_request() -> AggregationRequest {
+    let scope = "scenario:binding-best-start";
+    AggregationRequest {
+        scope: scope.to_string(),
+        segment: "2026-04-01/2027-03-31".to_string(),
+        roster_completeness: Some(nz_evidence("complete:roster")),
+        segment_completeness: Some(nz_evidence("complete:segment")),
+        persons: vec![
+            nz_person(
+                "primary",
+                25,
+                &nz_adult_values(
+                    "1000.12345678901234567890123456789012345",
+                    "52000",
+                    "52000",
+                    "11",
+                    "13",
+                    "101",
+                    "899",
+                    "40",
+                    "3",
+                    "4",
+                ),
+                false,
+            ),
+            nz_person(
+                "partner",
+                25,
+                &nz_adult_values(
+                    "740.87654321098765432109876543210987655",
+                    "38480",
+                    "38480",
+                    "7",
+                    "5",
+                    "71",
+                    "669",
+                    "20",
+                    "2",
+                    "6",
+                ),
+                false,
+            ),
+            nz_person(
+                "child-0",
+                1,
+                &[
+                    ("best_start_before_care_and_abatement", "4041"),
+                    ("best_start_claimant_care_fraction", "1"),
+                ],
+                true,
+            ),
+            nz_person(
+                "child-1",
+                2,
+                &[
+                    ("best_start_before_care_and_abatement", "4041"),
+                    ("best_start_claimant_care_fraction", "1"),
+                ],
+                true,
+            ),
+        ],
+        relations: vec![
+            nz_relation("partner_of", &[("primary", "partner")], scope),
+            nz_relation(
+                "dependent_child_of",
+                &[("primary", "child-0"), ("primary", "child-1")],
+                scope,
+            ),
+        ],
+        family_inputs: vec![AggregationFamilyInput {
+            anchor_person: "primary".to_string(),
+            evidence: nz_evidence("family-input:primary"),
+            named_people: BTreeMap::from([(
+                "mc7_entitlement_holder".to_string(),
+                nz_known("primary".to_string(), "mc7:primary"),
+            )]),
+            scalars: BTreeMap::from([
+                (
+                    "family_scheme_income".to_string(),
+                    nz_known("90480".to_string(), "family-income"),
+                ),
+                (
+                    "best_start_family_abatement".to_string(),
+                    nz_known("1000".to_string(), "best-start-adjustment"),
+                ),
+                (
+                    "best_start_abatement_threshold".to_string(),
+                    nz_known("80000".to_string(), "best-start-threshold"),
+                ),
+                (
+                    "best_start_abatement_rate".to_string(),
+                    nz_known("0.1".to_string(), "best-start-rate"),
+                ),
+            ]),
+        }],
+    }
+}
+
+fn determined<T>(value: &AggregationValue<T>) -> &T {
+    match value {
+        AggregationValue::Determined { value } => value,
+        AggregationValue::Indeterminate { reasons } => {
+            panic!("expected Determined, found {reasons:?}")
+        }
+    }
+}
+
+#[test]
+fn nz_family_fixture_uses_registered_artifact_and_asserts_every_output() {
+    let mut registry = UnitDerivationDocumentRegistry::default();
+    let artifact = registry
+        .register_aggregation_source(include_str!(
+            "../../tests/fixtures/unit_derivation/nz_income_explorer_family.yaml"
+        ))
+        .unwrap();
+    let artifact_json = artifact.to_json_pretty().unwrap();
+    let mut reloaded = UnitDerivationDocumentRegistry::default();
+    let plan_id = reloaded
+        .register_aggregation_json(&artifact_json)
+        .unwrap()
+        .plan_id()
+        .to_string();
+    let request = nz_request();
+    let result = reloaded
+        .execute_aggregation(&plan_id, &request, &enabled())
+        .unwrap();
+    assert_eq!(result.schema, EXPERIMENTAL_AGGREGATION_PLAN_SCHEMA);
+    assert_eq!(result.plan, "nz:incomeexplorer:family-aggregation-2026-27");
+    assert!(result.plan_digest.starts_with("sha256:"));
+    assert!(result.trace_root.starts_with("sha256:"));
+    let families = determined(&result.families);
+    assert_eq!(families.len(), 1);
+    let family = &families[0];
+    assert_eq!(
+        family.members,
+        vec!["child-0", "child-1", "partner", "primary"]
+    );
+    assert_eq!(*determined(&family.partner_present), true);
+    assert_eq!(
+        family
+            .counts
+            .iter()
+            .map(|(name, value)| (name.as_str(), *determined(value)))
+            .collect::<BTreeMap<_, _>>(),
+        BTreeMap::from([
+            ("best_start_eligible_child_count", 2),
+            ("child_count_age_0_13", 2),
+            ("child_count_age_14_18", 0),
+            ("dependent_child_count", 2),
+            ("youngest_child_age", 1),
+        ])
+    );
+    assert_eq!(
+        family
+            .predicates
+            .iter()
+            .map(|(name, value)| (name.as_str(), *determined(value)))
+            .collect::<BTreeMap<_, _>>(),
+        BTreeMap::from([
+            ("has_dependent_children", true),
+            ("has_two_or_more_dependent_children", true),
+            ("jss_sole_parent_youngest_age_at_least_14", false),
+            ("sole_parent_with_dependent_children", false),
+            ("youngest_child_age_at_least_14", false),
+        ])
+    );
+    assert_eq!(
+        family
+            .scalars
+            .iter()
+            .map(|(name, value)| (name.as_str(), determined(value).as_str()))
+            .collect::<BTreeMap<_, _>>(),
+        BTreeMap::from([
+            ("annual_family_scheme_base_income", "90480"),
+            ("annual_wages", "90480"),
+            ("best_start_entitlement_days", "365"),
+            ("best_start_total", "7082"),
+            ("best_start_total_before_abatement", "8082"),
+            ("best_start_total_continuous_abatement", "7034"),
+            ("family_tax_credit_eldest_dependent_child_care_units", "1"),
+            ("family_tax_credit_entitlement_days", "365"),
+            (
+                "family_tax_credit_subsequent_dependent_child_care_units",
+                "1"
+            ),
+            ("hours_total", "60"),
+            ("ietc_continuous_weekly", "10"),
+            ("ietc_weekly", "5"),
+            ("in_work_tax_credit_child_exclusive_care_fraction", "1"),
+            ("in_work_tax_credit_weekly_periods", "52"),
+            ("weekly_gross_benefit", "18"),
+            ("weekly_net_benefit", "18"),
+            ("weekly_net_wage", "1568"),
+            ("weekly_wage_tax", "172"),
+            ("weekly_wages", "1741"),
+            ("wff_family_credit_abatement_days", "365"),
+        ])
+    );
+    assert_eq!(family.children.len(), 2);
+    for (index, child) in family.children.iter().enumerate() {
+        assert_eq!(child.person, format!("child-{index}"));
+        assert_eq!(child.family, family.id);
+        assert_eq!(*determined(&child.age_years), (index + 1) as i64);
+        assert_eq!(
+            child
+                .age_bands
+                .iter()
+                .map(|(name, value)| (name.as_str(), *determined(value)))
+                .collect::<BTreeMap<_, _>>(),
+            BTreeMap::from([
+                ("best_start_eligible_child_count", true),
+                ("child_count_age_0_13", true),
+                ("child_count_age_14_18", false),
+                ("dependent_child_count", true),
+            ])
+        );
+        assert_eq!(
+            child
+                .scalars
+                .iter()
+                .map(|(name, value)| (name.as_str(), determined(value).as_str()))
+                .collect::<BTreeMap<_, _>>(),
+            BTreeMap::from([
+                ("best_start_claimant_care_fraction", "1"),
+                ("family_scheme_income", "90480"),
+            ])
+        );
+    }
+
+    let disabled = reloaded
+        .execute_aggregation(&plan_id, &request, &Default::default())
         .expect_err("aggregation retains the independent runtime gate");
     assert_eq!(disabled, UnitDerivationError::Disabled);
 }
 
 #[test]
-fn nz_best_start_host_defect_reproduces_but_plan_has_no_per_child_abatement_operator() {
-    let before = rust_decimal::Decimal::from(4041);
-    let abatement = rust_decimal::Decimal::from(1000);
-    let two = rust_decimal::Decimal::from(2);
-    let host_per_child = (before - abatement).max(rust_decimal::Decimal::ZERO) * two;
-    let family_once = (before * two - abatement).max(rust_decimal::Decimal::ZERO);
-    assert_eq!(host_per_child, rust_decimal::Decimal::from(6082));
-    assert_eq!(family_once, rust_decimal::Decimal::from(7082));
+fn nz_tier_b_legal_choices_are_explicit_cited_inputs_and_limitations() {
+    let artifact = nz_artifact();
+    let plan = &artifact.plan;
+    assert_eq!(
+        plan.partner_presence.citation.provision,
+        "Income Tax Act 2007 s MC 7"
+    );
+    assert_eq!(
+        plan.partner_presence.citation.authority,
+        "nz/statute/act/public/2007/0097/section/MC-7"
+    );
+    assert!(!plan.partner_presence.citation.provision.contains("MB 2"));
+    assert!(
+        plan.membership_relations
+            .iter()
+            .find(|relation| relation.relation == "partner_of")
+            .unwrap()
+            .citation
+            .provision
+            .contains("Caller-evidenced")
+    );
+    assert_eq!(plan.age_18_conditions.age, 18);
+    for input in [
+        &plan.age_18_conditions.not_financially_independent_input,
+        &plan.age_18_conditions.attending_school_or_tertiary_input,
+        &plan.age_18_conditions.commissioner_period_input,
+    ] {
+        let declaration = plan
+            .inputs
+            .iter()
+            .find(|declaration| declaration.name == *input)
+            .unwrap();
+        assert_eq!(
+            declaration.citation.authority,
+            "nz/statute/act/public/2007/0097/section/MC-9"
+        );
+    }
+    let best_start_care = plan
+        .inputs
+        .iter()
+        .find(|input| input.name == "best_start_claimant_care_fraction")
+        .unwrap();
+    assert_eq!(
+        best_start_care.citation.provision,
+        "Income Tax Act 2007 s MG 2(5)"
+    );
+    let iwtc_care = plan
+        .inputs
+        .iter()
+        .find(|input| input.name == "in_work_tax_credit_child_exclusive_care_fraction")
+        .unwrap();
+    assert_eq!(
+        iwtc_care.citation.provision,
+        "Income Tax Act 2007 s MC 10(3)"
+    );
+    let limitation_ids = plan
+        .limitations
+        .iter()
+        .map(|limitation| limitation.id.as_str())
+        .collect::<BTreeSet<_>>();
+    for required in [
+        "mc7-entitlement-selection",
+        "mc9-commissioner-period",
+        "mg2-care-fact",
+        "relationship-and-role-classification",
+        "mc10-iwtc-care",
+        "pinned-full-period-scenario",
+        "jss-scenario-gate",
+    ] {
+        assert!(limitation_ids.contains(required));
+    }
+}
 
-    let invalid =
-        include_str!("../../tests/fixtures/unit_derivation/nz_income_explorer_family.yaml")
-            .replace(
-                "sum_children_then_subtract_family_once",
-                "sum_per_child_after_abatement",
+#[test]
+fn reviewer_best_start_plan_is_rejected_by_named_family_scope_guard() {
+    let source = include_str!("../../tests/fixtures/unit_derivation/per_child_expressible.yaml");
+    assert!(
+        include_str!("../../tests/fixtures/unit_derivation/per_child_request.json")
+            .contains("\"two_child_abatement\": \"2000\"")
+    );
+    let error = compile_aggregation_plan(source)
+        .expect_err("the exact accepted reviewer plan must now fail semantic validation");
+    assert_eq!(
+        error,
+        UnitDerivationError::DuplicateFamilyScopeReduction {
+            key: "untyped-family-scope".to_string(),
+            first: "safe_best_start_total".to_string(),
+            second: "best_start_total".to_string(),
+        }
+    );
+}
+
+#[test]
+fn unknown_scalar_and_missing_relation_completeness_never_become_zero() {
+    let artifact = compile_aggregation_plan(include_str!(
+        "../../tests/fixtures/unit_derivation/nz_income_explorer_family.yaml"
+    ))
+    .unwrap();
+    let mut scalar_unknown = nz_request();
+    scalar_unknown.persons[0].scalars.insert(
+        "weekly_wage".to_string(),
+        AggregationKnowledge::Unknown {
+            evidence: nz_evidence("weekly-wage-unknown"),
+        },
+    );
+    let result = execute_aggregation_plan(&artifact, &scalar_unknown, &enabled()).unwrap();
+    let family = &determined(&result.families)[0];
+    assert!(matches!(
+        family.scalars["weekly_wages"],
+        AggregationValue::Indeterminate { .. }
+    ));
+
+    let mut scalar_conflict = nz_request();
+    scalar_conflict.persons[0].scalars.insert(
+        "weekly_wage".to_string(),
+        AggregationKnowledge::Conflict {
+            observations: vec![
+                AggregationObservation {
+                    value: "1000".to_string(),
+                    evidence: nz_evidence("weekly-wage-one"),
+                },
+                AggregationObservation {
+                    value: "2000".to_string(),
+                    evidence: nz_evidence("weekly-wage-two"),
+                },
+            ],
+        },
+    );
+    let result = execute_aggregation_plan(&artifact, &scalar_conflict, &enabled()).unwrap();
+    assert!(matches!(
+        determined(&result.families)[0].scalars["weekly_wages"],
+        AggregationValue::Indeterminate { .. }
+    ));
+
+    let mut missing_family_scalar = nz_request();
+    missing_family_scalar.family_inputs[0]
+        .scalars
+        .remove("family_scheme_income");
+    let result = execute_aggregation_plan(&artifact, &missing_family_scalar, &enabled()).unwrap();
+    let family = &determined(&result.families)[0];
+    assert!(matches!(
+        family.scalars["best_start_total_continuous_abatement"],
+        AggregationValue::Indeterminate { .. }
+    ));
+    assert!(family.children.iter().all(|child| matches!(
+        child.scalars["family_scheme_income"],
+        AggregationValue::Indeterminate { .. }
+    )));
+
+    let mut missing_completeness = nz_request();
+    let missing_child_relation = missing_completeness
+        .relations
+        .iter_mut()
+        .find(|family| family.name == "dependent_child_of")
+        .unwrap();
+    missing_child_relation.completeness = None;
+    missing_child_relation.facts.clear();
+    let result = execute_aggregation_plan(&artifact, &missing_completeness, &enabled()).unwrap();
+    assert!(matches!(
+        result.families,
+        AggregationValue::Indeterminate { .. }
+    ));
+}
+
+#[test]
+fn indeterminate_relation_knowledge_cannot_produce_a_smaller_determined_family() {
+    let artifact = nz_artifact();
+    let cases = vec![
+        AggregationKnowledge::Unknown {
+            evidence: nz_evidence("child-relation-unknown"),
+        },
+        AggregationKnowledge::Conflict {
+            observations: vec![AggregationObservation {
+                value: true,
+                evidence: nz_evidence("child-relation-conflict-one"),
+            }],
+        },
+        AggregationKnowledge::Conflict {
+            observations: vec![
+                AggregationObservation {
+                    value: true,
+                    evidence: nz_evidence("child-relation-conflict-true"),
+                },
+                AggregationObservation {
+                    value: false,
+                    evidence: nz_evidence("child-relation-conflict-false"),
+                },
+            ],
+        },
+        AggregationKnowledge::Observations {
+            observations: Vec::new(),
+        },
+    ];
+    for knowledge in cases {
+        let mut request = nz_request();
+        request
+            .relations
+            .iter_mut()
+            .find(|family| family.name == "dependent_child_of")
+            .unwrap()
+            .facts[0]
+            .knowledge = knowledge;
+        let result = execute_aggregation_plan(&artifact, &request, &enabled()).unwrap();
+        assert!(
+            matches!(result.families, AggregationValue::Indeterminate { .. }),
+            "an unresolved child relation must not become a determined smaller count"
+        );
+    }
+}
+
+#[test]
+fn omitted_relation_is_unknown_but_evidenced_complete_empty_is_known_empty() {
+    let artifact = nz_artifact();
+    let mut omitted = nz_request();
+    omitted
+        .relations
+        .retain(|family| family.name != "dependent_child_of");
+    let result = execute_aggregation_plan(&artifact, &omitted, &enabled()).unwrap();
+    assert!(matches!(
+        result.families,
+        AggregationValue::Indeterminate { .. }
+    ));
+
+    let mut complete_empty = nz_request();
+    complete_empty
+        .relations
+        .iter_mut()
+        .find(|family| family.name == "dependent_child_of")
+        .unwrap()
+        .facts
+        .clear();
+    let result = execute_aggregation_plan(&artifact, &complete_empty, &enabled()).unwrap();
+    let primary = determined(&result.families)
+        .iter()
+        .find(|family| family.members.contains(&"primary".to_string()))
+        .unwrap();
+    assert_eq!(*determined(&primary.counts["dependent_child_count"]), 0);
+    assert_eq!(
+        determined(&primary.scalars["best_start_total_before_abatement"]),
+        "0"
+    );
+}
+
+fn nz_artifact() -> CompiledAggregationArtifact {
+    compile_aggregation_plan(include_str!(
+        "../../tests/fixtures/unit_derivation/nz_income_explorer_family.yaml"
+    ))
+    .unwrap()
+}
+
+fn replace_children(request: &mut AggregationRequest, ages: &[i64]) {
+    request
+        .persons
+        .retain(|person| !person.id.starts_with("child-"));
+    let child_relation = request
+        .relations
+        .iter_mut()
+        .find(|family| family.name == "dependent_child_of")
+        .unwrap();
+    child_relation.facts.clear();
+    for (index, age) in ages.iter().enumerate() {
+        let id = format!("child-{index}");
+        request.persons.push(nz_person(
+            &id,
+            *age,
+            &[
+                ("best_start_before_care_and_abatement", "4041"),
+                ("best_start_claimant_care_fraction", "1"),
+            ],
+            true,
+        ));
+        child_relation.facts.push(AggregationRelationFact {
+            tuple: ["primary".to_string(), id.clone()],
+            knowledge: nz_known(true, &format!("relation:dependent_child_of:primary:{id}")),
+        });
+    }
+}
+
+#[test]
+fn child_age_boundaries_and_every_mc9_condition_are_operational() {
+    let artifact = nz_artifact();
+    let mut request = nz_request();
+    replace_children(&mut request, &[0, 2, 3, 13, 14, 18, 19]);
+    let result = execute_aggregation_plan(&artifact, &request, &enabled()).unwrap();
+    let family = &determined(&result.families)[0];
+    assert_eq!(*determined(&family.counts["dependent_child_count"]), 6);
+    assert_eq!(
+        *determined(&family.counts["best_start_eligible_child_count"]),
+        2
+    );
+    assert_eq!(*determined(&family.counts["child_count_age_0_13"]), 4);
+    assert_eq!(*determined(&family.counts["child_count_age_14_18"]), 2);
+    assert_eq!(*determined(&family.counts["youngest_child_age"]), 0);
+    let expected = [
+        (true, true, false, true),
+        (true, true, false, true),
+        (false, true, false, true),
+        (false, true, false, true),
+        (false, false, true, true),
+        (false, false, true, true),
+        (false, false, false, false),
+    ];
+    for (child, expected) in family.children.iter().zip(expected) {
+        assert_eq!(
+            (
+                *determined(&child.age_bands["best_start_eligible_child_count"]),
+                *determined(&child.age_bands["child_count_age_0_13"]),
+                *determined(&child.age_bands["child_count_age_14_18"]),
+                *determined(&child.age_bands["dependent_child_count"]),
+            ),
+            expected
+        );
+    }
+
+    for fact in [
+        "not_financially_independent_at_age_18",
+        "attending_school_or_tertiary_at_age_18",
+        "commissioner_period_contains_segment_at_age_18",
+    ] {
+        let mut false_request = request.clone();
+        false_request
+            .persons
+            .iter_mut()
+            .find(|person| person.id == "child-5")
+            .unwrap()
+            .facts
+            .insert(fact.to_string(), nz_known(false, &format!("false:{fact}")));
+        let result = execute_aggregation_plan(&artifact, &false_request, &enabled()).unwrap();
+        let family = &determined(&result.families)[0];
+        assert_eq!(*determined(&family.counts["dependent_child_count"]), 5);
+        assert_eq!(*determined(&family.counts["child_count_age_14_18"]), 1);
+    }
+
+    let mut unknown = request;
+    unknown
+        .persons
+        .iter_mut()
+        .find(|person| person.id == "child-5")
+        .unwrap()
+        .facts
+        .insert(
+            "attending_school_or_tertiary_at_age_18".to_string(),
+            AggregationKnowledge::Unknown {
+                evidence: nz_evidence("education-unknown"),
+            },
+        );
+    let result = execute_aggregation_plan(&artifact, &unknown, &enabled()).unwrap();
+    let family = &determined(&result.families)[0];
+    assert!(matches!(
+        family.counts["dependent_child_count"],
+        AggregationValue::Indeterminate { .. }
+    ));
+    assert!(matches!(
+        family.counts["child_count_age_14_18"],
+        AggregationValue::Indeterminate { .. }
+    ));
+}
+
+#[test]
+fn missing_unknown_and_conflicting_child_inputs_never_reduce_to_zero_or_false() {
+    let artifact = nz_artifact();
+    for age in [
+        None,
+        Some(AggregationKnowledge::Unknown {
+            evidence: nz_evidence("age-unknown"),
+        }),
+        Some(AggregationKnowledge::Conflict {
+            observations: vec![
+                AggregationObservation {
+                    value: 1,
+                    evidence: nz_evidence("age-one"),
+                },
+                AggregationObservation {
+                    value: 2,
+                    evidence: nz_evidence("age-two"),
+                },
+            ],
+        }),
+    ] {
+        let mut request = nz_request();
+        request
+            .persons
+            .iter_mut()
+            .find(|person| person.id == "child-0")
+            .unwrap()
+            .age_years = age;
+        let result = execute_aggregation_plan(&artifact, &request, &enabled()).unwrap();
+        let family = &determined(&result.families)[0];
+        assert!(matches!(
+            family.counts["dependent_child_count"],
+            AggregationValue::Indeterminate { .. }
+        ));
+        assert!(matches!(
+            family.children[0].age_years,
+            AggregationValue::Indeterminate { .. }
+        ));
+    }
+
+    for knowledge in [
+        AggregationKnowledge::Unknown {
+            evidence: nz_evidence("principal-care-unknown"),
+        },
+        AggregationKnowledge::Conflict {
+            observations: vec![
+                AggregationObservation {
+                    value: true,
+                    evidence: nz_evidence("principal-care-yes"),
+                },
+                AggregationObservation {
+                    value: false,
+                    evidence: nz_evidence("principal-care-no"),
+                },
+            ],
+        },
+    ] {
+        let mut request = nz_request();
+        request
+            .persons
+            .iter_mut()
+            .find(|person| person.id == "child-0")
+            .unwrap()
+            .facts
+            .insert("principal_care_for_family_scheme".to_string(), knowledge);
+        let result = execute_aggregation_plan(&artifact, &request, &enabled()).unwrap();
+        let family = &determined(&result.families)[0];
+        assert!(matches!(
+            family.counts["dependent_child_count"],
+            AggregationValue::Indeterminate { .. }
+        ));
+        assert!(matches!(
+            family.scalars["best_start_total"],
+            AggregationValue::Indeterminate { .. }
+        ));
+    }
+}
+
+#[test]
+fn mg2_care_fraction_and_principal_care_are_not_defaulted() {
+    let artifact = nz_artifact();
+    for (fraction, expected_gross) in [("0", "0"), ("0.5", "2020.5"), ("1", "4041")] {
+        let mut request = nz_request();
+        replace_children(&mut request, &[1]);
+        request
+            .persons
+            .iter_mut()
+            .find(|person| person.id == "child-0")
+            .unwrap()
+            .scalars
+            .insert(
+                "best_start_claimant_care_fraction".to_string(),
+                nz_known(fraction.to_string(), &format!("care:{fraction}")),
             );
-    let error = parse_aggregation_plan(&invalid)
-        .expect_err("the public plan grammar has no per-child abatement reducer");
+        request.family_inputs[0].scalars.insert(
+            "best_start_family_abatement".to_string(),
+            nz_known("0".to_string(), "no-adjustment"),
+        );
+        let result = execute_aggregation_plan(&artifact, &request, &enabled()).unwrap();
+        let family = &determined(&result.families)[0];
+        assert_eq!(
+            determined(&family.scalars["best_start_total_before_abatement"]),
+            expected_gross
+        );
+    }
+
+    let mut no_principal_care = nz_request();
+    replace_children(&mut no_principal_care, &[1]);
+    no_principal_care
+        .persons
+        .iter_mut()
+        .find(|person| person.id == "child-0")
+        .unwrap()
+        .facts
+        .insert(
+            "principal_care_for_family_scheme".to_string(),
+            nz_known(false, "no-principal-care"),
+        );
+    let result = execute_aggregation_plan(&artifact, &no_principal_care, &enabled()).unwrap();
+    let family = &determined(&result.families)[0];
+    assert_eq!(*determined(&family.counts["dependent_child_count"]), 0);
+    assert_eq!(
+        determined(&family.scalars["best_start_total_before_abatement"]),
+        "0"
+    );
+
+    for knowledge in [
+        AggregationKnowledge::Unknown {
+            evidence: nz_evidence("best-start-care-unknown"),
+        },
+        AggregationKnowledge::Conflict {
+            observations: vec![
+                AggregationObservation {
+                    value: "0.5".to_string(),
+                    evidence: nz_evidence("best-start-care-half"),
+                },
+                AggregationObservation {
+                    value: "1".to_string(),
+                    evidence: nz_evidence("best-start-care-full"),
+                },
+            ],
+        },
+    ] {
+        let mut request = nz_request();
+        request.persons[2]
+            .scalars
+            .insert("best_start_claimant_care_fraction".to_string(), knowledge);
+        let result = execute_aggregation_plan(&artifact, &request, &enabled()).unwrap();
+        let family = &determined(&result.families)[0];
+        assert!(matches!(
+            family.scalars["best_start_total"],
+            AggregationValue::Indeterminate { .. }
+        ));
+    }
+
+    for fraction in ["-0.1", "1.1"] {
+        let mut request = nz_request();
+        request.persons[2].scalars.insert(
+            "best_start_claimant_care_fraction".to_string(),
+            nz_known(fraction.to_string(), &format!("out-of-range:{fraction}")),
+        );
+        assert!(matches!(
+            execute_aggregation_plan(&artifact, &request, &enabled()),
+            Err(UnitDerivationError::InvalidPlan(message))
+                if message.contains("must be between 0 and 1")
+        ));
+    }
+
+    let mut inconsistent_iwtc = nz_request();
+    inconsistent_iwtc.persons[2].scalars.insert(
+        "in_work_tax_credit_child_exclusive_care_fraction".to_string(),
+        nz_known("0.5".to_string(), "iwtc-care-half"),
+    );
+    let result = execute_aggregation_plan(&artifact, &inconsistent_iwtc, &enabled()).unwrap();
+    assert!(matches!(
+        determined(&result.families)[0].scalars["in_work_tax_credit_child_exclusive_care_fraction"],
+        AggregationValue::Indeterminate { .. }
+    ));
+}
+
+#[test]
+fn direction_partner_anchor_unpartnered_and_actual_shape_predicates_are_checked() {
+    let artifact = nz_artifact();
+    let mut reversed_child = nz_request();
+    reversed_child
+        .relations
+        .iter_mut()
+        .find(|family| family.name == "dependent_child_of")
+        .unwrap()
+        .facts[0]
+        .tuple = ["child-0".to_string(), "primary".to_string()];
+    assert_eq!(
+        execute_aggregation_plan(&artifact, &reversed_child, &enabled()).unwrap_err(),
+        UnitDerivationError::InvalidRelationshipRole {
+            relation: "dependent_child_of".to_string(),
+            person: "child-0".to_string(),
+            role: "caregiver_must_be_adult".to_string(),
+        }
+    );
+
+    let mut reversed_non_holder = nz_request();
+    reversed_non_holder.persons.push(nz_person(
+        "caregiver-2",
+        30,
+        &nz_adult_values("0", "0", "0", "0", "0", "0", "0", "0", "0", "0"),
+        false,
+    ));
+    reversed_non_holder.persons.push(nz_person(
+        "child-2",
+        6,
+        &[
+            ("best_start_before_care_and_abatement", "0"),
+            ("best_start_claimant_care_fraction", "1"),
+        ],
+        true,
+    ));
+    reversed_non_holder
+        .relations
+        .iter_mut()
+        .find(|family| family.name == "dependent_child_of")
+        .unwrap()
+        .facts
+        .push(AggregationRelationFact {
+            tuple: ["child-2".to_string(), "caregiver-2".to_string()],
+            knowledge: nz_known(true, "reversed-non-holder"),
+        });
+    assert!(matches!(
+        execute_aggregation_plan(&artifact, &reversed_non_holder, &enabled()),
+        Err(UnitDerivationError::InvalidRelationshipRole { person, role, .. })
+            if person == "child-2" && role == "caregiver_must_be_adult"
+    ));
+
+    let mut reversed_partner = nz_request();
+    reversed_partner
+        .relations
+        .iter_mut()
+        .find(|family| family.name == "partner_of")
+        .unwrap()
+        .facts[0]
+        .tuple = ["partner".to_string(), "primary".to_string()];
+    let result = execute_aggregation_plan(&artifact, &reversed_partner, &enabled()).unwrap();
+    assert!(*determined(
+        &determined(&result.families)[0].partner_present
+    ));
+
+    let mut unpartnered = nz_request();
+    unpartnered.persons.retain(|person| person.id != "partner");
+    unpartnered
+        .relations
+        .iter_mut()
+        .find(|family| family.name == "partner_of")
+        .unwrap()
+        .facts
+        .clear();
+    replace_children(&mut unpartnered, &[14]);
+    let result = execute_aggregation_plan(&artifact, &unpartnered, &enabled()).unwrap();
+    let family = &determined(&result.families)[0];
+    assert!(!*determined(&family.partner_present));
+    assert!(*determined(
+        &family.predicates["sole_parent_with_dependent_children"]
+    ));
+    assert!(*determined(
+        &family.predicates["jss_sole_parent_youngest_age_at_least_14"]
+    ));
+    assert!(*determined(&family.predicates["has_dependent_children"]));
+    assert!(!*determined(
+        &family.predicates["has_two_or_more_dependent_children"]
+    ));
+
+    let mut unknown_holder = nz_request();
+    unknown_holder.family_inputs[0].named_people.insert(
+        "mc7_entitlement_holder".to_string(),
+        AggregationKnowledge::Unknown {
+            evidence: nz_evidence("mc7-holder-unknown"),
+        },
+    );
+    let result = execute_aggregation_plan(&artifact, &unknown_holder, &enabled()).unwrap();
+    assert!(matches!(
+        determined(&result.families)[0].partner_present,
+        AggregationValue::Indeterminate { .. }
+    ));
+
+    let mut child_holder = nz_request();
+    child_holder.family_inputs[0].named_people.insert(
+        "mc7_entitlement_holder".to_string(),
+        nz_known("child-0".to_string(), "invalid-child-holder"),
+    );
+    assert!(matches!(
+        execute_aggregation_plan(&artifact, &child_holder, &enabled()),
+        Err(UnitDerivationError::InvalidRelationshipRole { person, .. })
+            if person == "child-0"
+    ));
+}
+
+#[test]
+fn unrelated_family_preserves_family_id_but_changes_bound_trace() {
+    let artifact = nz_artifact();
+    let base_request = nz_request();
+    let base = execute_aggregation_plan(&artifact, &base_request, &enabled()).unwrap();
+    let base_family = &determined(&base.families)[0];
+    let base_id = base_family.id.clone();
+
+    let mut expanded = base_request.clone();
+    expanded.persons.push(nz_person(
+        "other-adult",
+        30,
+        &nz_adult_values("9", "468", "468", "0", "0", "0", "9", "1", "0", "0"),
+        false,
+    ));
+    expanded.persons.push(nz_person(
+        "other-child",
+        6,
+        &[
+            ("best_start_before_care_and_abatement", "0"),
+            ("best_start_claimant_care_fraction", "1"),
+        ],
+        true,
+    ));
+    expanded
+        .relations
+        .iter_mut()
+        .find(|family| family.name == "dependent_child_of")
+        .unwrap()
+        .facts
+        .push(AggregationRelationFact {
+            tuple: ["other-adult".to_string(), "other-child".to_string()],
+            knowledge: nz_known(true, "other-family-child"),
+        });
+    expanded.family_inputs.push(AggregationFamilyInput {
+        anchor_person: "other-adult".to_string(),
+        evidence: nz_evidence("family-input:other-adult"),
+        named_people: BTreeMap::from([(
+            "mc7_entitlement_holder".to_string(),
+            nz_known("other-adult".to_string(), "mc7:other-adult"),
+        )]),
+        scalars: BTreeMap::from([
+            (
+                "family_scheme_income".to_string(),
+                nz_known("468".to_string(), "other-family-income"),
+            ),
+            (
+                "best_start_family_abatement".to_string(),
+                nz_known("0".to_string(), "other-adjustment"),
+            ),
+            (
+                "best_start_abatement_threshold".to_string(),
+                nz_known("80000".to_string(), "other-threshold"),
+            ),
+            (
+                "best_start_abatement_rate".to_string(),
+                nz_known("0.1".to_string(), "other-rate"),
+            ),
+        ]),
+    });
+    let expanded_result = execute_aggregation_plan(&artifact, &expanded, &enabled()).unwrap();
+    let families = determined(&expanded_result.families);
+    assert_eq!(families.len(), 2);
+    let unchanged = families
+        .iter()
+        .find(|family| family.members.contains(&"primary".to_string()))
+        .unwrap();
+    assert_eq!(unchanged.id, base_id);
+    assert_eq!(unchanged, base_family);
+    let other = families
+        .iter()
+        .find(|family| family.members.contains(&"other-adult".to_string()))
+        .unwrap();
+    assert_eq!(
+        other.members,
+        vec!["other-adult".to_string(), "other-child".to_string()]
+    );
+    assert!(!*determined(&other.partner_present));
+    assert_eq!(*determined(&other.counts["dependent_child_count"]), 1);
+    assert_eq!(
+        *determined(&other.counts["best_start_eligible_child_count"]),
+        0
+    );
+    assert_eq!(determined(&other.scalars["weekly_wages"]), "9");
+    assert_eq!(determined(&other.scalars["annual_wages"]), "468");
+    assert_eq!(
+        determined(&other.scalars["best_start_total_before_abatement"]),
+        "0"
+    );
+    assert_eq!(determined(&other.scalars["best_start_total"]), "0");
+    assert_eq!(other.children.len(), 1);
+    assert_eq!(
+        determined(&other.children[0].scalars["family_scheme_income"]),
+        "468"
+    );
+    assert_ne!(expanded_result.trace_root, base.trace_root);
+
+    let mut reordered = base_request;
+    reordered.persons.reverse();
+    reordered.relations.reverse();
+    for family in &mut reordered.relations {
+        family.facts.reverse();
+    }
+    let reordered_result = execute_aggregation_plan(&artifact, &reordered, &enabled()).unwrap();
+    assert_eq!(reordered_result.trace_root, base.trace_root);
+    assert_eq!(reordered_result.families, base.families);
+}
+
+#[test]
+fn aggregation_trace_binds_scalar_evidence_and_normalizes_same_tuple_facts() {
+    let artifact = nz_artifact();
+    let base_request = nz_request();
+    let base = execute_aggregation_plan(&artifact, &base_request, &enabled()).unwrap();
+
+    let mut evidence_edit = base_request.clone();
+    if let AggregationKnowledge::Known { evidence, .. } = evidence_edit.persons[0]
+        .scalars
+        .get_mut("weekly_wage")
+        .unwrap()
+    {
+        evidence.id = "weekly-wage-independent-source".to_string();
+    }
+    let edited = execute_aggregation_plan(&artifact, &evidence_edit, &enabled()).unwrap();
+    assert_eq!(edited.families, base.families);
+    assert_ne!(edited.trace_root, base.trace_root);
+
+    let mut corroborated = base_request.clone();
+    corroborated
+        .relations
+        .iter_mut()
+        .find(|family| family.name == "dependent_child_of")
+        .unwrap()
+        .facts
+        .push(AggregationRelationFact {
+            tuple: ["primary".to_string(), "child-0".to_string()],
+            knowledge: nz_known(true, "corroborating-child-source"),
+        });
+    let first = execute_aggregation_plan(&artifact, &corroborated, &enabled()).unwrap();
+    corroborated
+        .relations
+        .iter_mut()
+        .find(|family| family.name == "dependent_child_of")
+        .unwrap()
+        .facts
+        .reverse();
+    let reversed = execute_aggregation_plan(&artifact, &corroborated, &enabled()).unwrap();
+    assert_eq!(reversed.trace_root, first.trace_root);
+    assert_eq!(reversed.families, first.families);
+
+    let mut exact_duplicate = base_request;
+    let relation = exact_duplicate
+        .relations
+        .iter_mut()
+        .find(|family| family.name == "dependent_child_of")
+        .unwrap();
+    relation.facts.push(relation.facts[0].clone());
+    let deduplicated = execute_aggregation_plan(&artifact, &exact_duplicate, &enabled()).unwrap();
+    assert_eq!(deduplicated.trace_root, base.trace_root);
+    assert_eq!(deduplicated.families, base.families);
+}
+
+#[test]
+fn conflicting_family_adjustment_is_indeterminate_and_order_invariant() {
+    let artifact = nz_artifact();
+    let mut agreeing = nz_request();
+    agreeing.family_inputs[0].scalars.insert(
+        "best_start_family_abatement".to_string(),
+        AggregationKnowledge::Observations {
+            observations: vec![
+                AggregationObservation {
+                    value: "1000".to_string(),
+                    evidence: nz_evidence("agreeing-adjustment-one"),
+                },
+                AggregationObservation {
+                    value: "1000".to_string(),
+                    evidence: nz_evidence("agreeing-adjustment-two"),
+                },
+            ],
+        },
+    );
+    let agreeing_result = execute_aggregation_plan(&artifact, &agreeing, &enabled()).unwrap();
+    assert_eq!(
+        determined(&determined(&agreeing_result.families)[0].scalars["best_start_total"]),
+        "7082"
+    );
+
+    let mut disagreeing = agreeing;
+    if let AggregationKnowledge::Observations { observations } = disagreeing.family_inputs[0]
+        .scalars
+        .get_mut("best_start_family_abatement")
+        .unwrap()
+    {
+        observations[1].value = "2000".to_string();
+    }
+    let disagreeing_result = execute_aggregation_plan(&artifact, &disagreeing, &enabled()).unwrap();
+    assert!(matches!(
+        determined(&disagreeing_result.families)[0].scalars["best_start_total"],
+        AggregationValue::Indeterminate { .. }
+    ));
+
+    let mut request = nz_request();
+    request.family_inputs[0].scalars.insert(
+        "best_start_family_abatement".to_string(),
+        AggregationKnowledge::Conflict {
+            observations: vec![
+                AggregationObservation {
+                    value: "1000".to_string(),
+                    evidence: nz_evidence("adjustment-one"),
+                },
+                AggregationObservation {
+                    value: "2000".to_string(),
+                    evidence: nz_evidence("adjustment-two"),
+                },
+            ],
+        },
+    );
+    let first = execute_aggregation_plan(&artifact, &request, &enabled()).unwrap();
+    let family = &determined(&first.families)[0];
+    assert!(matches!(
+        family.scalars["best_start_total"],
+        AggregationValue::Indeterminate { .. }
+    ));
+    if let AggregationKnowledge::Conflict { observations } = request.family_inputs[0]
+        .scalars
+        .get_mut("best_start_family_abatement")
+        .unwrap()
+    {
+        observations.reverse();
+    }
+    let reversed = execute_aggregation_plan(&artifact, &request, &enabled()).unwrap();
+    assert_eq!(reversed.trace_root, first.trace_root);
+    assert_eq!(reversed.families, first.families);
+}
+
+#[test]
+fn decimal_context_uses_half_even_at_both_midpoint_parities() {
+    let source =
+        include_str!("../../tests/fixtures/unit_derivation/nz_income_explorer_family.yaml")
+            .replace("decimal_precision: 40", "decimal_precision: 2");
+    let artifact = compile_aggregation_plan(&source).unwrap();
+    for (input, expected) in [("1.25", "1.2"), ("1.35", "1.4")] {
+        let mut request = nz_request();
+        request.persons.retain(|person| person.id == "primary");
+        request
+            .relations
+            .iter_mut()
+            .for_each(|family| family.facts.clear());
+        request.persons[0].scalars.insert(
+            "weekly_wage".to_string(),
+            nz_known(input.to_string(), &format!("midpoint:{input}")),
+        );
+        request.family_inputs[0].scalars.insert(
+            "best_start_family_abatement".to_string(),
+            nz_known("0".to_string(), "zero-adjustment"),
+        );
+        let result = execute_aggregation_plan(&artifact, &request, &enabled()).unwrap();
+        let family = &determined(&result.families)[0];
+        assert_eq!(determined(&family.scalars["weekly_wages"]), expected);
+    }
+}
+
+#[test]
+fn compiled_artifact_digest_tampering_and_plan_semantic_mutations_are_detected() {
+    let artifact = nz_artifact();
+    let pristine: serde_json::Value =
+        serde_json::from_str(&artifact.to_json_pretty().unwrap()).unwrap();
+    let mut value = pristine.clone();
+    value["plan_digest"] = serde_json::json!(
+        "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+    );
+    let error = CompiledAggregationArtifact::from_json_str(&serde_json::to_string(&value).unwrap())
+        .unwrap_err();
     assert!(matches!(
         error,
-        UnitDerivationError::InvalidPlan(message)
-            if message.contains("invalid aggregation plan YAML")
-                && message.contains("sum_per_child_after_abatement")
+        UnitDerivationError::InvalidAggregationArtifact(message)
+            if message.contains("advertised plan digest")
     ));
+
+    let source =
+        include_str!("../../tests/fixtures/unit_derivation/nz_income_explorer_family.yaml");
+    let citation_edit = compile_aggregation_plan(&source.replace(
+        "Income Tax Act 2007 s LC 13",
+        "Income Tax Act 2007 s LC 13 (citation mutation)",
+    ))
+    .unwrap();
+    assert_ne!(artifact.plan_digest, citation_edit.plan_digest);
+
+    for (pointer, replacement) in [
+        ("/format", serde_json::json!("wrong-format")),
+        ("/semantics_version", serde_json::json!("wrong-semantics")),
+        (
+            "/constitution_digest",
+            serde_json::json!(
+                "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+            ),
+        ),
+        (
+            "/phase_two_artifact/engine_version",
+            serde_json::json!("tampered-engine"),
+        ),
+    ] {
+        let mut mutant = pristine.clone();
+        *mutant.pointer_mut(pointer).unwrap() = replacement;
+        let mut registry = UnitDerivationDocumentRegistry::default();
+        assert!(
+            registry
+                .register_aggregation_json(&serde_json::to_string(&mutant).unwrap())
+                .is_err(),
+            "registry accepted artifact mutation at `{pointer}`"
+        );
+    }
+
+    let mut registry = UnitDerivationDocumentRegistry::default();
+    registry
+        .register_aggregation_artifact(artifact.clone())
+        .unwrap();
+    assert!(matches!(
+        registry.register_aggregation_artifact(artifact),
+        Err(UnitDerivationError::DuplicateNamespace { namespace, .. })
+            if namespace == "compiled unit-derivation document"
+    ));
+}
+
+#[test]
+fn every_stage3_structural_guard_kills_its_isolated_plan_mutant() {
+    let source =
+        include_str!("../../tests/fixtures/unit_derivation/nz_income_explorer_family.yaml");
+    let mutants = [
+        (
+            "all-members scalar reduction",
+            source.replacen("selector: adults", "selector: all_members", 1),
+        ),
+        (
+            "legacy child scalar alias",
+            source.replacen(
+                "child_gross_input: best_start_before_care_and_abatement",
+                "child_value: best_start_before_care_and_abatement",
+                1,
+            ),
+        ),
+        (
+            "family adjustment moved to child scope",
+            source.replacen(
+                "- name: best_start_family_abatement\n    scope: family",
+                "- name: best_start_family_abatement\n    scope: child",
+                1,
+            ),
+        ),
+        (
+            "family adjustment key mismatch",
+            source.replacen(
+                "- name: best_start_family_abatement\n    scope: family\n    kind: family_adjustment\n    reduction_key: best_start",
+                "- name: best_start_family_abatement\n    scope: family\n    kind: family_adjustment\n    reduction_key: another_family_reduction",
+                1,
+            ),
+        ),
+        (
+            "child gross loses typed provenance",
+            source.replacen("kind: child_gross_amount", "kind: additive_amount", 1),
+        ),
+        (
+            "wrong care operand",
+            source.replacen(
+                "care_fraction_input: best_start_claimant_care_fraction",
+                "care_fraction_input: in_work_tax_credit_child_exclusive_care_fraction",
+                1,
+            ),
+        ),
+        (
+            "child relation made symmetric",
+            source.replacen(
+                "- relation: dependent_child_of\n    direction: directed",
+                "- relation: dependent_child_of\n    direction: symmetric",
+                1,
+            ),
+        ),
+        (
+            "child tuple role swapped",
+            source.replacen("right_role: child", "right_role: caregiver", 1),
+        ),
+        (
+            "child projection reads family input",
+            source.replacen(
+                "- output: best_start_claimant_care_fraction\n    input: best_start_claimant_care_fraction",
+                "- output: best_start_claimant_care_fraction\n    input: family_scheme_income",
+                1,
+            ),
+        ),
+        (
+            "shape predicate names missing count",
+            source.replacen(
+                "count: dependent_child_count, minimum: 1",
+                "count: missing_child_count, minimum: 1",
+                1,
+            ),
+        ),
+        (
+            "required legal citation removed",
+            source.replacen(
+                "authority: nz/statute/act/public/2007/0097/section/MC-7",
+                "authority: ''",
+                1,
+            ),
+        ),
+    ];
+    for (name, mutant) in mutants {
+        assert_ne!(mutant, source, "mutant `{name}` must change the fixture");
+        assert!(
+            compile_aggregation_plan(&mutant).is_err(),
+            "plan validator accepted `{name}` mutant"
+        );
+    }
 }
 
 #[test]
@@ -1337,6 +2810,236 @@ fn compiled_semantics_digest_is_independently_recomputed_and_churns_on_semantic_
         compile(citation_edit).unwrap().semantics_digest(),
         "citation edits must churn the internally computed semantics digest"
     );
+}
+
+fn trace_binding_plan() -> ConstitutionPlan {
+    let mut plan = base_plan(&["a", "b"]);
+    plan.edges.push(edge(
+        "kin-edge",
+        EdgeKind::Base,
+        "a",
+        "b",
+        relation_expr("kin", "a", "b"),
+    ));
+    plan.statuses.push(StatusRule {
+        id: "status-b".to_string(),
+        person: "b".to_string(),
+        when: BoolExpr::fact(FactRef::Bool("status_b".to_string())),
+        citation: citation("trace:status-b"),
+    });
+    plan
+}
+
+fn trace_binding_input() -> ConstitutionInput {
+    let mut input = complete_input(&["a", "b"]);
+    let scope = input.roster.scope.clone();
+    input.relation_families = vec![
+        RelationFamilyInput {
+            name: "kin".to_string(),
+            scope: scope.clone(),
+            completeness: Some(evidence("complete-kin")),
+            facts: vec![
+                RelationFact {
+                    tuple: vec!["a".to_string(), "b".to_string()],
+                    observation: observed(true, "kin-a-b"),
+                },
+                RelationFact {
+                    tuple: vec!["b".to_string(), "a".to_string()],
+                    observation: observed(false, "kin-b-a"),
+                },
+            ],
+        },
+        RelationFamilyInput {
+            name: "unused_relation".to_string(),
+            scope,
+            completeness: Some(evidence("complete-unused-relation")),
+            facts: vec![RelationFact {
+                tuple: vec!["a".to_string(), "b".to_string()],
+                observation: observed(true, "unused-relation-a-b"),
+            }],
+        },
+    ];
+    input.bool_facts = vec![
+        BoolFactInput {
+            name: "status_b".to_string(),
+            observations: vec![observed(false, "status-b-false")],
+            explicit_unknown: None,
+        },
+        BoolFactInput {
+            name: "unused_bool".to_string(),
+            observations: vec![
+                observed(true, "unused-bool-true"),
+                observed(false, "unused-bool-false"),
+            ],
+            explicit_unknown: None,
+        },
+    ];
+    input.supplied_entities = vec![
+        SuppliedEntity {
+            entity_type: "external_case".to_string(),
+            id: "external-1".to_string(),
+            evidence: evidence("external-1-evidence"),
+        },
+        SuppliedEntity {
+            entity_type: "external_case".to_string(),
+            id: "external-2".to_string(),
+            evidence: evidence("external-2-evidence"),
+        },
+    ];
+    input.integrity_constraints = vec![
+        IntegrityConstraint {
+            id: "constraint-a".to_string(),
+            expr: BoolExpr::Literal(true),
+            citation: citation("trace:constraint-a"),
+        },
+        IntegrityConstraint {
+            id: "constraint-b".to_string(),
+            expr: BoolExpr::Literal(true),
+            citation: citation("trace:constraint-b"),
+        },
+    ];
+    input
+}
+
+fn trace_binding_root(plan: &ConstitutionPlan, input: &ConstitutionInput) -> String {
+    derive_units(&compile(plan.clone()).unwrap(), input, &enabled())
+        .unwrap()
+        .trace
+        .root
+}
+
+#[test]
+fn trace_root_structurally_normalizes_input_order_and_exact_duplicates() {
+    let plan = trace_binding_plan();
+    let input = trace_binding_input();
+    let expected = trace_binding_root(&plan, &input);
+
+    let mut reordered = input.clone();
+    reordered.roster.persons.reverse();
+    reordered.relation_families.reverse();
+    for family in &mut reordered.relation_families {
+        family.facts.reverse();
+    }
+    reordered.bool_facts.reverse();
+    for fact in &mut reordered.bool_facts {
+        fact.observations.reverse();
+    }
+    reordered.supplied_entities.reverse();
+    reordered.integrity_constraints.reverse();
+    assert_eq!(
+        trace_binding_root(&plan, &reordered),
+        expected,
+        "permuting set-like request records must not churn the trace root"
+    );
+
+    let mut duplicated = input.clone();
+    let relation_fact = duplicated.relation_families[0].facts[0].clone();
+    duplicated.relation_families[0].facts.push(relation_fact);
+    let observation = duplicated.bool_facts[0].observations[0].clone();
+    duplicated.bool_facts[0].observations.push(observation);
+    let supplied = duplicated.supplied_entities[0].clone();
+    duplicated.supplied_entities.push(supplied);
+    let constraint = duplicated.integrity_constraints[0].clone();
+    duplicated.integrity_constraints.push(constraint);
+    assert_eq!(
+        trace_binding_root(&plan, &duplicated),
+        expected,
+        "exact duplicate records are one normalized observation"
+    );
+
+    assert_eq!(
+        expected,
+        "sha256:76b0ad50498beddd41b510b4315ab17e2dcc1e24e4623ecf445f8c8e27e9eab1"
+    );
+}
+
+#[test]
+fn trace_root_binds_compiled_semantics_and_every_constitution_input_surface() {
+    let plan = trace_binding_plan();
+    let input = trace_binding_input();
+    let baseline = trace_binding_root(&plan, &input);
+
+    let mut semantic_edit = plan.clone();
+    semantic_edit.derived_bools.push(DerivedBool {
+        id: "unused-but-semantic".to_string(),
+        stratum: Stratum::Person,
+        expr: BoolExpr::Literal(true),
+    });
+    assert_ne!(
+        trace_binding_root(&semantic_edit, &input),
+        baseline,
+        "compiled semantics digest is part of the trace commitment"
+    );
+
+    let mut mutations = Vec::<(&str, ConstitutionInput)>::new();
+
+    let mut changed = input.clone();
+    changed.roster.persons.push("c".to_string());
+    mutations.push(("roster members", changed));
+
+    let mut changed = input.clone();
+    changed.roster.completeness.as_mut().unwrap().id = "other-roster-evidence".to_string();
+    mutations.push(("roster completeness evidence", changed));
+
+    let mut changed = input.clone();
+    changed.segment = "2026-08-01/2026-08-31".to_string();
+    mutations.push(("segment", changed));
+
+    let mut changed = input.clone();
+    changed.relation_families[0].facts[0].observation.value = false;
+    mutations.push(("relation observation value", changed));
+
+    let mut changed = input.clone();
+    changed.relation_families[0].facts[0]
+        .observation
+        .evidence
+        .id = "other-relation-evidence".to_string();
+    mutations.push(("relation observation evidence", changed));
+
+    let mut changed = input.clone();
+    changed.relation_families[0]
+        .completeness
+        .as_mut()
+        .unwrap()
+        .citation
+        .authority = "other-relation-completeness-authority".to_string();
+    mutations.push(("relation completeness evidence", changed));
+
+    let mut changed = input.clone();
+    changed.relation_families[0].scope = "other-scope".to_string();
+    mutations.push(("relation scope", changed));
+
+    let mut changed = input.clone();
+    changed.bool_facts[0].observations[0].value = true;
+    mutations.push(("boolean observation value", changed));
+
+    let mut changed = input.clone();
+    changed.bool_facts[0].observations[0]
+        .evidence
+        .citation
+        .provision = "other-boolean-evidence".to_string();
+    mutations.push(("boolean observation evidence", changed));
+
+    let mut changed = input.clone();
+    changed.bool_facts[0].observations.clear();
+    changed.bool_facts[0].explicit_unknown = Some(evidence("explicit-status-unknown"));
+    mutations.push(("explicit Unknown evidence", changed));
+
+    let mut changed = input.clone();
+    changed.supplied_entities[0].evidence.id = "other-supplied-entity-evidence".to_string();
+    mutations.push(("supplied entity evidence", changed));
+
+    let mut changed = input.clone();
+    changed.integrity_constraints[0].citation.authority = "other-integrity-authority".to_string();
+    mutations.push(("integrity constraint", changed));
+
+    for (surface, changed) in mutations {
+        assert_ne!(
+            trace_binding_root(&plan, &changed),
+            baseline,
+            "changing {surface} must churn the trace root"
+        );
+    }
 }
 
 fn independent_lp(output: &mut Vec<u8>, value: &[u8]) {

--- a/src/unit_derivation/tests.rs
+++ b/src/unit_derivation/tests.rs
@@ -1148,6 +1148,135 @@ fn invariant_normalized_input_conflict_is_classified_per_affected_projection() {
     );
 }
 
+fn nz_person(id: &str, age_years: i64, values: &[(&str, &str)]) -> AggregationPerson {
+    AggregationPerson {
+        id: id.to_string(),
+        age_years: Some(age_years),
+        scalars: values
+            .iter()
+            .map(|(name, value)| ((*name).to_string(), (*value).to_string()))
+            .collect(),
+    }
+}
+
+fn nz_values<'a>(
+    weekly_wage: &'a str,
+    annual_wage: &'a str,
+    base_income: &'a str,
+    before: &'a str,
+    abatement: &'a str,
+) -> Vec<(&'static str, &'a str)> {
+    vec![
+        ("weekly_wage", weekly_wage),
+        ("annual_wage", annual_wage),
+        ("annual_family_scheme_base_income", base_income),
+        ("weekly_net_benefit", "0"),
+        ("weekly_gross_benefit", "0"),
+        ("weekly_wage_tax", "0"),
+        ("weekly_net_wage", weekly_wage),
+        ("weekly_hours", "40"),
+        ("ietc_weekly", "0"),
+        ("ietc_continuous_weekly", "0"),
+        ("best_start_before_abatement", before),
+        ("best_start_family_abatement", abatement),
+    ]
+}
+
+#[test]
+fn nz_family_fixture_moves_person_child_aggregation_behind_the_barrier() {
+    let plan = parse_aggregation_plan(include_str!(
+        "../../tests/fixtures/unit_derivation/nz_income_explorer_family.yaml"
+    ))
+    .unwrap();
+    let primary_values = nz_values(
+        "1000.12345678901234567890123456789012345",
+        "52000",
+        "52000",
+        "0",
+        "0",
+    );
+    let partner_values = nz_values(
+        "740.87654321098765432109876543210987655",
+        "38480",
+        "38480",
+        "0",
+        "0",
+    );
+    let child_one_values = nz_values("0", "0", "0", "4041", "1000");
+    let child_two_values = nz_values("0", "0", "0", "4041", "1000");
+    let request = AggregationRequest {
+        scope: "scenario:binding-best-start".to_string(),
+        segment: "2026-04-01/2027-03-31".to_string(),
+        primary_person: "primary".to_string(),
+        persons: vec![
+            nz_person("primary", 25, &primary_values),
+            nz_person("partner", 25, &partner_values),
+            nz_person("child-0", 1, &child_one_values),
+            nz_person("child-1", 2, &child_two_values),
+        ],
+        relations: BTreeMap::from([
+            (
+                "partner_of".to_string(),
+                vec![["primary".to_string(), "partner".to_string()]],
+            ),
+            (
+                "dependent_child_of".to_string(),
+                vec![
+                    ["primary".to_string(), "child-0".to_string()],
+                    ["primary".to_string(), "child-1".to_string()],
+                ],
+            ),
+        ]),
+        family_scalars: BTreeMap::from([("family_scheme_income".to_string(), "90480".to_string())]),
+    };
+    let result = execute_aggregation_plan(&plan, &request, &enabled()).unwrap();
+    assert_eq!(result.families.len(), 1);
+    let family = &result.families[0];
+    assert!(family.partner_present);
+    assert_eq!(family.counts["dependent_child_count"], 2);
+    assert_eq!(family.counts["best_start_eligible_child_count"], 2);
+    assert_eq!(family.counts["youngest_child_age"], 1);
+    assert_eq!(family.scalars["weekly_wages"], "1741");
+    assert_eq!(family.scalars["annual_family_scheme_base_income"], "90480");
+    assert_eq!(family.scalars["best_start_total"], "7082");
+    assert_eq!(family.scalars["best_start_total_before_abatement"], "8082");
+    assert!(family.children.iter().all(|child| {
+        child.scalars["family_scheme_income"] == "90480"
+            && child.age_bands["best_start_eligible_child_count"]
+            && child.family == family.id
+    }));
+
+    let disabled = execute_aggregation_plan(&plan, &request, &Default::default())
+        .expect_err("aggregation retains the independent runtime gate");
+    assert_eq!(disabled, UnitDerivationError::Disabled);
+}
+
+#[test]
+fn nz_best_start_host_defect_reproduces_but_plan_has_no_per_child_abatement_operator() {
+    let before = rust_decimal::Decimal::from(4041);
+    let abatement = rust_decimal::Decimal::from(1000);
+    let two = rust_decimal::Decimal::from(2);
+    let host_per_child = (before - abatement).max(rust_decimal::Decimal::ZERO) * two;
+    let family_once = (before * two - abatement).max(rust_decimal::Decimal::ZERO);
+    assert_eq!(host_per_child, rust_decimal::Decimal::from(6082));
+    assert_eq!(family_once, rust_decimal::Decimal::from(7082));
+
+    let invalid =
+        include_str!("../../tests/fixtures/unit_derivation/nz_income_explorer_family.yaml")
+            .replace(
+                "sum_children_then_subtract_family_once",
+                "sum_per_child_after_abatement",
+            );
+    let error = parse_aggregation_plan(&invalid)
+        .expect_err("the public plan grammar has no per-child abatement reducer");
+    assert!(matches!(
+        error,
+        UnitDerivationError::InvalidPlan(message)
+            if message.contains("invalid aggregation plan YAML")
+                && message.contains("sum_per_child_after_abatement")
+    ));
+}
+
 #[test]
 fn identity_preimage_is_order_invariant_and_matches_the_frozen_vector() {
     let first = unit_id(

--- a/src/unit_derivation/types.rs
+++ b/src/unit_derivation/types.rs
@@ -460,6 +460,33 @@ pub enum UnitDerivationError {
         existing_type: String,
         incoming_type: String,
     },
+    #[error(
+        "family-scoped reduction key `{key}` is consumed more than once: first by `{first}`, then by `{second}`"
+    )]
+    DuplicateFamilyScopeReduction {
+        key: String,
+        first: String,
+        second: String,
+    },
+    #[error(
+        "aggregation operand `{input}` for `{operation}` has scope/provenance `{found}`, expected `{expected}`"
+    )]
+    InvalidAggregationOperand {
+        operation: String,
+        input: String,
+        expected: String,
+        found: String,
+    },
+    #[error(
+        "relationship `{relation}` assigns entitlement holder `{person}` the forbidden role `{role}`"
+    )]
+    InvalidRelationshipRole {
+        relation: String,
+        person: String,
+        role: String,
+    },
+    #[error("compiled aggregation artifact is invalid: {0}")]
+    InvalidAggregationArtifact(String),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -492,6 +519,19 @@ pub struct RelationKnowledgeRecord {
     pub tuple: Vec<String>,
     pub interval: crate::model::Interval,
     pub truth: LiftedTruth,
+}
+
+/// An unresolved scalar/fact/age input carried beside the ordinary phase-2
+/// dataset. Determined values remain ordinary typed `InputRecord`s; this
+/// channel prevents the production dataset's closed-world lookup from
+/// converting an explicitly Unknown or Conflict input into absence.
+#[derive(Clone, Debug, PartialEq)]
+pub struct InputKnowledgeRecord {
+    pub name: String,
+    pub entity: String,
+    pub entity_id: String,
+    pub interval: crate::model::Interval,
+    pub reduction: CompleteReduction<crate::model::ScalarValue>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/src/unit_derivation/types.rs
+++ b/src/unit_derivation/types.rs
@@ -478,7 +478,17 @@ pub enum UnitDerivationError {
         found: String,
     },
     #[error(
-        "relationship `{relation}` assigns entitlement holder `{person}` the forbidden role `{role}`"
+        "child-gross operand `{input}` for `{operation}` on child `{child}` has provenance `{found}`, expected `{expected}`"
+    )]
+    InvalidChildGrossProvenance {
+        operation: String,
+        input: String,
+        child: String,
+        expected: String,
+        found: String,
+    },
+    #[error(
+        "relationship `{relation}` assigns family reference person `{person}` the forbidden role `{role}`"
     )]
     InvalidRelationshipRole {
         relation: String,

--- a/stage3-nz/OUT.md
+++ b/stage3-nz/OUT.md
@@ -1,0 +1,108 @@
+# Stage 3 NZ out-file
+
+Status: complete. `PROGRESS.md` was not modified.
+
+## Aggregations moved behind the engine boundary
+
+- Explicit Person roster plus `partner_of` and `dependent_child_of` relation
+  facts derive one Family unit and its member projections.
+- Partner presence is derived from the Family relation graph.
+- Adult values are summed to Family: weekly and annual wages, family-scheme
+  base income, net and gross benefits, wage tax, net wage, hours, IETC, and
+  continuous IETC.
+- Child values are derived by age band: total dependent children, ages 0--2,
+  0--13, and 14--18, plus youngest-child age.
+- Family-scheme income is broadcast into each Child projection before the
+  Child Best Start evaluation.
+- Best Start is reduced as `sum(child gross credit) - family abatement once`,
+  clamped at zero. The plan grammar has no per-child abatement operator.
+
+The harness still marshals primitive Person scalars and explicit scenario
+relationship facts into the request. It no longer performs any of the above
+reductions or family/child-shape calculations in Python.
+
+## Plan fixture and legal boundary
+
+The plan is
+`tests/fixtures/unit_derivation/nz_income_explorer_family.yaml`. It is limited
+to the pinned IncomeExplorer comparison and records the cited Income Tax Act
+2007 family/partner/child provisions on the membership and aggregation
+operations. Relationship facts are explicit and complete inputs; the engine
+does not infer legal relationship status from age, income, or missing facts.
+Accordingly no deferred Tier-B choice is made. The 40-significant-digit
+round-half-even context is also an explicit plan input because it is part of
+the pinned comparison's numeric reproducibility contract, not a legal reading.
+
+## What stage 3 added beyond the stage-2 prototype
+
+- A declarative experimental aggregation-plan parser and executor in
+  `src/unit_derivation/aggregation.rs`.
+- Runtime construction of the stage-2 `ConstitutionPlan` from the explicit
+  roster and relation facts, followed by the existing compiler/deriver.
+- Family scalar sums, child counts/minimums, Family-to-Child broadcasts, and
+  the single structurally safe family-once reducer.
+- Arbitrary-precision decimal aggregation with explicit significant-digit
+  precision so the engine boundary preserves the pinned 40-digit results.
+- Feature-gated CLI command `run-unit-aggregation`, requiring both the Cargo
+  `unit-derivation` feature and the existing explicit runtime enable switch.
+
+The v2 artifact schema and RuleSpec lowering were not changed. With the
+feature disabled the new module, dependency, and CLI branch are not compiled.
+Against clean stage-2 merge `74881519c829106e4e696d77b38e10ba61c881d8`,
+the default-feature help text and compiled NZ composition artifact are
+byte-identical; both artifacts have SHA-256
+`355659bf30cef49c440d5fa24014f1bf6c9a17964befb164880196950462f3b2`.
+
+## Parity proof
+
+The patched harness ran end to end against the pinned expanded Treasury
+snapshot and performed two fresh runs:
+
+- 1,454 / 1,976 amount/control cells agree to the cent.
+- 522 amount/control exceptions are unchanged: class B 520, class C 2,
+  class A 0, class D 0.
+- All 2,080 primary comparison rows, including 104 EMTR rows, are
+  byte-identical to `bcf631b5:nz-lane/emtr_reproduction/comparison.csv`.
+- Therefore every cell value, classification, reason code/title, and ordered
+  disposition coordinate is identical. The pinned format has no literal
+  `disposition_id` field; its effective identity tuple
+  `(scenario_id, weekly_wage, column, classification, reason_code,
+  reason_title)` is unchanged.
+- The patched harness reports `deterministic_fresh_runs: 2`, 883 ordinary
+  engine evaluations, and 1,411 unit-aggregation evaluations.
+
+The regenerated `comparison.json` is intentionally not byte-identical to the
+old JSON because its provenance, methodology, and coverage evidence now name
+the aggregation plan and engine-owned reduction. Its comparison CSV payload
+is byte-identical, and each patched fresh run is byte-identical to the other.
+
+## Tests
+
+- Full engine, feature off: 284 passed, 0 failed, 0 ignored.
+- Full engine, feature on: 309 passed, 0 failed, 0 ignored.
+- Unit-derivation focused suite: 25 passed, 0 failed.
+- Pinned harness declared-closure tests: 2 passed.
+- The NZ fixture test verifies relation-derived Family/Child projections,
+  long-decimal sum fidelity, broadcasts, and the family-once Best Start value.
+- The regression test reproduces the old host result (6,082) versus the
+  correct family-once result (7,082), then proves the plan parser rejects a
+  `sum_per_child_after_abatement` operation.
+
+## Ops harness patch
+
+Apply `stage3-nz/ops-harness.patch` to ops commit `bcf631b5`. It changes only
+`nz-lane/emtr_reproduction/run.py`; the pinned composition and eligibility
+closures remain unchanged. The patch passes a dry-run application check,
+Python compilation, the two closure tests, and the end-to-end comparison.
+
+## Honest limits
+
+- This is an experimental plan API beside artifact v2, not a relation-bearing
+  artifact-schema extension. The compiled RuleSpec composition remains
+  relation-free; the separate engine-owned aggregation plan supplies the
+  relation semantics and reductions, as allowed by the stage-2 extension
+  route.
+- GitHub issue comment 5299498361 was unavailable from the local checkout and
+  could not be fetched in this environment. The implementation follows the
+  verbatim ratification supplied in the brief and the matching Tier A/D versus
+  deferred Tier B boundary recorded in `docs/unit-derivation.md`.

--- a/stage3-nz/ops-harness.patch
+++ b/stage3-nz/ops-harness.patch
@@ -1,6 +1,8 @@
+diff --git a/nz-lane/emtr_reproduction/run.py b/nz-lane/emtr_reproduction/run.py
+index d5f5d72..1fcff15 100644
 --- a/nz-lane/emtr_reproduction/run.py
 +++ b/nz-lane/emtr_reproduction/run.py
-@@ -43,13 +43,20 @@
+@@ -43,13 +43,23 @@ DEFAULT_TREASURY_ROOT = (
      Path.home() / "_axiom-worktrees" / "nz-treasury-income-explorer"
  )
  DEFAULT_COMPOSITION = HERE / "composition.yaml"
@@ -15,14 +17,198 @@
  DEFAULT_ORACLE_GENERATOR = HERE / "generate_treasury_emtr_snapshot_expanded.R"
  DEFAULT_RSCRIPT = Path("/usr/local/bin/Rscript")
  EXPANDED_ORACLE_NAME = "treasury-emtr-snapshot-expanded.json"
- 
+
  EXPECTED_RULESPEC_SHA = "89a7d25dc03a4d045348620283332de10b1047da"
 -EXPECTED_ENGINE_SHA = "d59969b53430ae2fd97eb4349d44ad23ce930d85"
-+EXPECTED_ENGINE_SHA = "74881519c829106e4e696d77b38e10ba61c881d8"
++EXPECTED_ENGINE_SHA = "d8d45a817b3700ed22ec49a9fcf1024aa6ed2198"
++EXPECTED_ENGINE_BINARY_SHA256 = (
++    "c5a3d3d8b1fdb8480bef7cffc6dd85658ca1a48cf7ca70da968b7a46c1e8a430"
++)
  EXPECTED_ORACLE_COMMIT = "741a6ca4f5d27b1dc00b43dc395e39ffc4040a4b"
  EXPECTED_PARAMETER_FILE = "inst/parameters/TY27_BEFU25.yaml"
  EXPECTED_PARAMETER_SHA256 = (
-@@ -373,6 +380,8 @@
+@@ -190,9 +200,15 @@ EXPECTED_CLOSURE_KEYS = {
+         "wff_commissioner_considers_primary_day_to_day_care_when_child_present",
+         "wff_care_is_temporary",
+         "wff_caregiver_lives_apart_when_child_present",
++        "iwtc_child_is_principal_caregiver_when_present",
+         "iwtc_child_exclusive_care_fraction",
+         "best_start_child_care_fraction",
+     },
++    "age_18": {
++        "not_financially_independent_at_age_18",
++        "attending_school_or_tertiary_at_age_18",
++        "commissioner_period_contains_segment_at_age_18",
++    },
+     "work_tests": {
+         "iwtc_allowed_paye_income_payment_when_wages_positive",
+         "iwtc_normally_earner_when_wages_positive",
+@@ -276,6 +292,90 @@ def decimal_text(value: Decimal) -> str:
+     return text
+
+
++def known(value: Any, evidence_id: str) -> dict[str, Any]:
++    """Construct one explicitly evidenced Knowledge value."""
++
++    return {
++        "status": "known",
++        "value": value,
++        "evidence": {"id": evidence_id},
++    }
++
++
++def observations(
++    values: Sequence[tuple[Any, str]],
++) -> dict[str, Any]:
++    """Let the engine determine whether independent observations agree."""
++
++    return {
++        "status": "observations",
++        "observations": [
++            {"value": value, "evidence": {"id": evidence_id}}
++            for value, evidence_id in values
++        ],
++    }
++
++
++def determined(value: Any, label: str) -> Any:
++    """Unwrap an engine Knowledge result, rejecting every indeterminate use."""
++
++    if not isinstance(value, dict) or value.get("status") != "determined":
++        raise HarnessError(f"unit aggregation output {label} is indeterminate: {value!r}")
++    if "value" not in value:
++        raise HarnessError(f"unit aggregation output {label} has no value: {value!r}")
++    return value["value"]
++
++
++def unwrap_aggregated_family(family: Mapping[str, Any]) -> dict[str, Any]:
++    """Adapt Knowledge-wrapped engine output without performing reductions."""
++
++    family_id = str(family.get("id"))
++    return {
++        "id": family_id,
++        "members": list(family.get("members", ())),
++        "partner_present": determined(
++            family.get("partner_present"), f"{family_id}.partner_present"
++        ),
++        "scalars": {
++            name: determined(value, f"{family_id}.scalars.{name}")
++            for name, value in family.get("scalars", {}).items()
++        },
++        "counts": {
++            name: determined(value, f"{family_id}.counts.{name}")
++            for name, value in family.get("counts", {}).items()
++        },
++        "predicates": {
++            name: determined(value, f"{family_id}.predicates.{name}")
++            for name, value in family.get("predicates", {}).items()
++        },
++        "children": [
++            {
++                "person": child["person"],
++                "family": child["family"],
++                "age_years": determined(
++                    child.get("age_years"),
++                    f"{family_id}.children.{child.get('person')}.age_years",
++                ),
++                "age_bands": {
++                    name: determined(
++                        value,
++                        f"{family_id}.children.{child.get('person')}.age_bands.{name}",
++                    )
++                    for name, value in child.get("age_bands", {}).items()
++                },
++                "scalars": {
++                    name: determined(
++                        value,
++                        f"{family_id}.children.{child.get('person')}.scalars.{name}",
++                    )
++                    for name, value in child.get("scalars", {}).items()
++                },
++            }
++            for child in family.get("children", ())
++        ],
++    }
++
++
+ def json_number(value: Decimal | None) -> float | None:
+     if value is None:
+         return None
+@@ -335,6 +435,45 @@ def git_tracked_dirty(root: Path) -> bool:
+     return bool(status.strip())
+
+
++def git_dirty(root: Path) -> bool:
++    """Return whether tracked or untracked, non-ignored checkout data changed."""
++
++    status = run_checked(
++        ["git", "-C", str(root), "status", "--porcelain"],
++        label=f"git status check for {root}",
++    ).stdout
++    return bool(status.strip())
++
++
++def verify_engine_binding(engine_root: Path, engine_binary: Path) -> tuple[str, str]:
++    """Bind execution to one clean checkout and one reviewed release binary."""
++
++    expected_binary = (
++        engine_root / "target" / "release" / "axiom-rules-engine"
++    ).resolve()
++    if engine_binary.resolve() != expected_binary:
++        raise HarnessError(
++            "engine binary must be the release binary under the pinned engine "
++            f"checkout: expected {expected_binary}, found {engine_binary.resolve()}"
++        )
++    engine_sha = git_sha(engine_root)
++    if engine_sha != EXPECTED_ENGINE_SHA:
++        raise HarnessError(
++            f"engine SHA mismatch: expected {EXPECTED_ENGINE_SHA}, found {engine_sha}"
++        )
++    if git_dirty(engine_root):
++        raise HarnessError(
++            f"engine checkout has tracked or untracked modifications: {engine_root}"
++        )
++    binary_sha256 = sha256_file(engine_binary)
++    if binary_sha256 != EXPECTED_ENGINE_BINARY_SHA256:
++        raise HarnessError(
++            "engine binary SHA-256 mismatch: expected "
++            f"{EXPECTED_ENGINE_BINARY_SHA256}, found {binary_sha256}"
++        )
++    return engine_sha, binary_sha256
++
++
+ def require_file(path: Path, label: str) -> Path:
+     resolved = path.expanduser().resolve()
+     if not resolved.is_file():
+@@ -342,6 +481,27 @@ def require_file(path: Path, label: str) -> Path:
+     return resolved
+
+
++def verify_aggregation_plan_binding(
++    engine_root: Path, aggregation_plan_path: Path
++) -> Path:
++    """Require the plan tracked by the clean, pinned engine checkout."""
++
++    expected = (
++        engine_root
++        / "tests"
++        / "fixtures"
++        / "unit_derivation"
++        / "nz_income_explorer_family.yaml"
++    ).resolve()
++    if aggregation_plan_path.resolve() != expected:
++        raise HarnessError(
++            "unit aggregation plan must be the canonical plan under the "
++            f"pinned engine checkout: expected {expected}, found "
++            f"{aggregation_plan_path.resolve()}"
++        )
++    return aggregation_plan_path
++
++
+ def require_directory(path: Path, label: str) -> Path:
+     resolved = path.expanduser().resolve()
+     if not resolved.is_dir():
+@@ -373,6 +533,8 @@ class Provenance:
      engine_binary_sha256: str
      composition_path: Path
      composition_sha256: str
@@ -31,7 +217,16 @@
      eligibility_closures_path: Path
      eligibility_closures_sha256: str
      eligibility_closures_version: str
-@@ -418,6 +427,11 @@
+@@ -411,13 +573,20 @@ class Provenance:
+                 "git_sha": self.engine_sha,
+                 "expected_git_sha": EXPECTED_ENGINE_SHA,
+                 "tracked_dirty": self.engine_tracked_dirty,
++                "cleanliness_scope": "tracked_and_untracked_nonignored",
+                 "binary": str(self.engine_binary),
+                 "binary_sha256": self.engine_binary_sha256,
++                "expected_binary_sha256": EXPECTED_ENGINE_BINARY_SHA256,
+             },
+             "composition": {
                  "path": str(self.composition_path),
                  "sha256": self.composition_sha256,
              },
@@ -43,7 +238,7 @@
              "eligibility_closures": {
                  "path": str(self.eligibility_closures_path),
                  "sha256": self.eligibility_closures_sha256,
-@@ -591,6 +605,7 @@
+@@ -591,6 +760,7 @@ def verify_inputs(
      engine_binary: Path,
      treasury_root: Path,
      composition_path: Path,
@@ -51,30 +246,64 @@
      eligibility_closures_path: Path,
      eligibility_closures: Mapping[str, Any],
      oracle_generator: Path,
-@@ -601,6 +616,9 @@
+@@ -601,18 +771,15 @@ def verify_inputs(
      engine_root = require_directory(engine_root, "engine root")
      engine_binary = require_file(engine_binary, "engine binary")
      composition_path = require_file(composition_path, "composition")
 +    aggregation_plan_path = require_file(
 +        aggregation_plan_path, "unit aggregation plan"
 +    )
++    aggregation_plan_path = verify_aggregation_plan_binding(
++        engine_root, aggregation_plan_path
++    )
      eligibility_closures_path = require_file(
          eligibility_closures_path, "eligibility closures"
      )
-@@ -787,8 +805,9 @@
-     engine_dirty = git_tracked_dirty(engine_root)
+-    expected_engine_binary = (
+-        engine_root / "target" / "release" / "axiom-rules-engine"
+-    ).resolve()
+-    if engine_binary != expected_engine_binary:
+-        raise HarnessError(
+-            "engine binary must be the release binary under the pinned engine "
+-            f"checkout: expected {expected_engine_binary}, found {engine_binary}"
+-        )
+-
+     if rulespec_root.name != "rulespec-nz":
+         raise HarnessError(
+             f"RuleSpec root basename must be rulespec-nz, got {rulespec_root.name!r}"
+@@ -773,22 +940,18 @@ def verify_inputs(
+                 )
+
+     rulespec_sha = git_sha(rulespec_root)
+-    engine_sha = git_sha(engine_root)
++    engine_sha, engine_binary_sha256 = verify_engine_binding(
++        engine_root, engine_binary
++    )
+     if rulespec_sha != EXPECTED_RULESPEC_SHA:
+         raise HarnessError(
+             f"RuleSpec SHA mismatch: expected {EXPECTED_RULESPEC_SHA}, "
+             f"found {rulespec_sha}"
+         )
+-    if engine_sha != EXPECTED_ENGINE_SHA:
+-        raise HarnessError(
+-            f"engine SHA mismatch: expected {EXPECTED_ENGINE_SHA}, found {engine_sha}"
+-        )
+     rulespec_dirty = git_tracked_dirty(rulespec_root)
+-    engine_dirty = git_tracked_dirty(engine_root)
      if rulespec_dirty:
          raise HarnessError(f"RuleSpec checkout has tracked modifications: {rulespec_root}")
 -    if engine_dirty:
 -        raise HarnessError(f"engine checkout has tracked modifications: {engine_root}")
-+    # Stage 3 is intentionally run from the local engine worktree before a
-+    # commit exists. The exact base commit and built binary hash remain pinned;
-+    # tracked modifications are recorded rather than rejected.
- 
++    engine_dirty = False
+
      treasury_root = require_directory(treasury_root, "Treasury source checkout")
      treasury_present = True
-@@ -837,6 +856,8 @@
-         engine_binary_sha256=sha256_file(engine_binary),
+@@ -834,9 +997,11 @@ def verify_inputs(
+         engine_sha=engine_sha,
+         engine_tracked_dirty=engine_dirty,
+         engine_binary=engine_binary,
+-        engine_binary_sha256=sha256_file(engine_binary),
++        engine_binary_sha256=engine_binary_sha256,
          composition_path=composition_path,
          composition_sha256=sha256_file(composition_path),
 +        aggregation_plan_path=aggregation_plan_path,
@@ -82,55 +311,85 @@
          eligibility_closures_path=eligibility_closures_path,
          eligibility_closures_sha256=sha256_file(eligibility_closures_path),
          eligibility_closures_version=str(eligibility_closures["version"]),
-@@ -857,12 +878,15 @@
+@@ -857,12 +1022,15 @@ class Engine:
          *,
          binary: Path,
          artifact: Path,
-+        aggregation_plan: Path,
++        aggregation_artifact: Path,
          catalog: Mapping[str, str],
      ) -> None:
          self.binary = binary
          self.artifact = artifact
-+        self.aggregation_plan = aggregation_plan
++        self.aggregation_artifact = aggregation_artifact
          self.catalog = dict(catalog)
          self.call_count = 0
 +        self.aggregation_call_count = 0
          self.observed_inputs: dict[str, set[str]] = {
              slot: set() for slot in self.catalog
          }
-@@ -875,6 +899,7 @@
+@@ -875,6 +1043,8 @@ class Engine:
          composition: Path,
          rulespec_root: Path,
          artifact: Path,
 +        aggregation_plan: Path,
++        aggregation_artifact: Path,
      ) -> tuple["Engine", dict[str, Any], str]:
          process = run_checked(
              [
-@@ -898,7 +923,12 @@
+@@ -898,7 +1068,41 @@ class Engine:
          }
          if not catalog:
              raise HarnessError("compiled artifact has an empty input catalog")
 -        engine = cls(binary=binary, artifact=artifact, catalog=catalog)
++        run_checked(
++            [
++                str(binary),
++                "compile-unit-aggregation",
++                "--plan",
++                str(aggregation_plan),
++                "--output",
++                str(aggregation_artifact),
++            ],
++            label="registered unit aggregation compile",
++        )
++        try:
++            compiled_aggregation = json.loads(
++                aggregation_artifact.read_text(encoding="utf-8")
++            )
++        except (OSError, json.JSONDecodeError) as exc:
++            raise HarnessError(
++                f"compiled unit aggregation artifact is invalid JSON: {exc}"
++            ) from exc
++        if (
++            compiled_aggregation.get("format")
++            != "axiom/compiled-unit-aggregation-stage3/1"
++            or not compiled_aggregation.get("plan_digest")
++            or not compiled_aggregation.get("phase_two_artifact")
++        ):
++            raise HarnessError(
++                "compiled unit aggregation artifact is incomplete or has an "
++                f"unknown format: {compiled_aggregation!r}"
++            )
 +        engine = cls(
 +            binary=binary,
 +            artifact=artifact,
-+            aggregation_plan=aggregation_plan,
++            aggregation_artifact=aggregation_artifact,
 +            catalog=catalog,
 +        )
          return engine, compiled, process.stdout.strip()
- 
+
      def input_record(
-@@ -1017,7 +1047,39 @@
+@@ -1017,6 +1221,38 @@ class Engine:
                  raise HarnessError(f"unknown engine output shape for {target}: {item!r}")
          return values, results[0].get("trace", {})
- 
+
 +    def aggregate(self, request: Mapping[str, Any]) -> dict[str, Any]:
 +        process = run_checked(
 +            [
 +                str(self.binary),
 +                "run-unit-aggregation",
-+                "--plan",
-+                str(self.aggregation_plan),
++                "--artifact",
++                str(self.aggregation_artifact),
 +                "--enable-experimental-unit-derivation",
 +            ],
 +            stdin=json.dumps(request, sort_keys=True, separators=(",", ":")),
@@ -148,31 +407,32 @@
 +            raise HarnessError(
 +                f"engine returned unknown aggregation schema: {response!r}"
 +            )
-+        families = response.get("families")
++        families = determined(response.get("families"), "families")
 +        if not isinstance(families, list) or len(families) != 1:
 +            raise HarnessError(
 +                "IncomeExplorer scenario must derive exactly one family, "
 +                f"found {families!r}"
 +            )
-+        return families[0]
- 
++        return unwrap_aggregated_family(families[0])
 +
+
  def normalize_children(raw: Any) -> list[int]:
      if isinstance(raw, list):
-         return [int(value) for value in raw]
-@@ -1262,6 +1324,7 @@
+@@ -1260,8 +1496,9 @@ class ModelEvaluator:
+         ] = {}
+         self._gross_benefit_cache: dict[Decimal, Decimal] = {}
          self._as_cutout_cache: dict[
-             tuple[bool, int, bool], Decimal
+-            tuple[bool, int, bool], Decimal
++            tuple[bool, bool, bool], Decimal
          ] = {}
 +        self._family_shape_cache: dict[str, dict[str, Any]] = {}
          self.tax_rates = selected_parameter_values(
              compiled, "individual_income_tax_bracket_rates"
          )
-@@ -1315,7 +1378,105 @@
-             raise HarnessError(
+@@ -1316,6 +1553,246 @@ class ModelEvaluator:
                  f"unexpected tax-threshold indexes: {sorted(self.tax_thresholds)}"
              )
-+
+
 +    @staticmethod
 +    def _zero_adult_scalars() -> dict[str, Decimal]:
 +        return {
@@ -187,7 +447,7 @@
 +            "ietc_weekly": D0,
 +            "ietc_continuous_weekly": D0,
 +        }
- 
++
 +    def aggregate_family(
 +        self,
 +        scenario: Scenario,
@@ -198,68 +458,210 @@
 +    ) -> dict[str, Any]:
 +        adults = adult_scalars or {}
 +        children = child_scalars or {}
++        scope = f"scenario:{scenario.id}"
++        primary_id = f"{scenario.id}:person:1"
 +        persons: list[dict[str, Any]] = []
 +        for person in (1, 2):
 +            if person == 2 and not scenario.partnered:
 +                continue
 +            scalars = self._zero_adult_scalars()
++            if person == 2:
++                scalars.update(
++                    {
++                        "weekly_wage": scenario.gross_wage2,
++                        "annual_wage": (
++                            scenario.gross_wage2 * WEEKS_IN_MODEL_YEAR
++                        ),
++                        "annual_family_scheme_base_income": (
++                            scenario.gross_wage2 * WEEKS_IN_MODEL_YEAR
++                        ),
++                        "weekly_hours": scenario.hours2,
++                    }
++                )
 +            scalars.update(adults.get(person, {}))
++            person_id = f"{scenario.id}:person:{person}"
 +            persons.append(
 +                {
-+                    "id": f"{scenario.id}:person:{person}",
-+                    "age_years": 25,
++                    "id": person_id,
++                    "role": "adult",
++                    "evidence": {"id": f"{scope}:adult:{person}"},
++                    "age_years": known(
++                        25, f"{scope}:adult:{person}:age"
++                    ),
 +                    "scalars": {
-+                        name: decimal_text(value)
++                        name: known(
++                            decimal_text(value),
++                            f"{scope}:adult:{person}:scalar:{name}",
++                        )
 +                        for name, value in sorted(scalars.items())
 +                    },
++                    "facts": {},
 +                }
 +            )
 +        for index, age in enumerate(scenario.children):
++            age_18 = self.closures["age_18"]
 +            values = {
-+                "best_start_before_abatement": D0,
-+                "best_start_family_abatement": D0,
++                "best_start_before_care_and_abatement": D0,
++                "best_start_claimant_care_fraction": dec(
++                    self.closures["care"][
++                        "best_start_child_care_fraction"
++                    ]
++                ),
++                "in_work_tax_credit_child_exclusive_care_fraction": dec(
++                    self.closures["care"][
++                        "iwtc_child_exclusive_care_fraction"
++                    ]
++                ),
 +            }
-+            values.update(children.get(index, {}))
++            values.update(
++                {
++                    name: value
++                    for name, value in children.get(index, {}).items()
++                    if name != "best_start_family_abatement"
++                }
++            )
++            child_id = f"{scenario.id}:child:{index}"
 +            persons.append(
 +                {
-+                    "id": f"{scenario.id}:child:{index}",
-+                    "age_years": age,
++                    "id": child_id,
++                    "role": "child",
++                    "evidence": {"id": f"{scope}:child:{index}"},
++                    "age_years": known(
++                        age, f"{scope}:child:{index}:age"
++                    ),
 +                    "scalars": {
-+                        name: decimal_text(value)
++                        name: known(
++                            decimal_text(value),
++                            f"{scope}:child:{index}:scalar:{name}",
++                        )
 +                        for name, value in sorted(values.items())
++                    },
++                    "facts": {
++                        "principal_care_for_family_scheme": known(
++                            bool(
++                                self.closures["care"][
++                                    "wff_commissioner_considers_primary_day_to_day_care_when_child_present"
++                                ]
++                            ),
++                            f"{scope}:child:{index}:principal-care",
++                        ),
++                        "in_work_tax_credit_principal_caregiver": known(
++                            bool(
++                                self.closures["care"][
++                                    "iwtc_child_is_principal_caregiver_when_present"
++                                ]
++                            ),
++                            f"{scope}:child:{index}:iwtc-principal-caregiver",
++                        ),
++                        "not_financially_independent_at_age_18": known(
++                            bool(
++                                age_18[
++                                    "not_financially_independent_at_age_18"
++                                ]
++                            ),
++                            f"{scope}:child:{index}:mc9-financial-dependence",
++                        ),
++                        "attending_school_or_tertiary_at_age_18": known(
++                            bool(
++                                age_18[
++                                    "attending_school_or_tertiary_at_age_18"
++                                ]
++                            ),
++                            f"{scope}:child:{index}:mc9-education",
++                        ),
++                        "commissioner_period_contains_segment_at_age_18": known(
++                            bool(
++                                age_18[
++                                    "commissioner_period_contains_segment_at_age_18"
++                                ]
++                            ),
++                            f"{scope}:child:{index}:mc9-period",
++                        ),
 +                    },
 +                }
 +            )
-+        relations: dict[str, list[list[str]]] = {
-+            "partner_of": [],
-+            "dependent_child_of": [],
-+        }
++        partner_tuples: list[tuple[str, str]] = []
 +        if scenario.partnered:
-+            relations["partner_of"].append(
-+                [
-+                    f"{scenario.id}:person:1",
-+                    f"{scenario.id}:person:2",
-+                ]
++            partner_tuples.append(
++                (primary_id, f"{scenario.id}:person:2")
 +            )
-+        relations["dependent_child_of"] = [
-+            [
-+                f"{scenario.id}:person:1",
-+                f"{scenario.id}:child:{index}",
-+            ]
++        child_tuples = [
++            (primary_id, f"{scenario.id}:child:{index}")
 +            for index, _age in enumerate(scenario.children)
 +        ]
++        relations = []
++        for relation, tuples in (
++            ("partner_of", partner_tuples),
++            ("dependent_child_of", child_tuples),
++        ):
++            relations.append(
++                {
++                    "name": relation,
++                    "scope": scope,
++                    "completeness": {
++                        "id": f"{scope}:complete:{relation}"
++                    },
++                    "facts": [
++                        {
++                            "tuple": list(pair),
++                            "knowledge": known(
++                                True,
++                                f"{scope}:relation:{relation}:{pair[0]}:{pair[1]}",
++                            ),
++                        }
++                        for pair in tuples
++                    ],
++                }
++            )
++        adjustment_values = [
++            (
++                decimal_text(values["best_start_family_abatement"]),
++                f"{scope}:child:{index}:best-start-family-abatement",
++            )
++            for index, values in sorted(children.items())
++            if "best_start_family_abatement" in values
++        ]
++        adjustment = (
++            observations(adjustment_values)
++            if adjustment_values
++            else known("0", f"{scope}:best-start-family-abatement:none")
++        )
 +        family = self.engine.aggregate(
 +            {
-+                "scope": f"scenario:{scenario.id}",
++                "scope": scope,
 +                "segment": f"{EXPECTED_PERIOD_START}/{EXPECTED_PERIOD_END}",
-+                "primary_person": f"{scenario.id}:person:1",
++                "roster_completeness": {"id": f"{scope}:complete:roster"},
++                "segment_completeness": {"id": f"{scope}:complete:segment"},
 +                "persons": persons,
 +                "relations": relations,
-+                "family_scalars": {
-+                    "family_scheme_income": decimal_text(
-+                        family_scheme_income
-+                    )
-+                },
++                "family_inputs": [
++                    {
++                        "anchor_person": primary_id,
++                        "evidence": {"id": f"{scope}:family-input"},
++                        "named_people": {
++                            "mc7_entitlement_holder": known(
++                                primary_id, f"{scope}:mc7-entitlement-holder"
++                            )
++                        },
++                        "scalars": {
++                            "family_scheme_income": known(
++                                decimal_text(family_scheme_income),
++                                f"{scope}:family-scheme-income",
++                            ),
++                            "best_start_family_abatement": adjustment,
++                            "best_start_abatement_threshold": known(
++                                decimal_text(
++                                    self.best_start_abatement_threshold
++                                ),
++                                f"{scope}:best-start-threshold",
++                            ),
++                            "best_start_abatement_rate": known(
++                                decimal_text(self.best_start_abatement_rate),
++                                f"{scope}:best-start-rate",
++                            ),
++                        },
++                    }
++                ],
 +            }
 +        )
 +        return family
@@ -274,7 +676,7 @@
      def _evaluate(
          self,
          *,
-@@ -1419,17 +1580,19 @@
+@@ -1419,17 +1896,19 @@ class ModelEvaluator:
          scenario: Scenario,
          weekly_family_income: Decimal,
      ) -> Decimal:
@@ -298,16 +700,18 @@
              "jobseeker_support_total_income": weekly_family_income,
              "jobseeker_support_transferred_2013_no_dependent_children": False,
              "jobseeker_support_youngest_dependent_child_age": youngest,
-@@ -1459,18 +1622,25 @@
+@@ -1459,25 +1938,39 @@ class ModelEvaluator:
          return scalar_decimal(values, SOLE_PARENT_OUTPUT)
- 
+
      def raw_iwtc_branch(self, scenario: Scenario, weekly_wages: Decimal) -> bool:
 -        return bool(scenario.children) and weekly_wages >= ORACLE_IWTC_WEEKLY_THRESHOLD
-+        child_count = int(
-+            self.family_shape(scenario)["counts"]["dependent_child_count"]
++        has_children = bool(
++            self.family_shape(scenario)["predicates"][
++                "has_dependent_children"
++            ]
 +        )
-+        return child_count > 0 and weekly_wages >= ORACLE_IWTC_WEEKLY_THRESHOLD
- 
++        return has_children and weekly_wages >= ORACLE_IWTC_WEEKLY_THRESHOLD
+
      def benefit_components(
          self,
          scenario: Scenario,
@@ -316,19 +720,38 @@
 -        if scenario.partnered:
 +        shape = self.family_shape(scenario)
 +        partnered = bool(shape["partner_present"])
-+        child_count = int(shape["counts"]["dependent_child_count"])
-+        youngest = int(shape["counts"]["youngest_child_age"])
++        has_children = bool(
++            shape["predicates"]["has_dependent_children"]
++        )
++        jss_sole_parent = bool(
++            shape["predicates"][
++                "jss_sole_parent_youngest_age_at_least_14"
++            ]
++        )
 +        if partnered:
              per_person = self.jobseeker_payment(scenario, weekly_wages)
              scheduled = (per_person, per_person)
 -        elif scenario.children:
 -            if min(scenario.children) >= 14:
-+        elif child_count:
-+            if youngest >= 14:
-                 # Treasury R/emtr.R lines 310-319 deliberately select the
-                 # lone-parent JSS rate with the SPS income-test scale once the
-                 # youngest child is 14. RuleSpec's Jobseeker branch encodes
-@@ -1489,7 +1659,7 @@
+-                # Treasury R/emtr.R lines 310-319 deliberately select the
+-                # lone-parent JSS rate with the SPS income-test scale once the
+-                # youngest child is 14. RuleSpec's Jobseeker branch encodes
+-                # that same combination.
+-                scheduled = (self.jobseeker_payment(scenario, weekly_wages),)
+-            else:
+-                scheduled = (self.sole_parent_payment(scenario, weekly_wages),)
++        elif jss_sole_parent:
++            # Treasury R/emtr.R lines 310-319 deliberately select the
++            # lone-parent JSS rate with the SPS income-test scale once the
++            # youngest child is 14. The cited plan derives the full branch
++            # predicate; Python only composes the selected program call.
++            scheduled = (self.jobseeker_payment(scenario, weekly_wages),)
++        elif has_children:
++            scheduled = (self.sole_parent_payment(scenario, weekly_wages),)
+         else:
+             scheduled = (self.jobseeker_payment(scenario, weekly_wages),)
+         if self.raw_iwtc_branch(scenario, weekly_wages):
+@@ -1489,7 +1982,7 @@ class ModelEvaluator:
          scenario: Scenario,
      ) -> tuple[Decimal, ...]:
          per_person = self.jobseeker_payment(scenario, D0)
@@ -336,24 +759,34 @@
 +        if bool(self.family_shape(scenario)["partner_present"]):
              return (per_person, per_person)
          return (per_person,)
- 
-@@ -1545,7 +1715,14 @@
+
+@@ -1545,7 +2038,10 @@ class ModelEvaluator:
          weekly_wages: Decimal,
          net_benefit: Decimal,
      ) -> dict[str, bool | int | Decimal]:
 -        has_children = bool(scenario.children)
-+        has_children = (
-+            int(
-+                self.family_shape(scenario)["counts"][
-+                    "dependent_child_count"
-+                ]
-+            )
-+            > 0
++        shape = self.family_shape(scenario)
++        has_children = bool(
++            shape["predicates"]["has_dependent_children"]
 +        )
          earns_paye = weekly_wages > 0
          residence = self.closures["residence"]
          care = self.closures["care"]
-@@ -1639,17 +1816,20 @@
+@@ -1568,8 +2064,11 @@ class ModelEvaluator:
+                 has_children and care["wff_caregiver_lives_apart_when_child_present"]
+             ),
+             "in_work_tax_credit_child_exclusive_care_fraction": (
+-                dec(care["iwtc_child_exclusive_care_fraction"])
+-                if has_children else D0
++                dec(
++                    shape["scalars"][
++                        "in_work_tax_credit_child_exclusive_care_fraction"
++                    ]
++                )
+             ),
+             "in_work_tax_credit_person_age": 25,
+             "in_work_tax_credit_child_financially_dependent": has_children,
+@@ -1639,30 +2138,48 @@ class ModelEvaluator:
          self,
          *,
          scenario: Scenario,
@@ -372,6 +805,9 @@
 +        child_count = int(
 +            family_aggregate["counts"]["dependent_child_count"]
 +        )
++        has_children = bool(
++            family_aggregate["predicates"]["has_dependent_children"]
++        )
 +        values = family_aggregate["scalars"]
 +        weekly_wages = dec(values["weekly_wages"])
 +        annual_wages = dec(values["annual_wages"])
@@ -384,7 +820,38 @@
          inputs = self.family_scheme_inputs(annual_base_income, annual_wages)
          inputs.update(
              {
-@@ -1675,7 +1855,7 @@
+                 "family_tax_credit_eldest_dependent_child_care_units": (
+-                    D1 if child_count else D0
++                    dec(
++                        values[
++                            "family_tax_credit_eldest_dependent_child_care_units"
++                        ]
++                    )
++                ),
++                "family_tax_credit_subsequent_dependent_child_care_units": dec(
++                    values[
++                        "family_tax_credit_subsequent_dependent_child_care_units"
++                    ]
++                ),
++                "family_tax_credit_entitlement_days": int(
++                    dec(values["family_tax_credit_entitlement_days"])
+                 ),
+-                "family_tax_credit_subsequent_dependent_child_care_units": Decimal(
+-                    max(0, child_count - 1)
++                "wff_family_credit_abatement_days": int(
++                    dec(values["wff_family_credit_abatement_days"])
+                 ),
+-                "family_tax_credit_entitlement_days": 365 if child_count else 0,
+-                "wff_family_credit_abatement_days": 365 if child_count else 0,
+                 "in_work_tax_credit_allowed_children_count": child_count,
+-                "in_work_tax_credit_weekly_periods": 52 if child_count else 0,
++                "in_work_tax_credit_weekly_periods": int(
++                    dec(values["in_work_tax_credit_weekly_periods"])
++                ),
+                 "child_tax_credit_for_entitlement_period": D0,
+                 "parental_tax_credit_for_entitlement_period": D0,
+                 "parental_tax_credit_additional_abatement": D0,
+@@ -1675,12 +2192,12 @@ class ModelEvaluator:
          full_time_hours = Decimal(
              work_tests[
                  "mftc_couple_full_time_hours_per_week"
@@ -393,7 +860,13 @@
                  else "mftc_single_full_time_hours_per_week"
              ]
          )
-@@ -1719,17 +1899,24 @@
+         mftc_eligible = (
+-            bool(child_count)
++            has_children
+             and hours_total >= full_time_hours
+             and net_benefit == 0
+         )
+@@ -1719,24 +2236,44 @@ class ModelEvaluator:
          self,
          *,
          scenario: Scenario,
@@ -428,8 +901,32 @@
 +            )
              inputs.update(
                  {
-                     "best_start_entitlement_days": 365,
-@@ -1746,39 +1933,39 @@
+-                    "best_start_entitlement_days": 365,
+-                    "best_start_child_care_fraction": dec(
+-                        self.closures["care"]["best_start_child_care_fraction"]
++                    "best_start_entitlement_days": int(
++                        dec(
++                            projected["scalars"][
++                                "best_start_entitlement_days"
++                            ]
++                        )
++                    ),
++                    # The child program emits the pre-care statutory amount.
++                    # The aggregation plan applies each explicit MG 2(5) care
++                    # fraction exactly once at the family reduction.
++                    "best_start_child_care_fraction": D1,
++                    "best_start_abatement_days": int(
++                        dec(
++                            projected["scalars"][
++                                "best_start_entitlement_days"
++                            ]
++                        )
+                     ),
+-                    "best_start_abatement_days": 365,
+                 }
+             )
+             values = self._evaluate(
+@@ -1746,39 +2283,32 @@ class ModelEvaluator:
                  outputs=[
                      BEST_START_BEFORE_OUTPUT,
                      BEST_START_ABATEMENT_OUTPUT,
@@ -452,8 +949,17 @@
 -        aggregate_total = max(
 -            D0,
 -            total_before_abatement - (family_abatement or D0),
+-        )
+-        continuous_total = max(
+-            D0,
+-            total_before_abatement
+-            - max(
+-                D0,
+-                annual_base_income - self.best_start_abatement_threshold,
+-            )
+-            * self.best_start_abatement_rate,
 +            child_values[index] = {
-+                "best_start_before_abatement": child_before,
++                "best_start_before_care_and_abatement": child_before,
 +                "best_start_family_abatement": child_abatement,
 +            }
 +        reduced = self.aggregate_family(
@@ -461,20 +967,12 @@
 +            adult_scalars=adult_scalars,
 +            child_scalars=child_values,
 +            family_scheme_income=family_scheme_income,
-         )
-+        aggregate_total = dec(reduced["scalars"]["best_start_total"])
-+        total_before_abatement = dec(
-+            reduced["scalars"]["best_start_total_before_abatement"]
 +        )
-         continuous_total = max(
-             D0,
-             total_before_abatement
-             - max(
-                 D0,
--                annual_base_income - self.best_start_abatement_threshold,
-+                family_scheme_income - self.best_start_abatement_threshold,
-             )
-             * self.best_start_abatement_rate,
++        aggregate_total = dec(reduced["scalars"]["best_start_total"])
++        continuous_total = dec(
++            reduced["scalars"][
++                "best_start_total_continuous_abatement"
++            ]
          )
          return (
              aggregate_total / WEEKS_IN_MODEL_YEAR,
@@ -482,14 +980,13 @@
              continuous_total / WEEKS_IN_MODEL_YEAR,
 +            child_values,
          )
- 
+
      def ietc_for_person(
-@@ -1863,14 +2050,18 @@
+@@ -1863,13 +2393,18 @@ class ModelEvaluator:
      ) -> Decimal:
          if net_benefit <= 0:
              return D0
 +        shape = self.family_shape(scenario)
-+        child_count = int(shape["counts"]["dependent_child_count"])
          values = self._evaluate(
              entity="Person",
              entity_id=f"{scenario.id}:winter-energy-rate",
@@ -499,35 +996,41 @@
 -                    scenario.children
 +                "winter_energy_payment_single": not bool(
 +                    shape["partner_present"]
-                 ),
-+                "winter_energy_payment_has_dependent_children": (
-+                    child_count > 0
 +                ),
++                "winter_energy_payment_has_dependent_children": (
++                    bool(
++                        shape["predicates"]["has_dependent_children"]
++                    )
+                 ),
              },
              outputs=[WEP_RATE_OUTPUT],
-         )
-@@ -1882,14 +2073,17 @@
+@@ -1882,14 +2417,22 @@ class ModelEvaluator:
          *,
          treasury_host_aligned: bool,
      ) -> Decimal:
 +        shape = self.family_shape(scenario)
 +        partnered = bool(shape["partner_present"])
-+        child_count = int(shape["counts"]["dependent_child_count"])
++        has_children = bool(
++            shape["predicates"]["has_dependent_children"]
++        )
++        sole_parent = bool(
++            shape["predicates"]["sole_parent_with_dependent_children"]
++        )
          key = (
 -            scenario.partnered,
 -            len(scenario.children),
 +            partnered,
-+            child_count,
++            has_children,
              treasury_host_aligned,
          )
          if key in self._as_cutout_cache:
              return self._as_cutout_cache[key]
 -        if not scenario.partnered and scenario.children:
-+        if not partnered and child_count:
++        if sole_parent:
              # Treasury's source-defined lone-parent AS branch is deliberately
              # not the SPS/JSS-with-children benefit schedule used for current
              # net benefit. R/emtr.R lines 324-329 instead combine the lone-
-@@ -1931,11 +2125,22 @@
+@@ -1931,11 +2474,30 @@ class ModelEvaluator:
          eldest_ftc_annual: Decimal,
          treasury_host_aligned: bool,
      ) -> tuple[Decimal, Decimal, Decimal, Decimal, Decimal]:
@@ -535,7 +1038,15 @@
 -            self.zero_income_jobseeker_components(scenario), D0
 +        shape = self.family_shape(scenario)
 +        partnered = bool(shape["partner_present"])
-+        child_count = int(shape["counts"]["dependent_child_count"])
++        has_children = bool(
++            shape["predicates"]["has_dependent_children"]
++        )
++        two_or_more = bool(
++            shape["predicates"]["has_two_or_more_dependent_children"]
++        )
++        sole_parent = bool(
++            shape["predicates"]["sole_parent_with_dependent_children"]
++        )
 +        zero_components = self.zero_income_jobseeker_components(scenario)
 +        zero_income_aggregate = self.aggregate_family(
 +            scenario,
@@ -549,44 +1060,49 @@
          )
          base_rate = zero_income_benefit
 -        if scenario.children:
-+        if child_count:
++        if has_children:
              # Social Security Regulations 2018 reg 17 uses the annual FTC rate
              # divided by 52. Treasury raw emtr() instead divides by 365/7; that
              # source-host convention is retained only in the labeled diagnostic.
-@@ -1956,13 +2161,11 @@
+@@ -1956,13 +2518,11 @@ class ModelEvaluator:
              "accommodation_supplement_boarder": boarder,
              "accommodation_supplement_business_use_area": D0,
              "accommodation_supplement_costs_are_homeownership": not rent,
 -            "accommodation_supplement_has_dependent_children": bool(
 -                scenario.children
 -            ),
-+            "accommodation_supplement_has_dependent_children": child_count > 0,
++            "accommodation_supplement_has_dependent_children": has_children,
              "accommodation_supplement_has_two_or_more_dependent_children": (
 -                len(scenario.children) >= 2
-+                child_count >= 2
++                two_or_more
              ),
 -            "accommodation_supplement_in_relationship": scenario.partnered,
 +            "accommodation_supplement_in_relationship": partnered,
              "accommodation_supplement_joint_owner_with_resident": False,
              "accommodation_supplement_non_beneficiary": net_benefit == 0,
              "accommodation_supplement_non_beneficiary_income_cutout_weekly_amount": (
-@@ -1984,7 +2187,7 @@
+@@ -1984,7 +2544,7 @@ class ModelEvaluator:
              "accommodation_supplement_self_contained_area_let_to_residents": D0,
              "accommodation_supplement_social_housing_weekly_contributions_paid": D0,
              "accommodation_supplement_sole_parent": (
 -                not scenario.partnered and bool(scenario.children)
-+                not partnered and child_count > 0
++                sole_parent
              ),
              "accommodation_supplement_total_premises_area": D0,
              "accommodation_supplement_weekly_board_and_lodgings_paid": (
-@@ -2024,21 +2227,50 @@
+@@ -2024,21 +2584,54 @@ class ModelEvaluator:
          scenario: Scenario,
          weekly_wage1: Decimal,
      ) -> dict[str, Decimal | str]:
+-        weekly_wage2 = scenario.gross_wage2
+-        weekly_wages = weekly_wage1 + weekly_wage2
 +        shape = self.family_shape(scenario)
 +        partnered = bool(shape["partner_present"])
-         weekly_wage2 = scenario.gross_wage2
--        weekly_wages = weekly_wage1 + weekly_wage2
++        # The cached shape request carries a zero-valued primary adult, so
++        # these family sums are exactly the partner scenario inputs when a
++        # partner is present and zero otherwise.
++        weekly_wage2 = dec(shape["scalars"]["weekly_wages"])
++        weekly_hours2 = dec(shape["scalars"]["hours_total"])
          hours1 = (
              weekly_wage1 / scenario.wage1_hourly
              if scenario.wage1_hourly > 0
@@ -610,7 +1126,7 @@
 +                "annual_family_scheme_base_income": (
 +                    weekly_wage2 * WEEKS_IN_MODEL_YEAR
 +                ),
-+                "weekly_hours": scenario.hours2,
++                "weekly_hours": weekly_hours2,
 +            }
 +        wage_aggregate = self.aggregate_family(
 +            scenario, adult_scalars=adult_scalars
@@ -631,16 +1147,16 @@
 +            adult_scalars[person]["annual_family_scheme_base_income"] = (
 +                adult_scalars[person]["weekly_wage"] + gross_component
 +            ) * WEEKS_IN_MODEL_YEAR
- 
+
          primary_gross_benefit = gross_benefits[0]
          tax1 = (
-@@ -2051,11 +2283,13 @@
+@@ -2051,11 +2644,13 @@ class ModelEvaluator:
              weekly_wage1 * WEEKS_IN_MODEL_YEAR
          ) / WEEKS_IN_MODEL_YEAR
          net_wage1 = weekly_wage1 - tax1 - acc1
 +        adult_scalars[1]["weekly_wage_tax"] = tax1
 +        adult_scalars[1]["weekly_net_wage"] = net_wage1
- 
+
          tax2 = D0
          acc2 = D0
          net_wage2 = D0
@@ -649,7 +1165,7 @@
              partner_gross_benefit = gross_benefits[1]
              tax2 = (
                  self.annual_tax(
-@@ -2068,15 +2302,22 @@
+@@ -2068,15 +2663,22 @@ class ModelEvaluator:
                  weekly_wage2 * WEEKS_IN_MODEL_YEAR
              ) / WEEKS_IN_MODEL_YEAR
              net_wage2 = weekly_wage2 - tax2 - acc2
@@ -666,7 +1182,7 @@
 +            aggregate_scalars["weekly_gross_benefit"]
 +        )
 +        hours_total = dec(aggregate_scalars["hours_total"])
- 
+
          family_values = self.family_credit_values(
              scenario=scenario,
 -            weekly_wages=weekly_wages,
@@ -678,10 +1194,10 @@
          )
          ftc_before = (
              scalar_decimal(family_values, FTC_BEFORE_OUTPUT)
-@@ -2106,18 +2347,14 @@
+@@ -2106,18 +2708,14 @@ class ModelEvaluator:
              ),
          )
- 
+
 -        annual_wages = weekly_wages * WEEKS_IN_MODEL_YEAR
 -        annual_base_income = (
 -            weekly_wages + gross_benefit_total
@@ -700,7 +1216,7 @@
          )
          family_support_payable = (wff + mftc + best_start) > 0
          ietc1, ietc1_continuous = self.ietc_for_person(
-@@ -2129,7 +2366,7 @@
+@@ -2129,7 +2727,7 @@ class ModelEvaluator:
          )
          ietc2 = D0
          ietc2_continuous = D0
@@ -709,7 +1225,7 @@
              ietc2, ietc2_continuous = self.ietc_for_person(
                  scenario=scenario,
                  person=2,
-@@ -2137,8 +2374,32 @@
+@@ -2137,8 +2735,32 @@ class ModelEvaluator:
                  weekly_benefit=benefit_components[1],
                  family_support_payable=family_support_payable,
              )
@@ -744,7 +1260,7 @@
          winter_energy = self.winter_energy_average(scenario, net_benefit)
          (
              as_unrounded,
-@@ -2192,9 +2453,6 @@
+@@ -2192,9 +2814,6 @@ class ModelEvaluator:
              "IETC_abated": ietc,
              "WinterEnergy": winter_energy,
              "BestStart_Total": best_start,
@@ -754,25 +1270,47 @@
              "BestStart_Total_continuous_abatement": (
                  best_start_continuous
              ),
-@@ -2265,17 +2523,7 @@
-             )
-             - scalar_decimal(
+@@ -2214,6 +2833,13 @@ class ModelEvaluator:
+             "wage2_ACC_levy": acc2,
+             "net_wage2": net_wage2,
+             "family_scheme_income": scalar_decimal(family_values, FSI_OUTPUT),
++            "weekly_family_wages": weekly_wages,
++            "child_count_age_0_13": dec(
++                family_aggregate["counts"]["child_count_age_0_13"]
++            ),
++            "child_count_age_14_18": dec(
++                family_aggregate["counts"]["child_count_age_14_18"]
++            ),
+             "WFF_abated_continuous_abatement": continuous_wff,
+             "IETC_abated_continuous_abatement": ietc_continuous,
+             "iwtc_entitlement": str(
+@@ -2267,16 +2893,6 @@ def sweep_scenario(
                  following_state, "AS_Amount_treasury_host_aligned"
--            )
--        )
+             )
+         )
 -        state["RuleSpec_EMTR_BestStart_Total_naive_per_child_abatement"] = (
 -            scalar_decimal(
 -                current_state,
 -                "BestStart_Total_naive_per_child_abatement",
-             )
+-            )
 -            - scalar_decimal(
 -                following_state,
 -                "BestStart_Total_naive_per_child_abatement",
 -            )
-         )
+-        )
          recomposed_emtr = sum(
              (
-@@ -2452,38 +2700,30 @@
+                 scalar_decimal(state, f"RuleSpec_EMTR_{component}")
+@@ -2337,7 +2953,7 @@ def sweep_scenario(
+         )
+         net_income = scalar_decimal(state, "Net_Income")
+         state["RR"] = baseline / net_income if net_income != 0 else None
+-        gross_income = Decimal(wage) + scenario.gross_wage2
++        gross_income = scalar_decimal(state, "weekly_family_wages")
+         state["PTR"] = (
+             D1 - (net_income - baseline) / gross_income
+             if gross_income != 0
+@@ -2452,38 +3068,30 @@ def validate_expanded_coverage(
              "treasury": dec(
                  treasury_state(best_start_id, wage)["BestStart_Total"]
              ),
@@ -820,10 +1358,36 @@
 +        raise HarnessError(
 +            "engine-side Best Start family abatement is not binding"
 +        )
- 
+
      dual_id = "couple_two_children_dual_full_time"
      dual_state = sweeps[dual_id][740]
-@@ -2565,7 +2805,7 @@
+@@ -2533,6 +3141,25 @@ def validate_expanded_coverage(
+             "RuleSpec boarder path did not convert $400 to $248"
+         )
+
++    age_band_expectations = {
++        "couple_two_best_start_children_binding": (Decimal(2), D0),
++        "lone_parent_two_teens_jss": (D0, Decimal(2)),
++        "couple_two_children_dual_full_time": (D1, D1),
++        "large_family_four_children_age_bands": (Decimal(3), D1),
++        "single_childless_ietc_focused": (D0, D0),
++    }
++    for scenario_id, expected in age_band_expectations.items():
++        state = sweeps[scenario_id][0]
++        actual = (
++            scalar_decimal(state, "child_count_age_0_13"),
++            scalar_decimal(state, "child_count_age_14_18"),
++        )
++        if actual != expected:
++            raise HarnessError(
++                "engine age-band counts changed for "
++                f"{scenario_id}: expected {expected!r}, found {actual!r}"
++            )
++
+     large_id = "large_family_four_children_age_bands"
+     large_zero = sweeps[large_id][0]
+     if (
+@@ -2565,7 +3192,7 @@ def validate_expanded_coverage(
          "sampled_point_count": sum(
              len(scenario.sampled_wages) for scenario in scenarios
          ),
@@ -832,9 +1396,20 @@
          "dual_full_time_partner_at_wage_740": {
              "primary_hours": scalar_decimal(dual_state, "hours1"),
              "partner_hours": scenario_by_id[dual_id].hours2,
-@@ -3577,12 +3817,10 @@
+@@ -2593,6 +3220,7 @@ def validate_expanded_coverage(
+         },
+         "large_family_at_wage_0": {
+             "children": scenario_by_id[large_id].children,
++            "engine_age_band_counts": age_band_expectations[large_id],
+             "rulespec_ftc": scalar_decimal(large_zero, "FTC_abated"),
+             "rulespec_winter_energy": scalar_decimal(
+                 large_zero, "WinterEnergy"
+@@ -3576,13 +4204,13 @@ def build_diagnostic_rows(
+         "wage2_ACC_levy",
          "net_wage2",
          "family_scheme_income",
++        "child_count_age_0_13",
++        "child_count_age_14_18",
          "iwtc_entitlement",
 -        "BestStart_Total_naive_per_child_abatement",
          "BestStart_Total_continuous_abatement",
@@ -845,15 +1420,18 @@
          "EMTR_ACC_rounding_component",
          "EMTR_WFF_complete_dollar_component",
          "EMTR_BestStart_complete_dollar_component",
-@@ -3850,6 +4088,7 @@
+@@ -3848,8 +4476,10 @@ def render_report(
+     oracle: Mapping[str, Any],
+     provenance: Provenance,
      compiled_artifact_sha256: str,
++    aggregation_artifact_sha256: str,
      compiled_counts: Mapping[str, int],
      engine_call_count: int,
 +    aggregation_call_count: int,
      scenarios: Sequence[Scenario],
      rows: Sequence[ComparisonRow],
      statistics: Mapping[str, Any],
-@@ -4012,9 +4251,9 @@
+@@ -4012,9 +4642,9 @@ def render_report(
              ),
              (
                  "| `couple_two_best_start_children_binding` | Two eligible "
@@ -865,7 +1443,19 @@
              ),
              (
                  "| `couple_two_children_dual_full_time` | Partner wage tax/ACC "
-@@ -4074,13 +4313,14 @@
+@@ -4048,7 +4678,10 @@ def render_report(
+                 "| `large_family_four_children_age_bands` | Four children "
+                 "aged 3, 6, 13, 16; FTC/IWTC subsequent-child scaling and "
+                 "dependent Winter Energy rate | none | FTC and Winter Energy "
+-                "are both positive at wage $0; Treasury/RuleSpec Winter Energy "
++                "are both positive at wage $0; engine age-band counts are "
++                f"{coverage_evidence['large_family_at_wage_0']['engine_age_band_counts'][0]} / "
++                f"{coverage_evidence['large_family_at_wage_0']['engine_age_band_counts'][1]} "
++                "for ages 0–13 / 14–18; Treasury/RuleSpec Winter Energy "
+                 f"is ${report_number(coverage_evidence['large_family_at_wage_0']['treasury_winter_energy'], 6)} / "
+                 f"${report_number(coverage_evidence['large_family_at_wage_0']['rulespec_winter_energy'], 6)} weekly. |"
+             ),
+@@ -4074,13 +4707,15 @@ def render_report(
              "$248 to Treasury tests downstream arithmetic, not Treasury's "
              "missing 62% transformation. This remains a named coverage gap.",
              "",
@@ -880,13 +1470,14 @@
 +            "The prior binding two-child audit exposed a host-composition "
 +            "defect: summing each child's post-abatement result subtracted the "
 +            "same family abatement once per child. This pass has no Python "
-+            "family reducer. The engine plan accepts child gross credits and "
-+            "an equal family-abatement projection, then exposes only a "
++            "Best Start child-to-family reducer. The engine plan accepts typed child gross credits "
++            "and independent observations of one family-scoped abatement; it "
++            "rejects disagreement as Indeterminate and exposes one structural "
 +            "sum-children-then-subtract-family-once operation.",
              "",
              "[Income Tax Act 2007 MG 1]"
              "(https://www.legislation.govt.nz/act/public/2007/0097/latest/"
-@@ -4096,24 +4336,23 @@
+@@ -4096,24 +4731,23 @@ def render_report(
              "the threshold reduces the one-, two-, and three-child family totals "
              "by the same amount, not once per child.",
              "",
@@ -919,18 +1510,55 @@
              f"{statistics['classification_counts']['a']} class-(a) cells.",
              "",
              "The prior four-family phase also fixed two host mappings before its "
-@@ -4265,7 +4504,9 @@
+@@ -4260,13 +4894,20 @@ def render_report(
+             "SHA-pinned parameter file. Require a byte-identical regeneration "
+             "of the original snapshot before generating the expanded oracle.",
+             "2. Verify the Treasury, RuleSpec, and engine commits; generator, "
+-            "parameter, composition, and binary hashes; clean tracked Treasury, "
+-            "RuleSpec, and engine trees; scenario semantics; dense wage "
++            "parameter, composition, aggregation artifact, and binary hashes; "
++            "clean tracked Treasury and RuleSpec trees and a wholly clean engine "
++            "tree; scenario semantics; dense wage "
              "coordinates; and serialized continuity objects.",
-             "3. Compile the ten-module RuleSpec composition from scratch and run "
-             "all engine queries in `explain` mode.",
+-            "3. Compile the ten-module RuleSpec composition from scratch and run "
+-            "all engine queries in `explain` mode.",
 -            "4. Map every profile to explicit person, child, and family inputs. "
+-            "The 14+ lone-parent path uses JSS with Income Test 1. Wage tax is "
++            "3. Compile the ten-module RuleSpec composition and the registered, "
++            "canonically digested aggregation artifact from scratch. Run "
++            "ordinary engine queries in `explain` mode and aggregation only "
++            "from that compiled artifact.",
 +            "4. Map every profile to explicit Person records plus complete "
 +            "partner/child relation facts. The engine derives the Family, "
-+            "person sums, age-band counts, and Child family-income projections. "
-             "The 14+ lone-parent path uses JSS with Income Test 1. Wage tax is "
++            "person sums, age-band counts, Child family-income projections, "
++            "child-shape/JSS/AS gates, care units, continuous and discrete Best "
++            "Start family reductions, and family wages used by PTR. The 14+ "
++            "lone-parent path uses JSS with Income Test 1. Wage tax is "
              "incremental tax above grossed taxable benefit, matching raw "
              "`emtr()`.",
-@@ -4304,10 +4545,6 @@
+             "5. Evaluate the common wages `0, 160, 250, 370, 555, 740, 1000, "
+@@ -4284,6 +4925,10 @@ def render_report(
+             "`WFF_or_Benefit: Max` wrapper can select between transfers. This "
+             "audit deliberately calls raw `emtr()` on both the continuity and "
+             "expanded grids.",
++            "Python still evaluates each statute program for its proper Person, "
++            "Child, or Family entity and composes downstream program outputs "
++            "into Net Income/EMTR. Those are scenario mechanics and cross-program "
++            "composition, not person-to-family or child-to-family aggregation.",
+             "",
+             "## Coverage gaps",
+             "",
+@@ -4300,14 +4945,15 @@ def render_report(
+             "assets, social housing, duplicate claims, and take-up.",
+             "- Full WFF child eligibility: principal caregiver, residence, "
+             "shared care, exact birth/due dates, parental leave, and part-year "
+-            "entitlement. Every listed child is assumed full-care for 365 days.",
++            "entitlement. The versioned scenario closures explicitly supply "
++            "separate MC 10(3) IWTC and MG 2(5) Best Start full-care inputs, "
++            "plus principal-caregiver facts, for 365 days. They also supply "
++            "the three MC 9 age-18 facts—financial dependence, education, and "
++            "the Commissioner-determined period—as explicit caller choices; "
++            "the pinned comparison profiles contain no age-18 child.",
              "- Full IWTC, MFTC, IETC, and Winter Energy legal eligibility. "
              "Omitted facts are supplied as disclosed stylised assumptions; WEP "
              "is host-gated by positive reconstructed benefit.",
@@ -941,13 +1569,15 @@
              "- The IncomeExplorer UI wrapper, population representativeness, "
              "non-integer wage kinks, or exhaustive threshold coverage. RR and "
              "PTR are emitted in `secondary_rates.csv` but remain outside the "
-@@ -4334,12 +4571,16 @@
+@@ -4334,12 +4980,18 @@ def render_report(
              f"| Engine source commit | `{provenance.engine_sha}` |",
              f"| Engine binary SHA-256 | `{provenance.engine_binary_sha256}` |",
              f"| Composition SHA-256 | `{provenance.composition_sha256}` |",
 +            f"| Unit aggregation plan SHA-256 | "
 +            f"`{provenance.aggregation_plan_sha256}` |",
              f"| Compiled artifact SHA-256 | `{compiled_artifact_sha256}` |",
++            f"| Compiled unit aggregation artifact SHA-256 | "
++            f"`{aggregation_artifact_sha256}` |",
              f"| Compiled shape | {compiled_counts['derived_outputs']} derived, "
              f"{compiled_counts['parameters']} parameters, "
              f"{compiled_counts['input_slots']} inputs, "
@@ -958,7 +1588,7 @@
              "| Tax-year interval | `2026-04-01` to `2027-03-31` |",
              "| Expanded snapshot `generated_at` | `2026-07-29` |",
              "",
-@@ -4411,6 +4652,7 @@
+@@ -4411,6 +5063,7 @@ def build_audit_artifacts(
      engine_binary: Path,
      treasury_root: Path,
      composition_path: Path,
@@ -966,7 +1596,7 @@
      eligibility_closures_path: Path,
      oracle_generator: Path,
      rscript: Path,
-@@ -4432,6 +4674,7 @@
+@@ -4432,6 +5085,7 @@ def build_audit_artifacts(
          engine_binary=engine_binary,
          treasury_root=treasury_root,
          composition_path=composition_path,
@@ -974,45 +1604,66 @@
          eligibility_closures_path=eligibility_closures_path,
          eligibility_closures=eligibility_closures,
          oracle_generator=oracle_generator,
-@@ -4446,6 +4689,7 @@
+@@ -4441,13 +5095,19 @@ def build_audit_artifacts(
+     with tempfile.TemporaryDirectory(prefix="axiom-emtr-fresh-") as raw_temp:
+         temp_root = Path(raw_temp)
+         compiled_path = temp_root / "composition.json"
++        aggregation_artifact_path = temp_root / "unit-aggregation.json"
+         engine, compiled, _compile_stdout = Engine.compile(
+             binary=provenance.engine_binary,
              composition=provenance.composition_path,
              rulespec_root=provenance.rulespec_root,
              artifact=compiled_path,
 +            aggregation_plan=provenance.aggregation_plan_path,
++            aggregation_artifact=aggregation_artifact_path,
          )
          compiled_artifact_sha256 = sha256_file(compiled_path)
++        aggregation_artifact_sha256 = sha256_file(
++            aggregation_artifact_path
++        )
          compiled_counts = {
-@@ -4587,6 +4831,9 @@
+             "derived_outputs": len(compiled["program"]["derived"]),
+             "parameters": len(compiled["program"]["parameters"]),
+@@ -4587,6 +5247,12 @@ def build_audit_artifacts(
                  **compiled_counts,
                  "artifact_sha256": compiled_artifact_sha256,
                  "engine_evaluations": engine.call_count,
 +                "unit_aggregation_evaluations": (
 +                    engine.aggregation_call_count
 +                ),
++                "unit_aggregation_artifact_sha256": (
++                    aggregation_artifact_sha256
++                ),
              },
              "exercise_input_catalog": {
                  slot: {
-@@ -4670,6 +4917,7 @@
+@@ -4668,8 +5334,10 @@ def build_audit_artifacts(
+             oracle=oracle,
+             provenance=provenance,
              compiled_artifact_sha256=compiled_artifact_sha256,
++            aggregation_artifact_sha256=aggregation_artifact_sha256,
              compiled_counts=compiled_counts,
              engine_call_count=engine.call_count,
 +            aggregation_call_count=engine.aggregation_call_count,
              scenarios=scenarios,
              rows=comparison_rows,
              statistics=statistics,
-@@ -4726,6 +4974,7 @@
+@@ -4725,7 +5393,11 @@ def build_audit_artifacts(
+             "headline": machine_payload["headline"],
              "statistics": statistics,
              "compiled_artifact_sha256": compiled_artifact_sha256,
++            "unit_aggregation_artifact_sha256": (
++                aggregation_artifact_sha256
++            ),
              "engine_evaluations": engine.call_count,
 +            "unit_aggregation_evaluations": engine.aggregation_call_count,
              "artifact_names": tuple(sorted(artifacts)),
          }
          return artifacts, run_summary
-@@ -4799,6 +5048,15 @@
-         "--composition",
+@@ -4800,6 +5472,15 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
          type=Path,
          default=DEFAULT_COMPOSITION,
-+    )
+     )
 +    parser.add_argument(
 +        "--aggregation-plan",
 +        type=Path,
@@ -1021,10 +1672,11 @@
 +            "Defaults to <engine-root>/tests/fixtures/unit_derivation/"
 +            "nz_income_explorer_family.yaml"
 +        ),
-     )
++    )
      parser.add_argument(
          "--eligibility-closures",
-@@ -4830,6 +5088,15 @@
+         type=Path,
+@@ -4830,6 +5511,15 @@ def main(argv: Sequence[str] | None = None) -> int:
          if args.engine_binary is not None
          else args.engine_root / "target" / "release" / "axiom-rules-engine"
      )
@@ -1040,7 +1692,7 @@
      try:
          first, summary = build_audit_artifacts(
              rulespec_root=args.rulespec_root,
-@@ -4837,6 +5104,7 @@
+@@ -4837,6 +5527,7 @@ def main(argv: Sequence[str] | None = None) -> int:
              engine_binary=engine_binary,
              treasury_root=args.treasury_root,
              composition_path=args.composition,
@@ -1048,7 +1700,7 @@
              eligibility_closures_path=args.eligibility_closures,
              oracle_generator=args.oracle_generator,
              rscript=args.rscript,
-@@ -4848,6 +5116,7 @@
+@@ -4848,6 +5539,7 @@ def main(argv: Sequence[str] | None = None) -> int:
              engine_binary=engine_binary,
              treasury_root=args.treasury_root,
              composition_path=args.composition,
@@ -1056,3 +1708,386 @@
              eligibility_closures_path=args.eligibility_closures,
              oracle_generator=args.oracle_generator,
              rscript=args.rscript,
+diff --git a/nz-lane/emtr_reproduction/eligibility-closures.json b/nz-lane/emtr_reproduction/eligibility-closures.json
+index f66e5e0..5fb441b 100644
+--- a/nz-lane/emtr_reproduction/eligibility-closures.json
++++ b/nz-lane/emtr_reproduction/eligibility-closures.json
+@@ -1,6 +1,6 @@
+ {
+   "schema": "axiom.nz_incomeexplorer.eligibility_closures.v1",
+-  "version": "2026-08-13",
++  "version": "2026-08-17",
+   "choices": {
+     "residence": {
+       "wff_caregiver_disqualifying_status": false,
+@@ -17,9 +17,15 @@
+       "wff_commissioner_considers_primary_day_to_day_care_when_child_present": true,
+       "wff_care_is_temporary": false,
+       "wff_caregiver_lives_apart_when_child_present": true,
++      "iwtc_child_is_principal_caregiver_when_present": true,
+       "iwtc_child_exclusive_care_fraction": 1,
+       "best_start_child_care_fraction": 1
+     },
++    "age_18": {
++      "not_financially_independent_at_age_18": true,
++      "attending_school_or_tertiary_at_age_18": true,
++      "commissioner_period_contains_segment_at_age_18": true
++    },
+     "work_tests": {
+       "iwtc_allowed_paye_income_payment_when_wages_positive": true,
+       "iwtc_normally_earner_when_wages_positive": true,
+diff --git a/nz-lane/emtr_reproduction/test_declared_closures.py b/nz-lane/emtr_reproduction/test_declared_closures.py
+index cc2dedf..8e7b32c 100644
+--- a/nz-lane/emtr_reproduction/test_declared_closures.py
++++ b/nz-lane/emtr_reproduction/test_declared_closures.py
+@@ -1,7 +1,10 @@
+ """Mutants proving declared eligibility closures are mandatory inputs."""
+
++import ast
+ import importlib.util
++import inspect
+ import json
++import subprocess
+ import sys
+ from pathlib import Path
+
+@@ -35,3 +38,339 @@ def test_incomplete_declared_closures_fail(tmp_path):
+     path.write_text(json.dumps(mutant))
+     with pytest.raises(harness.HarnessError, match="work_tests"):
+         harness.load_eligibility_closures(path)
++
++
++def test_missing_separate_mc10_principal_caregiver_choice_fails(tmp_path):
++    harness = _harness()
++    mutant = json.loads((HERE / "eligibility-closures.json").read_text())
++    del mutant["choices"]["care"][
++        "iwtc_child_is_principal_caregiver_when_present"
++    ]
++    path = tmp_path / "missing-mc10-care.json"
++    path.write_text(json.dumps(mutant))
++    with pytest.raises(harness.HarnessError, match="care"):
++        harness.load_eligibility_closures(path)
++
++
++def test_missing_mc9_age_18_choice_fails(tmp_path):
++    harness = _harness()
++    mutant = json.loads((HERE / "eligibility-closures.json").read_text())
++    del mutant["choices"]["age_18"][
++        "attending_school_or_tertiary_at_age_18"
++    ]
++    path = tmp_path / "missing-mc9-age-18.json"
++    path.write_text(json.dumps(mutant))
++    with pytest.raises(harness.HarnessError, match="age_18"):
++        harness.load_eligibility_closures(path)
++
++
++def test_aggregation_plan_must_be_the_pinned_checkout_fixture(tmp_path):
++    harness = _harness()
++    root = tmp_path / "engine"
++    canonical = (
++        root
++        / "tests"
++        / "fixtures"
++        / "unit_derivation"
++        / "nz_income_explorer_family.yaml"
++    )
++    canonical.parent.mkdir(parents=True)
++    canonical.write_text("canonical")
++    foreign = tmp_path / "foreign.yaml"
++    foreign.write_text("mutant")
++    assert harness.verify_aggregation_plan_binding(root, canonical) == canonical
++    with pytest.raises(harness.HarnessError, match="canonical plan"):
++        harness.verify_aggregation_plan_binding(root, foreign)
++
++
++def test_engine_preflight_rejects_dirty_checkout(tmp_path, monkeypatch):
++    harness = _harness()
++    root = tmp_path / "engine"
++    binary = root / "target" / "release" / "axiom-rules-engine"
++    binary.parent.mkdir(parents=True)
++    binary.write_bytes(b"reviewed-binary")
++    monkeypatch.setattr(harness, "git_sha", lambda _root: "reviewed-commit")
++    monkeypatch.setattr(harness, "git_dirty", lambda _root: True)
++    monkeypatch.setattr(harness, "EXPECTED_ENGINE_SHA", "reviewed-commit")
++    with pytest.raises(harness.HarnessError, match="tracked or untracked"):
++        harness.verify_engine_binding(root, binary)
++
++
++def test_engine_preflight_rejects_wrong_commit(tmp_path, monkeypatch):
++    harness = _harness()
++    root = tmp_path / "engine"
++    binary = root / "target" / "release" / "axiom-rules-engine"
++    binary.parent.mkdir(parents=True)
++    binary.write_bytes(b"reviewed-binary")
++    monkeypatch.setattr(harness, "git_sha", lambda _root: "wrong-parent")
++    monkeypatch.setattr(harness, "EXPECTED_ENGINE_SHA", "implementation-commit")
++    with pytest.raises(harness.HarnessError, match="engine SHA mismatch"):
++        harness.verify_engine_binding(root, binary)
++
++
++def test_engine_preflight_rejects_unbound_binary(tmp_path, monkeypatch):
++    harness = _harness()
++    root = tmp_path / "engine"
++    binary = root / "target" / "release" / "axiom-rules-engine"
++    binary.parent.mkdir(parents=True)
++    binary.write_bytes(b"mutant-binary")
++    monkeypatch.setattr(harness, "git_sha", lambda _root: "reviewed-commit")
++    monkeypatch.setattr(harness, "git_dirty", lambda _root: False)
++    monkeypatch.setattr(harness, "EXPECTED_ENGINE_SHA", "reviewed-commit")
++    monkeypatch.setattr(harness, "EXPECTED_ENGINE_BINARY_SHA256", "0" * 64)
++    with pytest.raises(harness.HarnessError, match="binary SHA-256 mismatch"):
++        harness.verify_engine_binding(root, binary)
++
++
++def test_runtime_uses_compiled_registered_artifact_not_raw_plan(tmp_path, monkeypatch):
++    harness = _harness()
++    artifact = tmp_path / "aggregation.json"
++    artifact.write_text("{}")
++    engine = harness.Engine(
++        binary=tmp_path / "axiom-rules-engine",
++        artifact=tmp_path / "composition.json",
++        aggregation_artifact=artifact,
++        catalog={"slot": "canonical"},
++    )
++    observed = []
++
++    family = {
++        "id": "Family:test",
++        "members": ["primary"],
++        "partner_present": {"status": "determined", "value": False},
++        "scalars": {},
++        "counts": {},
++        "predicates": {},
++        "children": [],
++    }
++
++    def fake_run(argv, **_kwargs):
++        observed.append(argv)
++        return subprocess.CompletedProcess(
++            argv,
++            0,
++            stdout=json.dumps(
++                {
++                    "schema": "axiom/unit-aggregation-plan-stage3/1",
++                    "families": {
++                        "status": "determined",
++                        "value": [family],
++                    },
++                }
++            ),
++            stderr="",
++        )
++
++    monkeypatch.setattr(harness, "run_checked", fake_run)
++    assert engine.aggregate({"request": "known"})["id"] == "Family:test"
++    assert "--artifact" in observed[0]
++    assert "--plan" not in observed[0]
++
++
++def test_compile_boundary_materializes_registered_aggregation_artifact(
++    tmp_path, monkeypatch
++):
++    harness = _harness()
++    composition_artifact = tmp_path / "composition.json"
++    aggregation_artifact = tmp_path / "aggregation.json"
++    commands = []
++
++    def fake_run(argv, **_kwargs):
++        commands.append(argv)
++        if "compile-composed" in argv:
++            composition_artifact.write_text(
++                json.dumps(
++                    {
++                        "metadata": {
++                            "input_catalog": [
++                                {
++                                    "slot": "taxable_income",
++                                    "canonical_request_name": "canonical-taxable-income",
++                                }
++                            ]
++                        }
++                    }
++                )
++            )
++        elif "compile-unit-aggregation" in argv:
++            aggregation_artifact.write_text(
++                json.dumps(
++                    {
++                        "format": "axiom/compiled-unit-aggregation-stage3/1",
++                        "plan_digest": "sha256:registered",
++                        "phase_two_artifact": {"format_version": 2},
++                    }
++                )
++            )
++        return subprocess.CompletedProcess(argv, 0, stdout="", stderr="")
++
++    monkeypatch.setattr(harness, "run_checked", fake_run)
++    engine, _compiled, _stdout = harness.Engine.compile(
++        binary=tmp_path / "axiom-rules-engine",
++        composition=tmp_path / "composition.yaml",
++        rulespec_root=tmp_path / "rulespec-nz",
++        artifact=composition_artifact,
++        aggregation_plan=tmp_path / "aggregation.yaml",
++        aggregation_artifact=aggregation_artifact,
++    )
++    assert engine.aggregation_artifact == aggregation_artifact
++    assert any("compile-unit-aggregation" in command for command in commands)
++
++
++def test_indeterminate_aggregation_result_never_becomes_a_default():
++    harness = _harness()
++    with pytest.raises(harness.HarnessError, match="indeterminate"):
++        harness.determined(
++            {"status": "indeterminate", "reasons": ["child:age:unknown"]},
++            "child_count",
++        )
++
++
++def test_operational_code_reads_scenario_relationship_shape_only_at_boundary():
++    harness = _harness()
++    tree = ast.parse(inspect.getsource(harness.ModelEvaluator))
++    evaluator = tree.body[0]
++    assert isinstance(evaluator, ast.ClassDef)
++    forbidden = (
++        "scenario.partnered",
++        "scenario.children",
++        "scenario.gross_wage2",
++    )
++    for method in evaluator.body:
++        if not isinstance(method, ast.FunctionDef) or method.name == "aggregate_family":
++            continue
++        source = ast.unparse(method)
++        assert all(term not in source for term in forbidden), method.name
++
++
++def test_engine_outputs_are_consumed_for_every_migrated_reduction():
++    harness = _harness()
++    family_credit = inspect.getsource(harness.ModelEvaluator.family_credit_values)
++    benefit = inspect.getsource(harness.ModelEvaluator.benefit_components)
++    best_start = inspect.getsource(harness.ModelEvaluator.best_start_total)
++    sweep = inspect.getsource(harness.sweep_scenario)
++    state = inspect.getsource(harness.ModelEvaluator.evaluate_state)
++    coverage = inspect.getsource(harness.validate_expanded_coverage)
++    assert "family_tax_credit_subsequent_dependent_child_care_units" in family_credit
++    assert "max(0, child_count - 1)" not in family_credit
++    assert "jss_sole_parent_youngest_age_at_least_14" in benefit
++    assert "youngest >= 14" not in benefit
++    assert "best_start_total_continuous_abatement" in best_start
++    assert "family_scheme_income - self.best_start_abatement_threshold" not in best_start
++    assert 'scalar_decimal(state, "weekly_family_wages")' in sweep
++    assert "scenario.gross_wage2" not in sweep
++    for output in ("child_count_age_0_13", "child_count_age_14_18"):
++        assert output in state
++        assert output in coverage
++
++
++def test_request_boundary_supplies_roles_evidence_legal_facts_and_observations():
++    harness = _harness()
++
++    class RecordingEngine:
++        def __init__(self):
++            self.request = None
++
++        def aggregate(self, request):
++            self.request = request
++            return {"engine": "boundary-only"}
++
++    engine = RecordingEngine()
++    evaluator = object.__new__(harness.ModelEvaluator)
++    evaluator.engine = engine
++    evaluator.best_start_abatement_threshold = harness.Decimal("79000")
++    evaluator.best_start_abatement_rate = harness.Decimal("0.21")
++    evaluator.closures = {
++        "care": {
++            "best_start_child_care_fraction": 0.5,
++            "iwtc_child_exclusive_care_fraction": 0.75,
++            "iwtc_child_is_principal_caregiver_when_present": True,
++            "wff_commissioner_considers_primary_day_to_day_care_when_child_present": True,
++        },
++        "age_18": {
++            "not_financially_independent_at_age_18": False,
++            "attending_school_or_tertiary_at_age_18": True,
++            "commissioner_period_contains_segment_at_age_18": False,
++        },
++    }
++    scenario = harness.Scenario(
++        id="boundary",
++        description="request boundary",
++        partnered=True,
++        wage1_hourly=harness.Decimal("25"),
++        children=(1, 18),
++        gross_wage2=harness.Decimal("740"),
++        hours2=harness.Decimal("20"),
++        accommodation_costs=harness.Decimal("0"),
++        accommodation_rent=True,
++        accommodation_area=1,
++        accommodation_boarder=False,
++        weekly_board_and_lodgings_paid=harness.Decimal("0"),
++        sampled_wages=(0,),
++    )
++    evaluator.aggregate_family(
++        scenario,
++        child_scalars={
++            0: {"best_start_family_abatement": harness.Decimal("1000")},
++            1: {"best_start_family_abatement": harness.Decimal("1001")},
++        },
++        family_scheme_income=harness.Decimal("90480"),
++    )
++    request = engine.request
++    assert request is not None
++    assert "named_people" not in request
++    assert "family_scalars" not in request
++    assert request["roster_completeness"]["id"]
++    assert request["segment_completeness"]["id"]
++    assert [person["role"] for person in request["persons"]] == [
++        "adult",
++        "adult",
++        "child",
++        "child",
++    ]
++    partner = request["persons"][1]
++    assert partner["scalars"]["weekly_wage"]["value"] == "740"
++    for child in request["persons"][2:]:
++        assert child["scalars"][
++            "best_start_claimant_care_fraction"
++        ]["value"] == "0.5"
++        assert child["scalars"][
++            "in_work_tax_credit_child_exclusive_care_fraction"
++        ]["value"] == "0.75"
++        assert child["facts"][
++            "principal_care_for_family_scheme"
++        ]["value"] is True
++        assert child["facts"][
++            "in_work_tax_credit_principal_caregiver"
++        ]["value"] is True
++        assert {
++            "not_financially_independent_at_age_18",
++            "attending_school_or_tertiary_at_age_18",
++            "commissioner_period_contains_segment_at_age_18",
++        } <= set(child["facts"])
++        assert child["facts"][
++            "not_financially_independent_at_age_18"
++        ]["value"] is False
++        assert child["facts"][
++            "attending_school_or_tertiary_at_age_18"
++        ]["value"] is True
++        assert child["facts"][
++            "commissioner_period_contains_segment_at_age_18"
++        ]["value"] is False
++    assert all(relation["completeness"]["id"] for relation in request["relations"])
++    assert all(
++        fact["knowledge"]["evidence"]["id"]
++        for relation in request["relations"]
++        for fact in relation["facts"]
++    )
++    family_input = request["family_inputs"][0]
++    assert family_input["anchor_person"] == "boundary:person:1"
++    assert family_input["named_people"][
++        "mc7_entitlement_holder"
++    ]["value"] == "boundary:person:1"
++    adjustment = family_input["scalars"]["best_start_family_abatement"]
++    assert adjustment["status"] == "observations"
++    assert [item["value"] for item in adjustment["observations"]] == [
++        "1000",
++        "1001",
++    ]

--- a/stage3-nz/ops-harness.patch
+++ b/stage3-nz/ops-harness.patch
@@ -1,0 +1,1058 @@
+--- a/nz-lane/emtr_reproduction/run.py
++++ b/nz-lane/emtr_reproduction/run.py
+@@ -43,13 +43,20 @@
+     Path.home() / "_axiom-worktrees" / "nz-treasury-income-explorer"
+ )
+ DEFAULT_COMPOSITION = HERE / "composition.yaml"
++DEFAULT_AGGREGATION_PLAN = (
++    DEFAULT_ENGINE_ROOT
++    / "tests"
++    / "fixtures"
++    / "unit_derivation"
++    / "nz_income_explorer_family.yaml"
++)
+ DEFAULT_ELIGIBILITY_CLOSURES = HERE / "eligibility-closures.json"
+ DEFAULT_ORACLE_GENERATOR = HERE / "generate_treasury_emtr_snapshot_expanded.R"
+ DEFAULT_RSCRIPT = Path("/usr/local/bin/Rscript")
+ EXPANDED_ORACLE_NAME = "treasury-emtr-snapshot-expanded.json"
+ 
+ EXPECTED_RULESPEC_SHA = "89a7d25dc03a4d045348620283332de10b1047da"
+-EXPECTED_ENGINE_SHA = "d59969b53430ae2fd97eb4349d44ad23ce930d85"
++EXPECTED_ENGINE_SHA = "74881519c829106e4e696d77b38e10ba61c881d8"
+ EXPECTED_ORACLE_COMMIT = "741a6ca4f5d27b1dc00b43dc395e39ffc4040a4b"
+ EXPECTED_PARAMETER_FILE = "inst/parameters/TY27_BEFU25.yaml"
+ EXPECTED_PARAMETER_SHA256 = (
+@@ -373,6 +380,8 @@
+     engine_binary_sha256: str
+     composition_path: Path
+     composition_sha256: str
++    aggregation_plan_path: Path
++    aggregation_plan_sha256: str
+     eligibility_closures_path: Path
+     eligibility_closures_sha256: str
+     eligibility_closures_version: str
+@@ -418,6 +427,11 @@
+                 "path": str(self.composition_path),
+                 "sha256": self.composition_sha256,
+             },
++            "unit_aggregation_plan": {
++                "path": str(self.aggregation_plan_path),
++                "sha256": self.aggregation_plan_sha256,
++                "experimental_schema": "axiom/unit-aggregation-plan-stage3/1",
++            },
+             "eligibility_closures": {
+                 "path": str(self.eligibility_closures_path),
+                 "sha256": self.eligibility_closures_sha256,
+@@ -591,6 +605,7 @@
+     engine_binary: Path,
+     treasury_root: Path,
+     composition_path: Path,
++    aggregation_plan_path: Path,
+     eligibility_closures_path: Path,
+     eligibility_closures: Mapping[str, Any],
+     oracle_generator: Path,
+@@ -601,6 +616,9 @@
+     engine_root = require_directory(engine_root, "engine root")
+     engine_binary = require_file(engine_binary, "engine binary")
+     composition_path = require_file(composition_path, "composition")
++    aggregation_plan_path = require_file(
++        aggregation_plan_path, "unit aggregation plan"
++    )
+     eligibility_closures_path = require_file(
+         eligibility_closures_path, "eligibility closures"
+     )
+@@ -787,8 +805,9 @@
+     engine_dirty = git_tracked_dirty(engine_root)
+     if rulespec_dirty:
+         raise HarnessError(f"RuleSpec checkout has tracked modifications: {rulespec_root}")
+-    if engine_dirty:
+-        raise HarnessError(f"engine checkout has tracked modifications: {engine_root}")
++    # Stage 3 is intentionally run from the local engine worktree before a
++    # commit exists. The exact base commit and built binary hash remain pinned;
++    # tracked modifications are recorded rather than rejected.
+ 
+     treasury_root = require_directory(treasury_root, "Treasury source checkout")
+     treasury_present = True
+@@ -837,6 +856,8 @@
+         engine_binary_sha256=sha256_file(engine_binary),
+         composition_path=composition_path,
+         composition_sha256=sha256_file(composition_path),
++        aggregation_plan_path=aggregation_plan_path,
++        aggregation_plan_sha256=sha256_file(aggregation_plan_path),
+         eligibility_closures_path=eligibility_closures_path,
+         eligibility_closures_sha256=sha256_file(eligibility_closures_path),
+         eligibility_closures_version=str(eligibility_closures["version"]),
+@@ -857,12 +878,15 @@
+         *,
+         binary: Path,
+         artifact: Path,
++        aggregation_plan: Path,
+         catalog: Mapping[str, str],
+     ) -> None:
+         self.binary = binary
+         self.artifact = artifact
++        self.aggregation_plan = aggregation_plan
+         self.catalog = dict(catalog)
+         self.call_count = 0
++        self.aggregation_call_count = 0
+         self.observed_inputs: dict[str, set[str]] = {
+             slot: set() for slot in self.catalog
+         }
+@@ -875,6 +899,7 @@
+         composition: Path,
+         rulespec_root: Path,
+         artifact: Path,
++        aggregation_plan: Path,
+     ) -> tuple["Engine", dict[str, Any], str]:
+         process = run_checked(
+             [
+@@ -898,7 +923,12 @@
+         }
+         if not catalog:
+             raise HarnessError("compiled artifact has an empty input catalog")
+-        engine = cls(binary=binary, artifact=artifact, catalog=catalog)
++        engine = cls(
++            binary=binary,
++            artifact=artifact,
++            aggregation_plan=aggregation_plan,
++            catalog=catalog,
++        )
+         return engine, compiled, process.stdout.strip()
+ 
+     def input_record(
+@@ -1017,7 +1047,39 @@
+                 raise HarnessError(f"unknown engine output shape for {target}: {item!r}")
+         return values, results[0].get("trace", {})
+ 
++    def aggregate(self, request: Mapping[str, Any]) -> dict[str, Any]:
++        process = run_checked(
++            [
++                str(self.binary),
++                "run-unit-aggregation",
++                "--plan",
++                str(self.aggregation_plan),
++                "--enable-experimental-unit-derivation",
++            ],
++            stdin=json.dumps(request, sort_keys=True, separators=(",", ":")),
++            label="engine unit aggregation",
++        )
++        self.aggregation_call_count += 1
++        try:
++            response = json.loads(process.stdout)
++        except json.JSONDecodeError as exc:
++            raise HarnessError(
++                "engine returned invalid unit aggregation JSON: "
++                f"{process.stdout!r}"
++            ) from exc
++        if response.get("schema") != "axiom/unit-aggregation-plan-stage3/1":
++            raise HarnessError(
++                f"engine returned unknown aggregation schema: {response!r}"
++            )
++        families = response.get("families")
++        if not isinstance(families, list) or len(families) != 1:
++            raise HarnessError(
++                "IncomeExplorer scenario must derive exactly one family, "
++                f"found {families!r}"
++            )
++        return families[0]
+ 
++
+ def normalize_children(raw: Any) -> list[int]:
+     if isinstance(raw, list):
+         return [int(value) for value in raw]
+@@ -1262,6 +1324,7 @@
+         self._as_cutout_cache: dict[
+             tuple[bool, int, bool], Decimal
+         ] = {}
++        self._family_shape_cache: dict[str, dict[str, Any]] = {}
+         self.tax_rates = selected_parameter_values(
+             compiled, "individual_income_tax_bracket_rates"
+         )
+@@ -1315,7 +1378,105 @@
+             raise HarnessError(
+                 f"unexpected tax-threshold indexes: {sorted(self.tax_thresholds)}"
+             )
++
++    @staticmethod
++    def _zero_adult_scalars() -> dict[str, Decimal]:
++        return {
++            "weekly_wage": D0,
++            "annual_wage": D0,
++            "annual_family_scheme_base_income": D0,
++            "weekly_net_benefit": D0,
++            "weekly_gross_benefit": D0,
++            "weekly_wage_tax": D0,
++            "weekly_net_wage": D0,
++            "weekly_hours": D0,
++            "ietc_weekly": D0,
++            "ietc_continuous_weekly": D0,
++        }
+ 
++    def aggregate_family(
++        self,
++        scenario: Scenario,
++        *,
++        adult_scalars: Mapping[int, Mapping[str, Decimal]] | None = None,
++        child_scalars: Mapping[int, Mapping[str, Decimal]] | None = None,
++        family_scheme_income: Decimal = D0,
++    ) -> dict[str, Any]:
++        adults = adult_scalars or {}
++        children = child_scalars or {}
++        persons: list[dict[str, Any]] = []
++        for person in (1, 2):
++            if person == 2 and not scenario.partnered:
++                continue
++            scalars = self._zero_adult_scalars()
++            scalars.update(adults.get(person, {}))
++            persons.append(
++                {
++                    "id": f"{scenario.id}:person:{person}",
++                    "age_years": 25,
++                    "scalars": {
++                        name: decimal_text(value)
++                        for name, value in sorted(scalars.items())
++                    },
++                }
++            )
++        for index, age in enumerate(scenario.children):
++            values = {
++                "best_start_before_abatement": D0,
++                "best_start_family_abatement": D0,
++            }
++            values.update(children.get(index, {}))
++            persons.append(
++                {
++                    "id": f"{scenario.id}:child:{index}",
++                    "age_years": age,
++                    "scalars": {
++                        name: decimal_text(value)
++                        for name, value in sorted(values.items())
++                    },
++                }
++            )
++        relations: dict[str, list[list[str]]] = {
++            "partner_of": [],
++            "dependent_child_of": [],
++        }
++        if scenario.partnered:
++            relations["partner_of"].append(
++                [
++                    f"{scenario.id}:person:1",
++                    f"{scenario.id}:person:2",
++                ]
++            )
++        relations["dependent_child_of"] = [
++            [
++                f"{scenario.id}:person:1",
++                f"{scenario.id}:child:{index}",
++            ]
++            for index, _age in enumerate(scenario.children)
++        ]
++        family = self.engine.aggregate(
++            {
++                "scope": f"scenario:{scenario.id}",
++                "segment": f"{EXPECTED_PERIOD_START}/{EXPECTED_PERIOD_END}",
++                "primary_person": f"{scenario.id}:person:1",
++                "persons": persons,
++                "relations": relations,
++                "family_scalars": {
++                    "family_scheme_income": decimal_text(
++                        family_scheme_income
++                    )
++                },
++            }
++        )
++        return family
++
++    def family_shape(self, scenario: Scenario) -> dict[str, Any]:
++        if scenario.id not in self._family_shape_cache:
++            self._family_shape_cache[scenario.id] = self.aggregate_family(
++                scenario
++            )
++        return self._family_shape_cache[scenario.id]
++
+     def _evaluate(
+         self,
+         *,
+@@ -1419,17 +1580,19 @@
+         scenario: Scenario,
+         weekly_family_income: Decimal,
+     ) -> Decimal:
+-        child_count = len(scenario.children)
+-        youngest = min(scenario.children) if scenario.children else 0
++        shape = self.family_shape(scenario)
++        child_count = int(shape["counts"]["dependent_child_count"])
++        youngest = int(shape["counts"]["youngest_child_age"])
++        partnered = bool(shape["partner_present"])
+         inputs: dict[str, bool | int | Decimal] = {
+             "jobseeker_support_applicant_age": 25,
+             "jobseeker_support_benefit_commenced_on_or_after_1998_07_01": False,
+             "jobseeker_support_dependent_children_count": child_count,
+             "jobseeker_support_living_with_parent": False,
+             "jobseeker_support_partner_ineligible_due_to_sanction_or_strike": False,
+-            "jobseeker_support_partner_receives_main_benefit": scenario.partnered,
++            "jobseeker_support_partner_receives_main_benefit": partnered,
+             "jobseeker_support_partner_receives_new_zealand_superannuation_or_veterans_pension": False,
+-            "jobseeker_support_single": not scenario.partnered,
++            "jobseeker_support_single": not partnered,
+             "jobseeker_support_total_income": weekly_family_income,
+             "jobseeker_support_transferred_2013_no_dependent_children": False,
+             "jobseeker_support_youngest_dependent_child_age": youngest,
+@@ -1459,18 +1622,25 @@
+         return scalar_decimal(values, SOLE_PARENT_OUTPUT)
+ 
+     def raw_iwtc_branch(self, scenario: Scenario, weekly_wages: Decimal) -> bool:
+-        return bool(scenario.children) and weekly_wages >= ORACLE_IWTC_WEEKLY_THRESHOLD
++        child_count = int(
++            self.family_shape(scenario)["counts"]["dependent_child_count"]
++        )
++        return child_count > 0 and weekly_wages >= ORACLE_IWTC_WEEKLY_THRESHOLD
+ 
+     def benefit_components(
+         self,
+         scenario: Scenario,
+         weekly_wages: Decimal,
+     ) -> tuple[Decimal, ...]:
+-        if scenario.partnered:
++        shape = self.family_shape(scenario)
++        partnered = bool(shape["partner_present"])
++        child_count = int(shape["counts"]["dependent_child_count"])
++        youngest = int(shape["counts"]["youngest_child_age"])
++        if partnered:
+             per_person = self.jobseeker_payment(scenario, weekly_wages)
+             scheduled = (per_person, per_person)
+-        elif scenario.children:
+-            if min(scenario.children) >= 14:
++        elif child_count:
++            if youngest >= 14:
+                 # Treasury R/emtr.R lines 310-319 deliberately select the
+                 # lone-parent JSS rate with the SPS income-test scale once the
+                 # youngest child is 14. RuleSpec's Jobseeker branch encodes
+@@ -1489,7 +1659,7 @@
+         scenario: Scenario,
+     ) -> tuple[Decimal, ...]:
+         per_person = self.jobseeker_payment(scenario, D0)
+-        if scenario.partnered:
++        if bool(self.family_shape(scenario)["partner_present"]):
+             return (per_person, per_person)
+         return (per_person,)
+ 
+@@ -1545,7 +1715,14 @@
+         weekly_wages: Decimal,
+         net_benefit: Decimal,
+     ) -> dict[str, bool | int | Decimal]:
+-        has_children = bool(scenario.children)
++        has_children = (
++            int(
++                self.family_shape(scenario)["counts"][
++                    "dependent_child_count"
++                ]
++            )
++            > 0
++        )
+         earns_paye = weekly_wages > 0
+         residence = self.closures["residence"]
+         care = self.closures["care"]
+@@ -1639,17 +1816,20 @@
+         self,
+         *,
+         scenario: Scenario,
+-        weekly_wages: Decimal,
+-        weekly_gross_benefits: Decimal,
+-        net_benefit: Decimal,
+-        wage_tax_total: Decimal,
+-        hours_total: Decimal,
++        family_aggregate: Mapping[str, Any],
+     ) -> dict[str, Decimal | str]:
+-        child_count = len(scenario.children)
+-        annual_wages = weekly_wages * WEEKS_IN_MODEL_YEAR
+-        annual_base_income = (
+-            weekly_wages + weekly_gross_benefits
+-        ) * WEEKS_IN_MODEL_YEAR
++        child_count = int(
++            family_aggregate["counts"]["dependent_child_count"]
++        )
++        values = family_aggregate["scalars"]
++        weekly_wages = dec(values["weekly_wages"])
++        annual_wages = dec(values["annual_wages"])
++        annual_base_income = dec(
++            values["annual_family_scheme_base_income"]
++        )
++        net_benefit = dec(values["weekly_net_benefit"])
++        wage_tax_total = dec(values["weekly_wage_tax"])
++        hours_total = dec(values["hours_total"])
+         inputs = self.family_scheme_inputs(annual_base_income, annual_wages)
+         inputs.update(
+             {
+@@ -1675,7 +1855,7 @@
+         full_time_hours = Decimal(
+             work_tests[
+                 "mftc_couple_full_time_hours_per_week"
+-                if scenario.partnered
++                if bool(family_aggregate["partner_present"])
+                 else "mftc_single_full_time_hours_per_week"
+             ]
+         )
+@@ -1719,17 +1899,24 @@
+         self,
+         *,
+         scenario: Scenario,
+-        annual_base_income: Decimal,
+-        annual_wages: Decimal,
+-    ) -> tuple[Decimal, Decimal, Decimal]:
+-        eligible_children = [
+-            index for index, age in enumerate(scenario.children) if age in (0, 1, 2)
+-        ]
+-        total_before_abatement = D0
+-        per_child_total = D0
+-        family_abatement: Decimal | None = None
+-        for index in eligible_children:
+-            inputs = self.family_scheme_inputs(annual_base_income, annual_wages)
++        adult_scalars: Mapping[int, Mapping[str, Decimal]],
++        family_scheme_income: Decimal,
++    ) -> tuple[Decimal, Decimal, dict[int, dict[str, Decimal]]]:
++        projected = self.aggregate_family(
++            scenario,
++            adult_scalars=adult_scalars,
++            family_scheme_income=family_scheme_income,
++        )
++        annual_wages = dec(projected["scalars"]["annual_wages"])
++        child_values: dict[int, dict[str, Decimal]] = {}
++        for child in projected["children"]:
++            index = int(str(child["person"]).rsplit(":", 1)[1])
++            if not child["age_bands"]["best_start_eligible_child_count"]:
++                continue
++            projected_income = dec(child["scalars"]["family_scheme_income"])
++            inputs = self.family_scheme_inputs(
++                projected_income, annual_wages
++            )
+             inputs.update(
+                 {
+                     "best_start_entitlement_days": 365,
+@@ -1746,39 +1933,39 @@
+                 outputs=[
+                     BEST_START_BEFORE_OUTPUT,
+                     BEST_START_ABATEMENT_OUTPUT,
+-                    BEST_START_OUTPUT,
+                 ],
+             )
+             child_before = scalar_decimal(values, BEST_START_BEFORE_OUTPUT)
+             child_abatement = scalar_decimal(
+                 values, BEST_START_ABATEMENT_OUTPUT
+             )
+-            total_before_abatement += child_before
+-            per_child_total += scalar_decimal(values, BEST_START_OUTPUT)
+-            if family_abatement is None:
+-                family_abatement = child_abatement
+-            elif child_abatement != family_abatement:
+-                raise HarnessError(
+-                    "Best Start family abatement changed between children for "
+-                    f"{scenario.id}"
+-                )
+-        aggregate_total = max(
+-            D0,
+-            total_before_abatement - (family_abatement or D0),
++            child_values[index] = {
++                "best_start_before_abatement": child_before,
++                "best_start_family_abatement": child_abatement,
++            }
++        reduced = self.aggregate_family(
++            scenario,
++            adult_scalars=adult_scalars,
++            child_scalars=child_values,
++            family_scheme_income=family_scheme_income,
+         )
++        aggregate_total = dec(reduced["scalars"]["best_start_total"])
++        total_before_abatement = dec(
++            reduced["scalars"]["best_start_total_before_abatement"]
++        )
+         continuous_total = max(
+             D0,
+             total_before_abatement
+             - max(
+                 D0,
+-                annual_base_income - self.best_start_abatement_threshold,
++                family_scheme_income - self.best_start_abatement_threshold,
+             )
+             * self.best_start_abatement_rate,
+         )
+         return (
+             aggregate_total / WEEKS_IN_MODEL_YEAR,
+-            per_child_total / WEEKS_IN_MODEL_YEAR,
+             continuous_total / WEEKS_IN_MODEL_YEAR,
++            child_values,
+         )
+ 
+     def ietc_for_person(
+@@ -1863,14 +2050,18 @@
+     ) -> Decimal:
+         if net_benefit <= 0:
+             return D0
++        shape = self.family_shape(scenario)
++        child_count = int(shape["counts"]["dependent_child_count"])
+         values = self._evaluate(
+             entity="Person",
+             entity_id=f"{scenario.id}:winter-energy-rate",
+             inputs={
+-                "winter_energy_payment_single": not scenario.partnered,
+-                "winter_energy_payment_has_dependent_children": bool(
+-                    scenario.children
++                "winter_energy_payment_single": not bool(
++                    shape["partner_present"]
+                 ),
++                "winter_energy_payment_has_dependent_children": (
++                    child_count > 0
++                ),
+             },
+             outputs=[WEP_RATE_OUTPUT],
+         )
+@@ -1882,14 +2073,17 @@
+         *,
+         treasury_host_aligned: bool,
+     ) -> Decimal:
++        shape = self.family_shape(scenario)
++        partnered = bool(shape["partner_present"])
++        child_count = int(shape["counts"]["dependent_child_count"])
+         key = (
+-            scenario.partnered,
+-            len(scenario.children),
++            partnered,
++            child_count,
+             treasury_host_aligned,
+         )
+         if key in self._as_cutout_cache:
+             return self._as_cutout_cache[key]
+-        if not scenario.partnered and scenario.children:
++        if not partnered and child_count:
+             # Treasury's source-defined lone-parent AS branch is deliberately
+             # not the SPS/JSS-with-children benefit schedule used for current
+             # net benefit. R/emtr.R lines 324-329 instead combine the lone-
+@@ -1931,11 +2125,22 @@
+         eldest_ftc_annual: Decimal,
+         treasury_host_aligned: bool,
+     ) -> tuple[Decimal, Decimal, Decimal, Decimal, Decimal]:
+-        zero_income_benefit = sum(
+-            self.zero_income_jobseeker_components(scenario), D0
++        shape = self.family_shape(scenario)
++        partnered = bool(shape["partner_present"])
++        child_count = int(shape["counts"]["dependent_child_count"])
++        zero_components = self.zero_income_jobseeker_components(scenario)
++        zero_income_aggregate = self.aggregate_family(
++            scenario,
++            adult_scalars={
++                person: {"weekly_net_benefit": value}
++                for person, value in enumerate(zero_components, start=1)
++            },
++        )
++        zero_income_benefit = dec(
++            zero_income_aggregate["scalars"]["weekly_net_benefit"]
+         )
+         base_rate = zero_income_benefit
+-        if scenario.children:
++        if child_count:
+             # Social Security Regulations 2018 reg 17 uses the annual FTC rate
+             # divided by 52. Treasury raw emtr() instead divides by 365/7; that
+             # source-host convention is retained only in the labeled diagnostic.
+@@ -1956,13 +2161,11 @@
+             "accommodation_supplement_boarder": boarder,
+             "accommodation_supplement_business_use_area": D0,
+             "accommodation_supplement_costs_are_homeownership": not rent,
+-            "accommodation_supplement_has_dependent_children": bool(
+-                scenario.children
+-            ),
++            "accommodation_supplement_has_dependent_children": child_count > 0,
+             "accommodation_supplement_has_two_or_more_dependent_children": (
+-                len(scenario.children) >= 2
++                child_count >= 2
+             ),
+-            "accommodation_supplement_in_relationship": scenario.partnered,
++            "accommodation_supplement_in_relationship": partnered,
+             "accommodation_supplement_joint_owner_with_resident": False,
+             "accommodation_supplement_non_beneficiary": net_benefit == 0,
+             "accommodation_supplement_non_beneficiary_income_cutout_weekly_amount": (
+@@ -1984,7 +2187,7 @@
+             "accommodation_supplement_self_contained_area_let_to_residents": D0,
+             "accommodation_supplement_social_housing_weekly_contributions_paid": D0,
+             "accommodation_supplement_sole_parent": (
+-                not scenario.partnered and bool(scenario.children)
++                not partnered and child_count > 0
+             ),
+             "accommodation_supplement_total_premises_area": D0,
+             "accommodation_supplement_weekly_board_and_lodgings_paid": (
+@@ -2024,21 +2227,50 @@
+         scenario: Scenario,
+         weekly_wage1: Decimal,
+     ) -> dict[str, Decimal | str]:
++        shape = self.family_shape(scenario)
++        partnered = bool(shape["partner_present"])
+         weekly_wage2 = scenario.gross_wage2
+-        weekly_wages = weekly_wage1 + weekly_wage2
+         hours1 = (
+             weekly_wage1 / scenario.wage1_hourly
+             if scenario.wage1_hourly > 0
+             else D0
+         )
+-        hours_total = hours1 + scenario.hours2
++        adult_scalars: dict[int, dict[str, Decimal]] = {
++            1: {
++                "weekly_wage": weekly_wage1,
++                "annual_wage": weekly_wage1 * WEEKS_IN_MODEL_YEAR,
++                "annual_family_scheme_base_income": (
++                    weekly_wage1 * WEEKS_IN_MODEL_YEAR
++                ),
++                "weekly_hours": hours1,
++            }
++        }
++        if partnered:
++            adult_scalars[2] = {
++                "weekly_wage": weekly_wage2,
++                "annual_wage": weekly_wage2 * WEEKS_IN_MODEL_YEAR,
++                "annual_family_scheme_base_income": (
++                    weekly_wage2 * WEEKS_IN_MODEL_YEAR
++                ),
++                "weekly_hours": scenario.hours2,
++            }
++        wage_aggregate = self.aggregate_family(
++            scenario, adult_scalars=adult_scalars
++        )
++        weekly_wages = dec(wage_aggregate["scalars"]["weekly_wages"])
+         benefit_components = self.benefit_components(scenario, weekly_wages)
+-        net_benefit = sum(benefit_components, D0)
+         gross_benefits = tuple(
+             self.gross_benefit_from_net_weekly(value)
+             for value in benefit_components
+         )
+-        gross_benefit_total = sum(gross_benefits, D0)
++        for person, (net_component, gross_component) in enumerate(
++            zip(benefit_components, gross_benefits, strict=True), start=1
++        ):
++            adult_scalars[person]["weekly_net_benefit"] = net_component
++            adult_scalars[person]["weekly_gross_benefit"] = gross_component
++            adult_scalars[person]["annual_family_scheme_base_income"] = (
++                adult_scalars[person]["weekly_wage"] + gross_component
++            ) * WEEKS_IN_MODEL_YEAR
+ 
+         primary_gross_benefit = gross_benefits[0]
+         tax1 = (
+@@ -2051,11 +2283,13 @@
+             weekly_wage1 * WEEKS_IN_MODEL_YEAR
+         ) / WEEKS_IN_MODEL_YEAR
+         net_wage1 = weekly_wage1 - tax1 - acc1
++        adult_scalars[1]["weekly_wage_tax"] = tax1
++        adult_scalars[1]["weekly_net_wage"] = net_wage1
+ 
+         tax2 = D0
+         acc2 = D0
+         net_wage2 = D0
+-        if scenario.partnered:
++        if partnered:
+             partner_gross_benefit = gross_benefits[1]
+             tax2 = (
+                 self.annual_tax(
+@@ -2068,15 +2302,22 @@
+                 weekly_wage2 * WEEKS_IN_MODEL_YEAR
+             ) / WEEKS_IN_MODEL_YEAR
+             net_wage2 = weekly_wage2 - tax2 - acc2
+-        net_wage = net_wage1 + net_wage2
++            adult_scalars[2]["weekly_wage_tax"] = tax2
++            adult_scalars[2]["weekly_net_wage"] = net_wage2
++        family_aggregate = self.aggregate_family(
++            scenario, adult_scalars=adult_scalars
++        )
++        aggregate_scalars = family_aggregate["scalars"]
++        net_wage = dec(aggregate_scalars["weekly_net_wage"])
++        net_benefit = dec(aggregate_scalars["weekly_net_benefit"])
++        gross_benefit_total = dec(
++            aggregate_scalars["weekly_gross_benefit"]
++        )
++        hours_total = dec(aggregate_scalars["hours_total"])
+ 
+         family_values = self.family_credit_values(
+             scenario=scenario,
+-            weekly_wages=weekly_wages,
+-            weekly_gross_benefits=gross_benefit_total,
+-            net_benefit=net_benefit,
+-            wage_tax_total=tax1 + tax2,
+-            hours_total=hours_total,
++            family_aggregate=family_aggregate,
+         )
+         ftc_before = (
+             scalar_decimal(family_values, FTC_BEFORE_OUTPUT)
+@@ -2106,18 +2347,14 @@
+             ),
+         )
+ 
+-        annual_wages = weekly_wages * WEEKS_IN_MODEL_YEAR
+-        annual_base_income = (
+-            weekly_wages + gross_benefit_total
+-        ) * WEEKS_IN_MODEL_YEAR
+         (
+             best_start,
+-            best_start_per_child,
+             best_start_continuous,
++            best_start_child_values,
+         ) = self.best_start_total(
+             scenario=scenario,
+-            annual_base_income=annual_base_income,
+-            annual_wages=annual_wages,
++            adult_scalars=adult_scalars,
++            family_scheme_income=family_scheme_income,
+         )
+         family_support_payable = (wff + mftc + best_start) > 0
+         ietc1, ietc1_continuous = self.ietc_for_person(
+@@ -2129,7 +2366,7 @@
+         )
+         ietc2 = D0
+         ietc2_continuous = D0
+-        if scenario.partnered:
++        if partnered:
+             ietc2, ietc2_continuous = self.ietc_for_person(
+                 scenario=scenario,
+                 person=2,
+@@ -2137,8 +2374,32 @@
+                 weekly_benefit=benefit_components[1],
+                 family_support_payable=family_support_payable,
+             )
+-        ietc = ietc1 + ietc2
+-        ietc_continuous = ietc1_continuous + ietc2_continuous
++        adult_scalars[1]["ietc_weekly"] = ietc1
++        adult_scalars[1]["ietc_continuous_weekly"] = ietc1_continuous
++        if partnered:
++            adult_scalars[2]["ietc_weekly"] = ietc2
++            adult_scalars[2][
++                "ietc_continuous_weekly"
++            ] = ietc2_continuous
++        final_aggregate = self.aggregate_family(
++            scenario,
++            adult_scalars=adult_scalars,
++            child_scalars=best_start_child_values,
++            family_scheme_income=family_scheme_income,
++        )
++        ietc = dec(final_aggregate["scalars"]["ietc_weekly"])
++        ietc_continuous = dec(
++            final_aggregate["scalars"]["ietc_continuous_weekly"]
++        )
++        final_best_start = (
++            dec(final_aggregate["scalars"]["best_start_total"])
++            / WEEKS_IN_MODEL_YEAR
++        )
++        if final_best_start != best_start:
++            raise HarnessError(
++                "Best Start family reduction changed between aggregation "
++                f"passes for {scenario.id}"
++            )
+         winter_energy = self.winter_energy_average(scenario, net_benefit)
+         (
+             as_unrounded,
+@@ -2192,9 +2453,6 @@
+             "IETC_abated": ietc,
+             "WinterEnergy": winter_energy,
+             "BestStart_Total": best_start,
+-            "BestStart_Total_naive_per_child_abatement": (
+-                best_start_per_child
+-            ),
+             "BestStart_Total_continuous_abatement": (
+                 best_start_continuous
+             ),
+@@ -2265,17 +2523,7 @@
+             )
+             - scalar_decimal(
+                 following_state, "AS_Amount_treasury_host_aligned"
+-            )
+-        )
+-        state["RuleSpec_EMTR_BestStart_Total_naive_per_child_abatement"] = (
+-            scalar_decimal(
+-                current_state,
+-                "BestStart_Total_naive_per_child_abatement",
+             )
+-            - scalar_decimal(
+-                following_state,
+-                "BestStart_Total_naive_per_child_abatement",
+-            )
+         )
+         recomposed_emtr = sum(
+             (
+@@ -2452,38 +2700,30 @@
+             "treasury": dec(
+                 treasury_state(best_start_id, wage)["BestStart_Total"]
+             ),
+-            "rulespec_after_aggregate_once": scalar_decimal(
++            "rulespec_engine_family_reduction": scalar_decimal(
+                 state, "BestStart_Total"
+             ),
+-            "rulespec_before_naive_per_child_abatement": scalar_decimal(
+-                state, "BestStart_Total_naive_per_child_abatement"
+-            ),
+         }
+-        if (
+-            row["rulespec_after_aggregate_once"]
+-            < row["rulespec_before_naive_per_child_abatement"]
+-        ):
+-            raise HarnessError(
+-                "Best Start aggregate-once correction is not active at "
+-                f"wage {wage}"
+-            )
+         best_start_rows.append(row)
+-    if not any(
+-        row["rulespec_after_aggregate_once"]
+-        > row["rulespec_before_naive_per_child_abatement"]
+-        for row in best_start_rows
+-    ):
+-        raise HarnessError(
+-            "Best Start aggregate-once and naive per-child results never diverge"
+-        )
+     treasury_best_start_at_zero = dec(
+         treasury_state(best_start_id, 0)["BestStart_Total"]
+     )
++    rulespec_best_start_at_zero = scalar_decimal(
++        sweeps[best_start_id][0], "BestStart_Total"
++    )
+     if not any(
+         D0 < row["treasury"] < treasury_best_start_at_zero
+         for row in best_start_rows
+     ):
+         raise HarnessError("Treasury Best Start abatement is not binding")
++    if not any(
++        D0 < row["rulespec_engine_family_reduction"]
++        < rulespec_best_start_at_zero
++        for row in best_start_rows
++    ):
++        raise HarnessError(
++            "engine-side Best Start family abatement is not binding"
++        )
+ 
+     dual_id = "couple_two_children_dual_full_time"
+     dual_state = sweeps[dual_id][740]
+@@ -2565,7 +2805,7 @@
+         "sampled_point_count": sum(
+             len(scenario.sampled_wages) for scenario in scenarios
+         ),
+-        "best_start_aggregate_fix": best_start_rows,
++        "best_start_engine_family_reduction": best_start_rows,
+         "dual_full_time_partner_at_wage_740": {
+             "primary_hours": scalar_decimal(dual_state, "hours1"),
+             "partner_hours": scenario_by_id[dual_id].hours2,
+@@ -3577,12 +3817,10 @@
+         "net_wage2",
+         "family_scheme_income",
+         "iwtc_entitlement",
+-        "BestStart_Total_naive_per_child_abatement",
+         "BestStart_Total_continuous_abatement",
+         "WFF_abated_continuous_abatement",
+         "IETC_abated_continuous_abatement",
+         "RuleSpec_EMTR_AS_Amount_treasury_host_aligned",
+-        "RuleSpec_EMTR_BestStart_Total_naive_per_child_abatement",
+         "EMTR_ACC_rounding_component",
+         "EMTR_WFF_complete_dollar_component",
+         "EMTR_BestStart_complete_dollar_component",
+@@ -3850,6 +4088,7 @@
+     compiled_artifact_sha256: str,
+     compiled_counts: Mapping[str, int],
+     engine_call_count: int,
++    aggregation_call_count: int,
+     scenarios: Sequence[Scenario],
+     rows: Sequence[ComparisonRow],
+     statistics: Mapping[str, Any],
+@@ -4012,9 +4251,9 @@
+             ),
+             (
+                 "| `couple_two_best_start_children_binding` | Two eligible "
+-                "children, full-time partner, aggregate Best Start abatement | "
++                "children, full-time partner, engine-side family Best Start abatement | "
+                 "775/776, 1125/1126, 1476/1477 | Abatement binds inside the "
+-                "grid; aggregate-once and old naive composition diverge. |"
++                "grid through the family-once reducer. |"
+             ),
+             (
+                 "| `couple_two_children_dual_full_time` | Partner wage tax/ACC "
+@@ -4074,13 +4313,14 @@
+             "$248 to Treasury tests downstream arithmetic, not Treasury's "
+             "missing 62% transformation. This remains a named coverage gap.",
+             "",
+-            "## Class-(a) defect found and fixed",
++            "## Class-(a) regression structurally excluded",
+             "",
+-            "The binding two-child scenario exposed a host-composition defect. "
+-            "RuleSpec's Best Start module is child-entity based. The old harness "
+-            "summed each child's *post-abatement* result, thereby subtracting the "
+-            "same family abatement once per child. The fixed harness sums the "
+-            "per-child gross credits and subtracts one family abatement.",
++            "The prior binding two-child audit exposed a host-composition "
++            "defect: summing each child's post-abatement result subtracted the "
++            "same family abatement once per child. This pass has no Python "
++            "family reducer. The engine plan accepts child gross credits and "
++            "an equal family-abatement projection, then exposes only a "
++            "sum-children-then-subtract-family-once operation.",
+             "",
+             "[Income Tax Act 2007 MG 1]"
+             "(https://www.legislation.govt.nz/act/public/2007/0097/latest/"
+@@ -4096,24 +4336,23 @@
+             "the threshold reduces the one-, two-, and three-child family totals "
+             "by the same amount, not once per child.",
+             "",
+-            "| Primary wage | Treasury | Before: naive per-child abatement | "
+-            "After: aggregate once |",
+-            "|---:|---:|---:|---:|",
++            "| Primary wage | Treasury | Engine family-once reduction |",
++            "|---:|---:|---:|",
+         ]
+     )
+-    for item in coverage_evidence["best_start_aggregate_fix"]:
++    for item in coverage_evidence["best_start_engine_family_reduction"]:
+         lines.append(
+             f"| {item['weekly_wage']} | "
+             f"{report_number(item['treasury'], 6)} | "
+-            f"{report_number(item['rulespec_before_naive_per_child_abatement'], 6)} | "
+-            f"{report_number(item['rulespec_after_aggregate_once'], 6)} |"
++            f"{report_number(item['rulespec_engine_family_reduction'], 6)} |"
+         )
+     lines.extend(
+         [
+             "",
+-            "This was a harness aggregation bug, not a defect in the underlying "
+-            "RuleSpec child-level amount formula. It is fixed in `run.py`; the "
+-            "isolated RuleSpec worktree remains unchanged. The final matrix has "
++            "The in-repo engine test reproduces the old 6,082-versus-7,082 "
++            "two-child defect and proves the plan grammar rejects a per-child "
++            "abatement reducer. The isolated RuleSpec worktree remains "
++            "unchanged. The final matrix has "
+             f"{statistics['classification_counts']['a']} class-(a) cells.",
+             "",
+             "The prior four-family phase also fixed two host mappings before its "
+@@ -4265,7 +4504,9 @@
+             "coordinates; and serialized continuity objects.",
+             "3. Compile the ten-module RuleSpec composition from scratch and run "
+             "all engine queries in `explain` mode.",
+-            "4. Map every profile to explicit person, child, and family inputs. "
++            "4. Map every profile to explicit Person records plus complete "
++            "partner/child relation facts. The engine derives the Family, "
++            "person sums, age-band counts, and Child family-income projections. "
+             "The 14+ lone-parent path uses JSS with Income Test 1. Wage tax is "
+             "incremental tax above grossed taxable benefit, matching raw "
+             "`emtr()`.",
+@@ -4304,10 +4545,6 @@
+             "- Full IWTC, MFTC, IETC, and Winter Energy legal eligibility. "
+             "Omitted facts are supplied as disclosed stylised assumptions; WEP "
+             "is host-gated by positive reconstructed benefit.",
+-            "- Relation-native person/child/family aggregation. The compiled "
+-            "composition has zero relations, so the auditable host harness "
+-            "performs aggregation, including the corrected Best Start family "
+-            "abatement.",
+             "- The IncomeExplorer UI wrapper, population representativeness, "
+             "non-integer wage kinks, or exhaustive threshold coverage. RR and "
+             "PTR are emitted in `secondary_rates.csv` but remain outside the "
+@@ -4334,12 +4571,16 @@
+             f"| Engine source commit | `{provenance.engine_sha}` |",
+             f"| Engine binary SHA-256 | `{provenance.engine_binary_sha256}` |",
+             f"| Composition SHA-256 | `{provenance.composition_sha256}` |",
++            f"| Unit aggregation plan SHA-256 | "
++            f"`{provenance.aggregation_plan_sha256}` |",
+             f"| Compiled artifact SHA-256 | `{compiled_artifact_sha256}` |",
+             f"| Compiled shape | {compiled_counts['derived_outputs']} derived, "
+             f"{compiled_counts['parameters']} parameters, "
+             f"{compiled_counts['input_slots']} inputs, "
+             f"{compiled_counts['relations']} relations |",
+             f"| Engine evaluations per fresh pass | {engine_call_count} |",
++            f"| Engine unit-aggregation evaluations per fresh pass | "
++            f"{aggregation_call_count} |",
+             "| Tax-year interval | `2026-04-01` to `2027-03-31` |",
+             "| Expanded snapshot `generated_at` | `2026-07-29` |",
+             "",
+@@ -4411,6 +4652,7 @@
+     engine_binary: Path,
+     treasury_root: Path,
+     composition_path: Path,
++    aggregation_plan_path: Path,
+     eligibility_closures_path: Path,
+     oracle_generator: Path,
+     rscript: Path,
+@@ -4432,6 +4674,7 @@
+         engine_binary=engine_binary,
+         treasury_root=treasury_root,
+         composition_path=composition_path,
++        aggregation_plan_path=aggregation_plan_path,
+         eligibility_closures_path=eligibility_closures_path,
+         eligibility_closures=eligibility_closures,
+         oracle_generator=oracle_generator,
+@@ -4446,6 +4689,7 @@
+             composition=provenance.composition_path,
+             rulespec_root=provenance.rulespec_root,
+             artifact=compiled_path,
++            aggregation_plan=provenance.aggregation_plan_path,
+         )
+         compiled_artifact_sha256 = sha256_file(compiled_path)
+         compiled_counts = {
+@@ -4587,6 +4831,9 @@
+                 **compiled_counts,
+                 "artifact_sha256": compiled_artifact_sha256,
+                 "engine_evaluations": engine.call_count,
++                "unit_aggregation_evaluations": (
++                    engine.aggregation_call_count
++                ),
+             },
+             "exercise_input_catalog": {
+                 slot: {
+@@ -4670,6 +4917,7 @@
+             compiled_artifact_sha256=compiled_artifact_sha256,
+             compiled_counts=compiled_counts,
+             engine_call_count=engine.call_count,
++            aggregation_call_count=engine.aggregation_call_count,
+             scenarios=scenarios,
+             rows=comparison_rows,
+             statistics=statistics,
+@@ -4726,6 +4974,7 @@
+             "statistics": statistics,
+             "compiled_artifact_sha256": compiled_artifact_sha256,
+             "engine_evaluations": engine.call_count,
++            "unit_aggregation_evaluations": engine.aggregation_call_count,
+             "artifact_names": tuple(sorted(artifacts)),
+         }
+         return artifacts, run_summary
+@@ -4799,6 +5048,15 @@
+         "--composition",
+         type=Path,
+         default=DEFAULT_COMPOSITION,
++    )
++    parser.add_argument(
++        "--aggregation-plan",
++        type=Path,
++        default=None,
++        help=(
++            "Defaults to <engine-root>/tests/fixtures/unit_derivation/"
++            "nz_income_explorer_family.yaml"
++        ),
+     )
+     parser.add_argument(
+         "--eligibility-closures",
+@@ -4830,6 +5088,15 @@
+         if args.engine_binary is not None
+         else args.engine_root / "target" / "release" / "axiom-rules-engine"
+     )
++    aggregation_plan = (
++        args.aggregation_plan
++        if args.aggregation_plan is not None
++        else args.engine_root
++        / "tests"
++        / "fixtures"
++        / "unit_derivation"
++        / "nz_income_explorer_family.yaml"
++    )
+     try:
+         first, summary = build_audit_artifacts(
+             rulespec_root=args.rulespec_root,
+@@ -4837,6 +5104,7 @@
+             engine_binary=engine_binary,
+             treasury_root=args.treasury_root,
+             composition_path=args.composition,
++            aggregation_plan_path=aggregation_plan,
+             eligibility_closures_path=args.eligibility_closures,
+             oracle_generator=args.oracle_generator,
+             rscript=args.rscript,
+@@ -4848,6 +5116,7 @@
+             engine_binary=engine_binary,
+             treasury_root=args.treasury_root,
+             composition_path=args.composition,
++            aggregation_plan_path=aggregation_plan,
+             eligibility_closures_path=args.eligibility_closures,
+             oracle_generator=args.oracle_generator,
+             rscript=args.rscript,

--- a/stage3-nz/ops-harness.patch
+++ b/stage3-nz/ops-harness.patch
@@ -1,5 +1,5 @@
 diff --git a/nz-lane/emtr_reproduction/run.py b/nz-lane/emtr_reproduction/run.py
-index d5f5d72..1fcff15 100644
+index d5f5d72..8ee3b3b 100644
 --- a/nz-lane/emtr_reproduction/run.py
 +++ b/nz-lane/emtr_reproduction/run.py
 @@ -43,13 +43,23 @@ DEFAULT_TREASURY_ROOT = (
@@ -20,9 +20,9 @@ index d5f5d72..1fcff15 100644
 
  EXPECTED_RULESPEC_SHA = "89a7d25dc03a4d045348620283332de10b1047da"
 -EXPECTED_ENGINE_SHA = "d59969b53430ae2fd97eb4349d44ad23ce930d85"
-+EXPECTED_ENGINE_SHA = "d8d45a817b3700ed22ec49a9fcf1024aa6ed2198"
++EXPECTED_ENGINE_SHA = "d9069693e92ee338ab2c1d62461e73bcb02f195d"
 +EXPECTED_ENGINE_BINARY_SHA256 = (
-+    "c5a3d3d8b1fdb8480bef7cffc6dd85658ca1a48cf7ca70da968b7a46c1e8a430"
++    "3a37cd2bfa570569252b97ac0f563fcf089fd97f43b208943c15ae28bb445e34"
 +)
  EXPECTED_ORACLE_COMMIT = "741a6ca4f5d27b1dc00b43dc395e39ffc4040a4b"
  EXPECTED_PARAMETER_FILE = "inst/parameters/TY27_BEFU25.yaml"
@@ -336,7 +336,7 @@ index d5f5d72..1fcff15 100644
      ) -> tuple["Engine", dict[str, Any], str]:
          process = run_checked(
              [
-@@ -898,7 +1068,41 @@ class Engine:
+@@ -898,7 +1068,45 @@ class Engine:
          }
          if not catalog:
              raise HarnessError("compiled artifact has an empty input catalog")
@@ -347,6 +347,8 @@ index d5f5d72..1fcff15 100644
 +                "compile-unit-aggregation",
 +                "--plan",
 +                str(aggregation_plan),
++                "--source-artifact",
++                str(artifact),
 +                "--output",
 +                str(aggregation_artifact),
 +            ],
@@ -364,6 +366,8 @@ index d5f5d72..1fcff15 100644
 +            compiled_aggregation.get("format")
 +            != "axiom/compiled-unit-aggregation-stage3/1"
 +            or not compiled_aggregation.get("plan_digest")
++            or not compiled_aggregation.get("source_artifact_digest")
++            or not compiled_aggregation.get("source_artifact")
 +            or not compiled_aggregation.get("phase_two_artifact")
 +        ):
 +            raise HarnessError(
@@ -379,10 +383,54 @@ index d5f5d72..1fcff15 100644
          return engine, compiled, process.stdout.strip()
 
      def input_record(
-@@ -1017,6 +1221,38 @@ class Engine:
+@@ -949,18 +1157,11 @@ class Engine:
+     ) -> tuple[dict[str, Decimal | str], dict[str, Any]]:
+         request = {
+             "mode": "explain",
+-            "dataset": {
+-                "inputs": [
+-                    self.input_record(
+-                        slot=slot,
+-                        value=value,
+-                        entity=entity,
+-                        entity_id=entity_id,
+-                    )
+-                    for slot, value in sorted(inputs.items())
+-                ],
+-                "relations": [],
+-            },
++            "dataset": self.dataset(
++                entity=entity,
++                entity_id=entity_id,
++                inputs=inputs,
++            ),
+             "queries": [
+                 {
+                     "entity_id": entity_id,
+@@ -1017,6 +1218,58 @@ class Engine:
                  raise HarnessError(f"unknown engine output shape for {target}: {item!r}")
          return values, results[0].get("trace", {})
 
++    def dataset(
++        self,
++        *,
++        entity: str,
++        entity_id: str,
++        inputs: Mapping[str, bool | int | Decimal],
++    ) -> dict[str, Any]:
++        return {
++            "inputs": [
++                self.input_record(
++                    slot=slot,
++                    value=value,
++                    entity=entity,
++                    entity_id=entity_id,
++                )
++                for slot, value in sorted(inputs.items())
++            ],
++            "relations": [],
++        }
++
 +    def aggregate(self, request: Mapping[str, Any]) -> dict[str, Any]:
 +        process = run_checked(
 +            [
@@ -418,7 +466,7 @@ index d5f5d72..1fcff15 100644
 
  def normalize_children(raw: Any) -> list[int]:
      if isinstance(raw, list):
-@@ -1260,8 +1496,9 @@ class ModelEvaluator:
+@@ -1260,8 +1513,9 @@ class ModelEvaluator:
          ] = {}
          self._gross_benefit_cache: dict[Decimal, Decimal] = {}
          self._as_cutout_cache: dict[
@@ -429,7 +477,7 @@ index d5f5d72..1fcff15 100644
          self.tax_rates = selected_parameter_values(
              compiled, "individual_income_tax_bracket_rates"
          )
-@@ -1316,6 +1553,246 @@ class ModelEvaluator:
+@@ -1316,6 +1570,266 @@ class ModelEvaluator:
                  f"unexpected tax-threshold indexes: {sorted(self.tax_thresholds)}"
              )
 
@@ -454,10 +502,12 @@ index d5f5d72..1fcff15 100644
 +        *,
 +        adult_scalars: Mapping[int, Mapping[str, Decimal]] | None = None,
 +        child_scalars: Mapping[int, Mapping[str, Decimal]] | None = None,
++        child_gross_datasets: Mapping[int, Mapping[str, Any]] | None = None,
 +        family_scheme_income: Decimal = D0,
 +    ) -> dict[str, Any]:
 +        adults = adult_scalars or {}
 +        children = child_scalars or {}
++        gross_datasets = child_gross_datasets or {}
 +        scope = f"scenario:{scenario.id}"
 +        primary_id = f"{scenario.id}:person:1"
 +        persons: list[dict[str, Any]] = []
@@ -501,7 +551,6 @@ index d5f5d72..1fcff15 100644
 +        for index, age in enumerate(scenario.children):
 +            age_18 = self.closures["age_18"]
 +            values = {
-+                "best_start_before_care_and_abatement": D0,
 +                "best_start_claimant_care_fraction": dec(
 +                    self.closures["care"][
 +                        "best_start_child_care_fraction"
@@ -517,10 +566,24 @@ index d5f5d72..1fcff15 100644
 +                {
 +                    name: value
 +                    for name, value in children.get(index, {}).items()
-+                    if name != "best_start_family_abatement"
++                    if name
++                    not in {
++                        "best_start_before_care_and_abatement",
++                        "best_start_family_abatement",
++                    }
 +                }
 +            )
 +            child_id = f"{scenario.id}:child:{index}"
++            gross_dataset = gross_datasets.get(index)
++            if gross_dataset is None:
++                gross_dataset = self.engine.dataset(
++                    entity="Child",
++                    entity_id=child_id,
++                    inputs={
++                        "best_start_entitlement_days": 0,
++                        "best_start_child_care_fraction": D1,
++                    },
++                )
 +            persons.append(
 +                {
 +                    "id": child_id,
@@ -577,6 +640,11 @@ index d5f5d72..1fcff15 100644
 +                            ),
 +                            f"{scope}:child:{index}:mc9-period",
 +                        ),
++                    },
++                    "engine_computations": {
++                        "best_start_before_care_and_abatement": {
++                            "dataset": gross_dataset,
++                        }
 +                    },
 +                }
 +            )
@@ -639,8 +707,8 @@ index d5f5d72..1fcff15 100644
 +                        "anchor_person": primary_id,
 +                        "evidence": {"id": f"{scope}:family-input"},
 +                        "named_people": {
-+                            "mc7_entitlement_holder": known(
-+                                primary_id, f"{scope}:mc7-entitlement-holder"
++                            "family_unit_reference_person": known(
++                                primary_id, f"{scope}:family-reference-person"
 +                            )
 +                        },
 +                        "scalars": {
@@ -676,7 +744,7 @@ index d5f5d72..1fcff15 100644
      def _evaluate(
          self,
          *,
-@@ -1419,17 +1896,19 @@ class ModelEvaluator:
+@@ -1419,17 +1933,19 @@ class ModelEvaluator:
          scenario: Scenario,
          weekly_family_income: Decimal,
      ) -> Decimal:
@@ -700,7 +768,7 @@ index d5f5d72..1fcff15 100644
              "jobseeker_support_total_income": weekly_family_income,
              "jobseeker_support_transferred_2013_no_dependent_children": False,
              "jobseeker_support_youngest_dependent_child_age": youngest,
-@@ -1459,25 +1938,39 @@ class ModelEvaluator:
+@@ -1459,25 +1975,39 @@ class ModelEvaluator:
          return scalar_decimal(values, SOLE_PARENT_OUTPUT)
 
      def raw_iwtc_branch(self, scenario: Scenario, weekly_wages: Decimal) -> bool:
@@ -751,7 +819,7 @@ index d5f5d72..1fcff15 100644
          else:
              scheduled = (self.jobseeker_payment(scenario, weekly_wages),)
          if self.raw_iwtc_branch(scenario, weekly_wages):
-@@ -1489,7 +1982,7 @@ class ModelEvaluator:
+@@ -1489,7 +2019,7 @@ class ModelEvaluator:
          scenario: Scenario,
      ) -> tuple[Decimal, ...]:
          per_person = self.jobseeker_payment(scenario, D0)
@@ -760,7 +828,7 @@ index d5f5d72..1fcff15 100644
              return (per_person, per_person)
          return (per_person,)
 
-@@ -1545,7 +2038,10 @@ class ModelEvaluator:
+@@ -1545,7 +2075,10 @@ class ModelEvaluator:
          weekly_wages: Decimal,
          net_benefit: Decimal,
      ) -> dict[str, bool | int | Decimal]:
@@ -772,7 +840,7 @@ index d5f5d72..1fcff15 100644
          earns_paye = weekly_wages > 0
          residence = self.closures["residence"]
          care = self.closures["care"]
-@@ -1568,8 +2064,11 @@ class ModelEvaluator:
+@@ -1568,8 +2101,11 @@ class ModelEvaluator:
                  has_children and care["wff_caregiver_lives_apart_when_child_present"]
              ),
              "in_work_tax_credit_child_exclusive_care_fraction": (
@@ -786,7 +854,7 @@ index d5f5d72..1fcff15 100644
              ),
              "in_work_tax_credit_person_age": 25,
              "in_work_tax_credit_child_financially_dependent": has_children,
-@@ -1639,30 +2138,48 @@ class ModelEvaluator:
+@@ -1639,30 +2175,48 @@ class ModelEvaluator:
          self,
          *,
          scenario: Scenario,
@@ -832,12 +900,12 @@ index d5f5d72..1fcff15 100644
 +                    values[
 +                        "family_tax_credit_subsequent_dependent_child_care_units"
 +                    ]
-+                ),
-+                "family_tax_credit_entitlement_days": int(
-+                    dec(values["family_tax_credit_entitlement_days"])
                  ),
 -                "family_tax_credit_subsequent_dependent_child_care_units": Decimal(
 -                    max(0, child_count - 1)
++                "family_tax_credit_entitlement_days": int(
++                    dec(values["family_tax_credit_entitlement_days"])
++                ),
 +                "wff_family_credit_abatement_days": int(
 +                    dec(values["wff_family_credit_abatement_days"])
                  ),
@@ -851,7 +919,7 @@ index d5f5d72..1fcff15 100644
                  "child_tax_credit_for_entitlement_period": D0,
                  "parental_tax_credit_for_entitlement_period": D0,
                  "parental_tax_credit_additional_abatement": D0,
-@@ -1675,12 +2192,12 @@ class ModelEvaluator:
+@@ -1675,12 +2229,12 @@ class ModelEvaluator:
          full_time_hours = Decimal(
              work_tests[
                  "mftc_couple_full_time_hours_per_week"
@@ -866,7 +934,7 @@ index d5f5d72..1fcff15 100644
              and hours_total >= full_time_hours
              and net_benefit == 0
          )
-@@ -1719,24 +2236,44 @@ class ModelEvaluator:
+@@ -1719,66 +2273,98 @@ class ModelEvaluator:
          self,
          *,
          scenario: Scenario,
@@ -883,7 +951,12 @@ index d5f5d72..1fcff15 100644
 -            inputs = self.family_scheme_inputs(annual_base_income, annual_wages)
 +        adult_scalars: Mapping[int, Mapping[str, Decimal]],
 +        family_scheme_income: Decimal,
-+    ) -> tuple[Decimal, Decimal, dict[int, dict[str, Decimal]]]:
++    ) -> tuple[
++        Decimal,
++        Decimal,
++        dict[int, dict[str, Decimal]],
++        dict[int, dict[str, Any]],
++    ]:
 +        projected = self.aggregate_family(
 +            scenario,
 +            adult_scalars=adult_scalars,
@@ -891,6 +964,7 @@ index d5f5d72..1fcff15 100644
 +        )
 +        annual_wages = dec(projected["scalars"]["annual_wages"])
 +        child_values: dict[int, dict[str, Decimal]] = {}
++        child_gross_datasets: dict[int, dict[str, Any]] = {}
 +        for child in projected["children"]:
 +            index = int(str(child["person"]).rsplit(":", 1)[1])
 +            if not child["age_bands"]["best_start_eligible_child_count"]:
@@ -925,15 +999,31 @@ index d5f5d72..1fcff15 100644
 -                    "best_start_abatement_days": 365,
                  }
              )
++            child_id = f"{scenario.id}:child:{index}"
++            child_gross_datasets[index] = self.engine.dataset(
++                entity="Child",
++                entity_id=child_id,
++                inputs={
++                    "best_start_entitlement_days": inputs[
++                        "best_start_entitlement_days"
++                    ],
++                    "best_start_child_care_fraction": inputs[
++                        "best_start_child_care_fraction"
++                    ],
++                },
++            )
              values = self._evaluate(
-@@ -1746,39 +2283,32 @@ class ModelEvaluator:
+                 entity="Child",
+-                entity_id=f"{scenario.id}:child:{index}",
++                entity_id=child_id,
+                 inputs=inputs,
                  outputs=[
                      BEST_START_BEFORE_OUTPUT,
                      BEST_START_ABATEMENT_OUTPUT,
 -                    BEST_START_OUTPUT,
                  ],
              )
-             child_before = scalar_decimal(values, BEST_START_BEFORE_OUTPUT)
+-            child_before = scalar_decimal(values, BEST_START_BEFORE_OUTPUT)
              child_abatement = scalar_decimal(
                  values, BEST_START_ABATEMENT_OUTPUT
              )
@@ -959,13 +1049,13 @@ index d5f5d72..1fcff15 100644
 -            )
 -            * self.best_start_abatement_rate,
 +            child_values[index] = {
-+                "best_start_before_care_and_abatement": child_before,
 +                "best_start_family_abatement": child_abatement,
 +            }
 +        reduced = self.aggregate_family(
 +            scenario,
 +            adult_scalars=adult_scalars,
 +            child_scalars=child_values,
++            child_gross_datasets=child_gross_datasets,
 +            family_scheme_income=family_scheme_income,
 +        )
 +        aggregate_total = dec(reduced["scalars"]["best_start_total"])
@@ -979,10 +1069,11 @@ index d5f5d72..1fcff15 100644
 -            per_child_total / WEEKS_IN_MODEL_YEAR,
              continuous_total / WEEKS_IN_MODEL_YEAR,
 +            child_values,
++            child_gross_datasets,
          )
 
      def ietc_for_person(
-@@ -1863,13 +2393,18 @@ class ModelEvaluator:
+@@ -1863,13 +2449,18 @@ class ModelEvaluator:
      ) -> Decimal:
          if net_benefit <= 0:
              return D0
@@ -1004,7 +1095,7 @@ index d5f5d72..1fcff15 100644
                  ),
              },
              outputs=[WEP_RATE_OUTPUT],
-@@ -1882,14 +2417,22 @@ class ModelEvaluator:
+@@ -1882,14 +2473,22 @@ class ModelEvaluator:
          *,
          treasury_host_aligned: bool,
      ) -> Decimal:
@@ -1030,7 +1121,7 @@ index d5f5d72..1fcff15 100644
              # Treasury's source-defined lone-parent AS branch is deliberately
              # not the SPS/JSS-with-children benefit schedule used for current
              # net benefit. R/emtr.R lines 324-329 instead combine the lone-
-@@ -1931,11 +2474,30 @@ class ModelEvaluator:
+@@ -1931,11 +2530,30 @@ class ModelEvaluator:
          eldest_ftc_annual: Decimal,
          treasury_host_aligned: bool,
      ) -> tuple[Decimal, Decimal, Decimal, Decimal, Decimal]:
@@ -1064,7 +1155,7 @@ index d5f5d72..1fcff15 100644
              # Social Security Regulations 2018 reg 17 uses the annual FTC rate
              # divided by 52. Treasury raw emtr() instead divides by 365/7; that
              # source-host convention is retained only in the labeled diagnostic.
-@@ -1956,13 +2518,11 @@ class ModelEvaluator:
+@@ -1956,13 +2574,11 @@ class ModelEvaluator:
              "accommodation_supplement_boarder": boarder,
              "accommodation_supplement_business_use_area": D0,
              "accommodation_supplement_costs_are_homeownership": not rent,
@@ -1081,7 +1172,7 @@ index d5f5d72..1fcff15 100644
              "accommodation_supplement_joint_owner_with_resident": False,
              "accommodation_supplement_non_beneficiary": net_benefit == 0,
              "accommodation_supplement_non_beneficiary_income_cutout_weekly_amount": (
-@@ -1984,7 +2544,7 @@ class ModelEvaluator:
+@@ -1984,7 +2600,7 @@ class ModelEvaluator:
              "accommodation_supplement_self_contained_area_let_to_residents": D0,
              "accommodation_supplement_social_housing_weekly_contributions_paid": D0,
              "accommodation_supplement_sole_parent": (
@@ -1090,7 +1181,7 @@ index d5f5d72..1fcff15 100644
              ),
              "accommodation_supplement_total_premises_area": D0,
              "accommodation_supplement_weekly_board_and_lodgings_paid": (
-@@ -2024,21 +2584,54 @@ class ModelEvaluator:
+@@ -2024,21 +2640,54 @@ class ModelEvaluator:
          scenario: Scenario,
          weekly_wage1: Decimal,
      ) -> dict[str, Decimal | str]:
@@ -1150,7 +1241,7 @@ index d5f5d72..1fcff15 100644
 
          primary_gross_benefit = gross_benefits[0]
          tax1 = (
-@@ -2051,11 +2644,13 @@ class ModelEvaluator:
+@@ -2051,11 +2700,13 @@ class ModelEvaluator:
              weekly_wage1 * WEEKS_IN_MODEL_YEAR
          ) / WEEKS_IN_MODEL_YEAR
          net_wage1 = weekly_wage1 - tax1 - acc1
@@ -1165,7 +1256,7 @@ index d5f5d72..1fcff15 100644
              partner_gross_benefit = gross_benefits[1]
              tax2 = (
                  self.annual_tax(
-@@ -2068,15 +2663,22 @@ class ModelEvaluator:
+@@ -2068,15 +2719,22 @@ class ModelEvaluator:
                  weekly_wage2 * WEEKS_IN_MODEL_YEAR
              ) / WEEKS_IN_MODEL_YEAR
              net_wage2 = weekly_wage2 - tax2 - acc2
@@ -1194,7 +1285,7 @@ index d5f5d72..1fcff15 100644
          )
          ftc_before = (
              scalar_decimal(family_values, FTC_BEFORE_OUTPUT)
-@@ -2106,18 +2708,14 @@ class ModelEvaluator:
+@@ -2106,18 +2764,15 @@ class ModelEvaluator:
              ),
          )
 
@@ -1207,6 +1298,7 @@ index d5f5d72..1fcff15 100644
 -            best_start_per_child,
              best_start_continuous,
 +            best_start_child_values,
++            best_start_child_gross_datasets,
          ) = self.best_start_total(
              scenario=scenario,
 -            annual_base_income=annual_base_income,
@@ -1216,7 +1308,7 @@ index d5f5d72..1fcff15 100644
          )
          family_support_payable = (wff + mftc + best_start) > 0
          ietc1, ietc1_continuous = self.ietc_for_person(
-@@ -2129,7 +2727,7 @@ class ModelEvaluator:
+@@ -2129,7 +2784,7 @@ class ModelEvaluator:
          )
          ietc2 = D0
          ietc2_continuous = D0
@@ -1225,7 +1317,7 @@ index d5f5d72..1fcff15 100644
              ietc2, ietc2_continuous = self.ietc_for_person(
                  scenario=scenario,
                  person=2,
-@@ -2137,8 +2735,32 @@ class ModelEvaluator:
+@@ -2137,8 +2792,33 @@ class ModelEvaluator:
                  weekly_benefit=benefit_components[1],
                  family_support_payable=family_support_payable,
              )
@@ -1242,6 +1334,7 @@ index d5f5d72..1fcff15 100644
 +            scenario,
 +            adult_scalars=adult_scalars,
 +            child_scalars=best_start_child_values,
++            child_gross_datasets=best_start_child_gross_datasets,
 +            family_scheme_income=family_scheme_income,
 +        )
 +        ietc = dec(final_aggregate["scalars"]["ietc_weekly"])
@@ -1260,7 +1353,7 @@ index d5f5d72..1fcff15 100644
          winter_energy = self.winter_energy_average(scenario, net_benefit)
          (
              as_unrounded,
-@@ -2192,9 +2814,6 @@ class ModelEvaluator:
+@@ -2192,9 +2872,6 @@ class ModelEvaluator:
              "IETC_abated": ietc,
              "WinterEnergy": winter_energy,
              "BestStart_Total": best_start,
@@ -1270,7 +1363,7 @@ index d5f5d72..1fcff15 100644
              "BestStart_Total_continuous_abatement": (
                  best_start_continuous
              ),
-@@ -2214,6 +2833,13 @@ class ModelEvaluator:
+@@ -2214,6 +2891,13 @@ class ModelEvaluator:
              "wage2_ACC_levy": acc2,
              "net_wage2": net_wage2,
              "family_scheme_income": scalar_decimal(family_values, FSI_OUTPUT),
@@ -1284,7 +1377,7 @@ index d5f5d72..1fcff15 100644
              "WFF_abated_continuous_abatement": continuous_wff,
              "IETC_abated_continuous_abatement": ietc_continuous,
              "iwtc_entitlement": str(
-@@ -2267,16 +2893,6 @@ def sweep_scenario(
+@@ -2267,16 +2951,6 @@ def sweep_scenario(
                  following_state, "AS_Amount_treasury_host_aligned"
              )
          )
@@ -1301,7 +1394,7 @@ index d5f5d72..1fcff15 100644
          recomposed_emtr = sum(
              (
                  scalar_decimal(state, f"RuleSpec_EMTR_{component}")
-@@ -2337,7 +2953,7 @@ def sweep_scenario(
+@@ -2337,7 +3011,7 @@ def sweep_scenario(
          )
          net_income = scalar_decimal(state, "Net_Income")
          state["RR"] = baseline / net_income if net_income != 0 else None
@@ -1310,7 +1403,7 @@ index d5f5d72..1fcff15 100644
          state["PTR"] = (
              D1 - (net_income - baseline) / gross_income
              if gross_income != 0
-@@ -2452,38 +3068,30 @@ def validate_expanded_coverage(
+@@ -2452,38 +3126,30 @@ def validate_expanded_coverage(
              "treasury": dec(
                  treasury_state(best_start_id, wage)["BestStart_Total"]
              ),
@@ -1361,7 +1454,7 @@ index d5f5d72..1fcff15 100644
 
      dual_id = "couple_two_children_dual_full_time"
      dual_state = sweeps[dual_id][740]
-@@ -2533,6 +3141,25 @@ def validate_expanded_coverage(
+@@ -2533,6 +3199,25 @@ def validate_expanded_coverage(
              "RuleSpec boarder path did not convert $400 to $248"
          )
 
@@ -1387,7 +1480,7 @@ index d5f5d72..1fcff15 100644
      large_id = "large_family_four_children_age_bands"
      large_zero = sweeps[large_id][0]
      if (
-@@ -2565,7 +3192,7 @@ def validate_expanded_coverage(
+@@ -2565,7 +3250,7 @@ def validate_expanded_coverage(
          "sampled_point_count": sum(
              len(scenario.sampled_wages) for scenario in scenarios
          ),
@@ -1396,7 +1489,7 @@ index d5f5d72..1fcff15 100644
          "dual_full_time_partner_at_wage_740": {
              "primary_hours": scalar_decimal(dual_state, "hours1"),
              "partner_hours": scenario_by_id[dual_id].hours2,
-@@ -2593,6 +3220,7 @@ def validate_expanded_coverage(
+@@ -2593,6 +3278,7 @@ def validate_expanded_coverage(
          },
          "large_family_at_wage_0": {
              "children": scenario_by_id[large_id].children,
@@ -1404,7 +1497,7 @@ index d5f5d72..1fcff15 100644
              "rulespec_ftc": scalar_decimal(large_zero, "FTC_abated"),
              "rulespec_winter_energy": scalar_decimal(
                  large_zero, "WinterEnergy"
-@@ -3576,13 +4204,13 @@ def build_diagnostic_rows(
+@@ -3576,13 +4262,13 @@ def build_diagnostic_rows(
          "wage2_ACC_levy",
          "net_wage2",
          "family_scheme_income",
@@ -1420,7 +1513,7 @@ index d5f5d72..1fcff15 100644
          "EMTR_ACC_rounding_component",
          "EMTR_WFF_complete_dollar_component",
          "EMTR_BestStart_complete_dollar_component",
-@@ -3848,8 +4476,10 @@ def render_report(
+@@ -3848,8 +4534,10 @@ def render_report(
      oracle: Mapping[str, Any],
      provenance: Provenance,
      compiled_artifact_sha256: str,
@@ -1431,7 +1524,7 @@ index d5f5d72..1fcff15 100644
      scenarios: Sequence[Scenario],
      rows: Sequence[ComparisonRow],
      statistics: Mapping[str, Any],
-@@ -4012,9 +4642,9 @@ def render_report(
+@@ -4012,9 +4700,9 @@ def render_report(
              ),
              (
                  "| `couple_two_best_start_children_binding` | Two eligible "
@@ -1443,7 +1536,7 @@ index d5f5d72..1fcff15 100644
              ),
              (
                  "| `couple_two_children_dual_full_time` | Partner wage tax/ACC "
-@@ -4048,7 +4678,10 @@ def render_report(
+@@ -4048,7 +4736,10 @@ def render_report(
                  "| `large_family_four_children_age_bands` | Four children "
                  "aged 3, 6, 13, 16; FTC/IWTC subsequent-child scaling and "
                  "dependent Winter Energy rate | none | FTC and Winter Energy "
@@ -1455,7 +1548,7 @@ index d5f5d72..1fcff15 100644
                  f"is ${report_number(coverage_evidence['large_family_at_wage_0']['treasury_winter_energy'], 6)} / "
                  f"${report_number(coverage_evidence['large_family_at_wage_0']['rulespec_winter_energy'], 6)} weekly. |"
              ),
-@@ -4074,13 +4707,15 @@ def render_report(
+@@ -4074,13 +4765,15 @@ def render_report(
              "$248 to Treasury tests downstream arithmetic, not Treasury's "
              "missing 62% transformation. This remains a named coverage gap.",
              "",
@@ -1477,7 +1570,7 @@ index d5f5d72..1fcff15 100644
              "",
              "[Income Tax Act 2007 MG 1]"
              "(https://www.legislation.govt.nz/act/public/2007/0097/latest/"
-@@ -4096,24 +4731,23 @@ def render_report(
+@@ -4096,24 +4789,23 @@ def render_report(
              "the threshold reduces the one-, two-, and three-child family totals "
              "by the same amount, not once per child.",
              "",
@@ -1510,7 +1603,7 @@ index d5f5d72..1fcff15 100644
              f"{statistics['classification_counts']['a']} class-(a) cells.",
              "",
              "The prior four-family phase also fixed two host mappings before its "
-@@ -4260,13 +4894,20 @@ def render_report(
+@@ -4260,13 +4952,20 @@ def render_report(
              "SHA-pinned parameter file. Require a byte-identical regeneration "
              "of the original snapshot before generating the expanded oracle.",
              "2. Verify the Treasury, RuleSpec, and engine commits; generator, "
@@ -1537,7 +1630,7 @@ index d5f5d72..1fcff15 100644
              "incremental tax above grossed taxable benefit, matching raw "
              "`emtr()`.",
              "5. Evaluate the common wages `0, 160, 250, 370, 555, 740, 1000, "
-@@ -4284,6 +4925,10 @@ def render_report(
+@@ -4284,6 +4983,10 @@ def render_report(
              "`WFF_or_Benefit: Max` wrapper can select between transfers. This "
              "audit deliberately calls raw `emtr()` on both the continuity and "
              "expanded grids.",
@@ -1548,7 +1641,7 @@ index d5f5d72..1fcff15 100644
              "",
              "## Coverage gaps",
              "",
-@@ -4300,14 +4945,15 @@ def render_report(
+@@ -4300,14 +5003,15 @@ def render_report(
              "assets, social housing, duplicate claims, and take-up.",
              "- Full WFF child eligibility: principal caregiver, residence, "
              "shared care, exact birth/due dates, parental leave, and part-year "
@@ -1569,7 +1662,7 @@ index d5f5d72..1fcff15 100644
              "- The IncomeExplorer UI wrapper, population representativeness, "
              "non-integer wage kinks, or exhaustive threshold coverage. RR and "
              "PTR are emitted in `secondary_rates.csv` but remain outside the "
-@@ -4334,12 +4980,18 @@ def render_report(
+@@ -4334,12 +5038,18 @@ def render_report(
              f"| Engine source commit | `{provenance.engine_sha}` |",
              f"| Engine binary SHA-256 | `{provenance.engine_binary_sha256}` |",
              f"| Composition SHA-256 | `{provenance.composition_sha256}` |",
@@ -1588,7 +1681,7 @@ index d5f5d72..1fcff15 100644
              "| Tax-year interval | `2026-04-01` to `2027-03-31` |",
              "| Expanded snapshot `generated_at` | `2026-07-29` |",
              "",
-@@ -4411,6 +5063,7 @@ def build_audit_artifacts(
+@@ -4411,6 +5121,7 @@ def build_audit_artifacts(
      engine_binary: Path,
      treasury_root: Path,
      composition_path: Path,
@@ -1596,7 +1689,7 @@ index d5f5d72..1fcff15 100644
      eligibility_closures_path: Path,
      oracle_generator: Path,
      rscript: Path,
-@@ -4432,6 +5085,7 @@ def build_audit_artifacts(
+@@ -4432,6 +5143,7 @@ def build_audit_artifacts(
          engine_binary=engine_binary,
          treasury_root=treasury_root,
          composition_path=composition_path,
@@ -1604,7 +1697,7 @@ index d5f5d72..1fcff15 100644
          eligibility_closures_path=eligibility_closures_path,
          eligibility_closures=eligibility_closures,
          oracle_generator=oracle_generator,
-@@ -4441,13 +5095,19 @@ def build_audit_artifacts(
+@@ -4441,13 +5153,19 @@ def build_audit_artifacts(
      with tempfile.TemporaryDirectory(prefix="axiom-emtr-fresh-") as raw_temp:
          temp_root = Path(raw_temp)
          compiled_path = temp_root / "composition.json"
@@ -1624,7 +1717,7 @@ index d5f5d72..1fcff15 100644
          compiled_counts = {
              "derived_outputs": len(compiled["program"]["derived"]),
              "parameters": len(compiled["program"]["parameters"]),
-@@ -4587,6 +5247,12 @@ def build_audit_artifacts(
+@@ -4587,6 +5305,12 @@ def build_audit_artifacts(
                  **compiled_counts,
                  "artifact_sha256": compiled_artifact_sha256,
                  "engine_evaluations": engine.call_count,
@@ -1637,7 +1730,7 @@ index d5f5d72..1fcff15 100644
              },
              "exercise_input_catalog": {
                  slot: {
-@@ -4668,8 +5334,10 @@ def build_audit_artifacts(
+@@ -4668,8 +5392,10 @@ def build_audit_artifacts(
              oracle=oracle,
              provenance=provenance,
              compiled_artifact_sha256=compiled_artifact_sha256,
@@ -1648,7 +1741,7 @@ index d5f5d72..1fcff15 100644
              scenarios=scenarios,
              rows=comparison_rows,
              statistics=statistics,
-@@ -4725,7 +5393,11 @@ def build_audit_artifacts(
+@@ -4725,7 +5451,11 @@ def build_audit_artifacts(
              "headline": machine_payload["headline"],
              "statistics": statistics,
              "compiled_artifact_sha256": compiled_artifact_sha256,
@@ -1660,7 +1753,7 @@ index d5f5d72..1fcff15 100644
              "artifact_names": tuple(sorted(artifacts)),
          }
          return artifacts, run_summary
-@@ -4800,6 +5472,15 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+@@ -4800,6 +5530,15 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
          type=Path,
          default=DEFAULT_COMPOSITION,
      )
@@ -1676,7 +1769,7 @@ index d5f5d72..1fcff15 100644
      parser.add_argument(
          "--eligibility-closures",
          type=Path,
-@@ -4830,6 +5511,15 @@ def main(argv: Sequence[str] | None = None) -> int:
+@@ -4830,6 +5569,15 @@ def main(argv: Sequence[str] | None = None) -> int:
          if args.engine_binary is not None
          else args.engine_root / "target" / "release" / "axiom-rules-engine"
      )
@@ -1692,7 +1785,7 @@ index d5f5d72..1fcff15 100644
      try:
          first, summary = build_audit_artifacts(
              rulespec_root=args.rulespec_root,
-@@ -4837,6 +5527,7 @@ def main(argv: Sequence[str] | None = None) -> int:
+@@ -4837,6 +5585,7 @@ def main(argv: Sequence[str] | None = None) -> int:
              engine_binary=engine_binary,
              treasury_root=args.treasury_root,
              composition_path=args.composition,
@@ -1700,7 +1793,7 @@ index d5f5d72..1fcff15 100644
              eligibility_closures_path=args.eligibility_closures,
              oracle_generator=args.oracle_generator,
              rscript=args.rscript,
-@@ -4848,6 +5539,7 @@ def main(argv: Sequence[str] | None = None) -> int:
+@@ -4848,6 +5597,7 @@ def main(argv: Sequence[str] | None = None) -> int:
              engine_binary=engine_binary,
              treasury_root=args.treasury_root,
              composition_path=args.composition,
@@ -1737,7 +1830,7 @@ index f66e5e0..5fb441b 100644
        "iwtc_allowed_paye_income_payment_when_wages_positive": true,
        "iwtc_normally_earner_when_wages_positive": true,
 diff --git a/nz-lane/emtr_reproduction/test_declared_closures.py b/nz-lane/emtr_reproduction/test_declared_closures.py
-index cc2dedf..8e7b32c 100644
+index cc2dedf..fc9a843 100644
 --- a/nz-lane/emtr_reproduction/test_declared_closures.py
 +++ b/nz-lane/emtr_reproduction/test_declared_closures.py
 @@ -1,7 +1,10 @@
@@ -1751,7 +1844,7 @@ index cc2dedf..8e7b32c 100644
  import sys
  from pathlib import Path
 
-@@ -35,3 +38,339 @@ def test_incomplete_declared_closures_fail(tmp_path):
+@@ -35,3 +38,364 @@ def test_incomplete_declared_closures_fail(tmp_path):
      path.write_text(json.dumps(mutant))
      with pytest.raises(harness.HarnessError, match="work_tests"):
          harness.load_eligibility_closures(path)
@@ -1915,6 +2008,8 @@ index cc2dedf..8e7b32c 100644
 +                    {
 +                        "format": "axiom/compiled-unit-aggregation-stage3/1",
 +                        "plan_digest": "sha256:registered",
++                        "source_artifact_digest": "sha256:source",
++                        "source_artifact": {"artifact_format_version": 2},
 +                        "phase_two_artifact": {"format_version": 2},
 +                    }
 +                )
@@ -1931,7 +2026,12 @@ index cc2dedf..8e7b32c 100644
 +        aggregation_artifact=aggregation_artifact,
 +    )
 +    assert engine.aggregation_artifact == aggregation_artifact
-+    assert any("compile-unit-aggregation" in command for command in commands)
++    aggregation_compile = next(
++        command for command in commands if "compile-unit-aggregation" in command
++    )
++    assert aggregation_compile[
++        aggregation_compile.index("--source-artifact") + 1
++    ] == str(composition_artifact)
 +
 +
 +def test_indeterminate_aggregation_result_never_becomes_a_default():
@@ -1992,6 +2092,20 @@ index cc2dedf..8e7b32c 100644
 +            self.request = request
 +            return {"engine": "boundary-only"}
 +
++        def dataset(self, *, entity, entity_id, inputs):
++            return {
++                "inputs": [
++                    {
++                        "slot": slot,
++                        "value": str(value),
++                        "entity": entity,
++                        "entity_id": entity_id,
++                    }
++                    for slot, value in sorted(inputs.items())
++                ],
++                "relations": [],
++            }
++
 +    engine = RecordingEngine()
 +    evaluator = object.__new__(harness.ModelEvaluator)
 +    evaluator.engine = engine
@@ -2048,6 +2162,10 @@ index cc2dedf..8e7b32c 100644
 +    partner = request["persons"][1]
 +    assert partner["scalars"]["weekly_wage"]["value"] == "740"
 +    for child in request["persons"][2:]:
++        assert "best_start_before_care_and_abatement" not in child["scalars"]
++        assert child["engine_computations"][
++            "best_start_before_care_and_abatement"
++        ]["dataset"]["inputs"]
 +        assert child["scalars"][
 +            "best_start_claimant_care_fraction"
 +        ]["value"] == "0.5"
@@ -2083,7 +2201,7 @@ index cc2dedf..8e7b32c 100644
 +    family_input = request["family_inputs"][0]
 +    assert family_input["anchor_person"] == "boundary:person:1"
 +    assert family_input["named_people"][
-+        "mc7_entitlement_holder"
++        "family_unit_reference_person"
 +    ]["value"] == "boundary:person:1"
 +    adjustment = family_input["scalars"]["best_start_family_abatement"]
 +    assert adjustment["status"] == "observations"

--- a/stage3-nz/parity-proof.json
+++ b/stage3-nz/parity-proof.json
@@ -1,0 +1,79 @@
+{
+  "schema": "axiom.stage3-nz.adversarial-cure-proof.v1",
+  "ops_harness_base_commit": "bcf631b5",
+  "certified_engine_commit": "d8d45a817b3700ed22ec49a9fcf1024aa6ed2198",
+  "certified_engine_binary_sha256": "c5a3d3d8b1fdb8480bef7cffc6dd85658ca1a48cf7ca70da968b7a46c1e8a430",
+  "engine_checkout_cleanliness": "tracked_and_untracked_nonignored",
+  "aggregation_plan_sha256": "4a0a53cdb3f6e41a3ac203e324c30871f967de397153f84c040c7d1de12a1ba3",
+  "ops_harness_patch_sha256": "9a98f3def4f4a734d69ca9563ed3bb09ab90a3a2b36c7ef68ea87cd39a0d6bab",
+  "flag_off": {
+    "parent_commit": "74881519c829106e4e696d77b38e10ba61c881d8",
+    "parent_artifact_sha256": "355659bf30cef49c440d5fa24014f1bf6c9a17964befb164880196950462f3b2",
+    "current_artifact_sha256": "355659bf30cef49c440d5fa24014f1bf6c9a17964befb164880196950462f3b2",
+    "artifact_byte_identical": true,
+    "top_level_help_byte_identical": true,
+    "artifact_format_version": 2,
+    "derived_outputs": 176
+  },
+  "tests": {
+    "cargo_test_flag_off": {
+      "passed": 285,
+      "failed": 0,
+      "ignored": 0
+    },
+    "cargo_test_unit_derivation": {
+      "passed": 328,
+      "failed": 0,
+      "ignored": 0
+    },
+    "cargo_test_all_features": {
+      "passed": 344,
+      "failed": 0,
+      "ignored": 0
+    },
+    "copied_harness_mutants": {
+      "passed": 14,
+      "failed": 0
+    }
+  },
+  "parity": {
+    "external_invocations": 2,
+    "fresh_runs_per_invocation": 2,
+    "amount_control_cells": 1976,
+    "amount_control_cells_agree_to_cent": 1454,
+    "amount_control_cells_outside_cent": 522,
+    "outside_cent_by_class": {
+      "a": 0,
+      "b": 520,
+      "c": 2,
+      "d": 0,
+      "match": 0
+    },
+    "comparison_csv_sha256_run_1": "ccaa4dcb61b112587b47afb0e1892f670df354670fcd35f4d801edc621dd4bf2",
+    "comparison_csv_sha256_run_2": "ccaa4dcb61b112587b47afb0e1892f670df354670fcd35f4d801edc621dd4bf2",
+    "comparison_csv_sha256_prior_review": "ccaa4dcb61b112587b47afb0e1892f670df354670fcd35f4d801edc621dd4bf2",
+    "comparison_csv_byte_identical": true,
+    "compiled_program_artifact_sha256": "355659bf30cef49c440d5fa24014f1bf6c9a17964befb164880196950462f3b2",
+    "compiled_unit_aggregation_artifact_sha256": "dc1d368844e071c17649cd463568eca5e1d82eacf822694cce0ac45f1882fc41",
+    "ordinary_engine_evaluations_per_fresh_run": 881,
+    "unit_aggregation_evaluations_per_fresh_run": 1411,
+    "disposition_identity": {
+      "fields": [
+        "scenario_id",
+        "weekly_wage",
+        "column",
+        "classification",
+        "reason_code",
+        "reason_title"
+      ],
+      "run_1_count": 522,
+      "run_2_count": 522,
+      "prior_review_count": 522,
+      "canonical_sorted_set_sha256": "44063af7ec7c3a4dc6a296b70efc18914762a0d88e59594610e025c4d671e14e",
+      "only_in_run_1": [],
+      "only_in_run_2": [],
+      "only_in_run_1_vs_prior_review": [],
+      "only_in_prior_review_vs_run_1": []
+    }
+  }
+}

--- a/stage3-nz/parity-proof.json
+++ b/stage3-nz/parity-proof.json
@@ -1,13 +1,13 @@
 {
   "schema": "axiom.stage3-nz.adversarial-cure-proof.v1",
   "ops_harness_base_commit": "bcf631b5",
-  "certified_engine_commit": "d8d45a817b3700ed22ec49a9fcf1024aa6ed2198",
-  "certified_engine_binary_sha256": "c5a3d3d8b1fdb8480bef7cffc6dd85658ca1a48cf7ca70da968b7a46c1e8a430",
+  "certified_engine_commit": "d9069693e92ee338ab2c1d62461e73bcb02f195d",
+  "certified_engine_binary_sha256": "3a37cd2bfa570569252b97ac0f563fcf089fd97f43b208943c15ae28bb445e34",
   "engine_checkout_cleanliness": "tracked_and_untracked_nonignored",
-  "aggregation_plan_sha256": "4a0a53cdb3f6e41a3ac203e324c30871f967de397153f84c040c7d1de12a1ba3",
-  "ops_harness_patch_sha256": "9a98f3def4f4a734d69ca9563ed3bb09ab90a3a2b36c7ef68ea87cd39a0d6bab",
+  "aggregation_plan_sha256": "311f64cb64c3b5a4b0f49fd2ff634cda43cb327d4a148683784a8fe1705787a6",
+  "ops_harness_patch_sha256": "11018bb4eb935bbb27ac1ce80e5dd008da045d0d28827c64cf0dfbbb6745087a",
   "flag_off": {
-    "parent_commit": "74881519c829106e4e696d77b38e10ba61c881d8",
+    "parent_commit": "d32cf980bdd5a3b7a7e582604dffa90687784b69",
     "parent_artifact_sha256": "355659bf30cef49c440d5fa24014f1bf6c9a17964befb164880196950462f3b2",
     "current_artifact_sha256": "355659bf30cef49c440d5fa24014f1bf6c9a17964befb164880196950462f3b2",
     "artifact_byte_identical": true,
@@ -22,12 +22,12 @@
       "ignored": 0
     },
     "cargo_test_unit_derivation": {
-      "passed": 328,
+      "passed": 331,
       "failed": 0,
       "ignored": 0
     },
     "cargo_test_all_features": {
-      "passed": 344,
+      "passed": 347,
       "failed": 0,
       "ignored": 0
     },
@@ -54,7 +54,7 @@
     "comparison_csv_sha256_prior_review": "ccaa4dcb61b112587b47afb0e1892f670df354670fcd35f4d801edc621dd4bf2",
     "comparison_csv_byte_identical": true,
     "compiled_program_artifact_sha256": "355659bf30cef49c440d5fa24014f1bf6c9a17964befb164880196950462f3b2",
-    "compiled_unit_aggregation_artifact_sha256": "dc1d368844e071c17649cd463568eca5e1d82eacf822694cce0ac45f1882fc41",
+    "compiled_unit_aggregation_artifact_sha256": "46d9bb6cbd03d69cde3419b409225e62f23f43056fc9133340b0c7138eba4f2c",
     "ordinary_engine_evaluations_per_fresh_run": 881,
     "unit_aggregation_evaluations_per_fresh_run": 1411,
     "disposition_identity": {

--- a/stage3-nz/probes/mixed_evidence_probe.sh
+++ b/stage3-nz/probes/mixed_evidence_probe.sh
@@ -1,0 +1,63 @@
+#!/bin/sh
+set -eu
+
+repo_root=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
+engine="$repo_root/target/debug/axiom-rules-engine"
+plan="$repo_root/tests/fixtures/unit_derivation/nz_income_explorer_family.yaml"
+request="$repo_root/tests/fixtures/unit_derivation/nz_income_explorer_request.json"
+scratch=$(mktemp -d "${TMPDIR:-/tmp}/axiom-stage3-mixed-evidence.XXXXXX")
+trap 'rm -rf "$scratch"' EXIT HUP INT TERM
+scratch=$(CDPATH= cd -- "$scratch" && pwd -P)
+
+rulespec_root="$scratch/rulespec-nz"
+source_program="$rulespec_root/nz/statutes/income_tax/family_scheme/tax_credits.yaml"
+mkdir -p "$(dirname -- "$source_program")"
+cp "$repo_root/tests/fixtures/unit_derivation/nz_best_start_gross.rulespec.yaml" "$source_program"
+
+"$engine" compile \
+  --program "$source_program" \
+  --rulespec-root "$rulespec_root" \
+  --output "$scratch/source.json" >/dev/null
+"$engine" compile-unit-aggregation \
+  --plan "$plan" \
+  --source-artifact "$scratch/source.json" \
+  --output "$scratch/aggregation.json" >/dev/null
+
+result=$(
+  jq '
+    (.persons[] | select(.id == "child-0") |
+      .scalars.best_start_claimant_care_fraction) = {
+        "status": "conflict",
+        "observations": [
+          {"value": "1", "evidence": {"id": "mixed:care:full"}},
+          {"value": "0.5", "evidence": {"id": "mixed:care:half"}}
+        ]
+      }
+    | (.persons[] | select(.id == "child-1") | .age_years) = {
+        "status": "unknown",
+        "evidence": {"id": "mixed:age:unknown"}
+      }
+  ' "$request" |
+    "$engine" run-unit-aggregation \
+      --artifact "$scratch/aggregation.json" \
+      --enable-experimental-unit-derivation
+)
+
+printf '%s\n' "$result" | jq -e '
+  .families.status == "indeterminate"
+  and .families.value[0].members == ["child-0", "child-1", "partner", "primary"]
+  and [.families.value[0].children[].person] == ["child-0", "child-1"]
+  and (.families.value[0].children[0].scalars.best_start_claimant_care_fraction.status == "indeterminate")
+  and (.families.value[0].scalars.best_start_total.status == "indeterminate")
+  and (.families.value[0].counts.dependent_child_count.status == "indeterminate")
+  and (.families.value[0].counts.youngest_child_age.status == "indeterminate")
+' >/dev/null
+
+printf '%s\n' "$result" | jq '{
+  families_status: .families.status,
+  members: .families.value[0].members,
+  children: [.families.value[0].children[].person],
+  best_start_total: .families.value[0].scalars.best_start_total.status,
+  dependent_child_count: .families.value[0].counts.dependent_child_count.status,
+  youngest_child_age: .families.value[0].counts.youngest_child_age.status
+}'

--- a/stage3-nz/sol-stage3-final.md
+++ b/stage3-nz/sol-stage3-final.md
@@ -1,0 +1,272 @@
+# Stage-3 NZ final verification cures
+
+Audit basis: `stage3-nz/sol-verify-r3.md`, read end to end before changes.
+Only its open findings 1, 2, and 6 were changed. Findings 3, 4, 5, and 7
+were rechecked after the cures.
+
+- Starting audit commit: `d32cf980bdd5a3b7a7e582604dffa90687784b69`
+- Final implementation commit: `d9069693e92ee338ab2c1d62461e73bcb02f195d`
+- Ops harness base, read only: `bcf631b5`
+- Release binary SHA-256: `3a37cd2bfa570569252b97ac0f563fcf089fd97f43b208943c15ae28bb445e34`
+- Harness patch SHA-256: `11018bb4eb935bbb27ac1ce80e5dd008da045d0d28827c64cf0dfbbb6745087a`
+
+No push or PR was made. No `PROGRESS.md` was created, edited, deleted, or
+materialized. Clean-checkout builds used `git archive` into scratch trees with
+the tracked root `PROGRESS.md` explicitly excluded.
+
+## Cure 1 — typed child-gross provenance
+
+### Implementation
+
+The aggregation plan now binds every `ChildGrossAmount` to a public numeric,
+Child-scoped rule in a production-validated compiled source artifact. The
+compiled aggregation artifact embeds and digests that source artifact, and its
+surfaced plan digest binds both the canonical plan and the source-artifact
+digest. Coordinated source changes therefore change the plan identity.
+
+The materialization layer maintains a private `OperandProvenance` index:
+
+- request scalars are always `RequestSupplied`;
+- only successful execution of the bound embedded engine artifact constructs
+  `EngineComputed { source_artifact_digest, rule_id, stage: Gross }`;
+- supplying a scalar and a same-name computation recipe leaves the operand
+  request-supplied; and
+- the family reduction compares the exact marker before reading any child
+  gross operand.
+
+The named rejection is:
+
+```text
+InvalidChildGrossProvenance {
+  operation,
+  input,
+  child,
+  expected,
+  found,
+}
+```
+
+For the committed audit reproduction it renders:
+
+```text
+child-gross operand `best_start_after_per_child_abatement` for `best_start_total` on child `child-0` has provenance `request_supplied`, expected `engine_computed(source_artifact=sha256:60cf4aef86b144b9acf65cdf9c1f0c43a29b03122858d9a44b2f716ed3aa5525,rule_id=nz:statutes/income_tax/family_scheme/tax_credits#best_start_tax_credit_before_abatement,stage=gross)`
+```
+
+Committed regressions:
+
+- `renamed_child_gross_plan.yaml`, SHA-256
+  `5f649402d4d221cefbb11770daa72260ae6de0fe9ec757487ef3640d08657cbc`;
+- `renamed_child_gross_request.json`, SHA-256
+  `7648a58de650e2fa717ac18d8a3a6d758801617210fdcb95a650f5d9bd85e810`;
+- `relabelled_request_scalar_is_rejected_by_named_engine_provenance_guard`;
+- `request_scalar_cannot_launder_through_a_same_name_engine_recipe`; and
+- source-artifact, advertised-source-digest, plan, constitution, and phase
+  tamper mutants.
+
+The two audit comments were restored in `per_child_expressible.yaml`. Its exact
+SHA-256 is the required
+`39011e1c1f512d98c969b951ff91420d4996e18ccdea6770762611d51b49867d`.
+
+### Guard reversion
+
+This was repeated against an archive-derived copy of the final implementation.
+With only the provenance comparison changed to `false && ...`, the audit attack
+went green:
+
+```text
+mutant_exit=0
+families.status=determined
+best_start_total=6082
+best_start_total_before_abatement=6082
+plan_digest=sha256:b169151f941d7d891f75c5f0175a8703c0de1cc1f5d159af9e87a0cf7056e5a2
+```
+
+After restoring the comparison and rebuilding the same plan, the attack went
+red with exit 1 and the named error above. The plan digest remained
+`sha256:b169151f941d7d891f75c5f0175a8703c0de1cc1f5d159af9e87a0cf7056e5a2`.
+The scratch source then compared byte-for-byte with the committed source.
+
+## Cure 2 — family-level Knowledge propagation
+
+### Implementation
+
+The family envelope is now `AggregationFamilyKnowledge`, with exactly the two
+stage-2 statuses `determined` and `indeterminate`. Once family topology is
+known, an indeterminate envelope retains `value: Some(families)` so members and
+children remain complete. Its reasons are the sorted union of every consumed
+indeterminate partner value, scalar, count, predicate, child age, age-band
+value, and child scalar.
+
+The committed regression is
+`stage3-nz/probes/mixed_evidence_probe.sh`, backed by
+`mixed_conflict_care_and_unknown_age_indetermines_family_without_losing_topology`.
+It sets child 0 care to Conflict and child 1 age to Unknown and asserts the
+family status, reasons, scalars, counts, and exact topology.
+
+### Guard reversion
+
+With only the nonempty-reasons branch forced back to `determined`, the
+committed probe exited 1. The raw result reproduced the audit defect without
+losing topology:
+
+```text
+families_status=determined
+members=child-0,child-1,partner,primary
+children=child-0,child-1
+best_start_total=indeterminate
+dependent_child_count=indeterminate
+youngest_child_age=indeterminate
+```
+
+After restoring the branch, rebuilding, and rerunning the same probe:
+
+```text
+families_status=indeterminate
+members=child-0,child-1,partner,primary
+children=child-0,child-1
+best_start_total=indeterminate
+dependent_child_count=indeterminate
+youngest_child_age=indeterminate
+```
+
+The restored probe exited 0, and the scratch source compared byte-for-byte
+with the committed source.
+
+The five prior named Knowledge probes each passed one test:
+
+```text
+lifted_derived_relation_never_drops_unknown_or_conflict
+unknown_and_conflict_survive_derived_relation_gates_for_counts_and_sums
+indeterminate_relation_knowledge_cannot_produce_a_smaller_determined_family
+omitted_relation_is_unknown_but_evidenced_complete_empty_is_known_empty
+unknown_status_survives_materialization_and_indeterminates_phase_two_count
+```
+
+## Cure 3 — citation accuracy
+
+I checked each corrected citation against the official New Zealand Legislation
+text on 19 August 2026.
+
+- [MC 9](https://www.legislation.govt.nz/act/public/2007/0097/latest/DLM1518490.html)
+  was split into (1)(a), (1)(b), and (2)-(3). Its operative phrases are
+  “is not financially independent”, “is attending school or a tertiary
+  educational establishment”, and “The Commissioner must determine the
+  period”. The full conjunction is used only for age 18.
+- [YA 1](https://www.legislation.govt.nz/act/public/2007/0097/latest/DLM1520575.html)
+  now supplies ages 14-17: “is aged 15 years or less” and “is aged 16 or 17
+  years and is not financially independent”. Its age-18 branch says “is aged
+  18 years”, which the plan combines with the MC 9 facts.
+- [MC 10](https://www.legislation.govt.nz/act/public/2007/0097/latest/DLM1518492.html)
+  keeps principal-caregiver qualification at subsection (3), including
+  “totalling at least one-third”. The exclusive-care mechanic cites subsection
+  (4), whose operative phrase is “periods during which the principal caregiver
+  has exclusive care”.
+- [MD 10](https://www.legislation.govt.nz/act/public/2007/0097/latest/DLM1518534.html)
+  is now included for the applicable calculation: subsection (2) supplies the
+  formula introduced by “calculated using the formula”, and subsection (3)(d)
+  defines “weekly periods”.
+- [MC 7](https://www.legislation.govt.nz/act/public/2007/0097/latest/DLM1518486.html)
+  says “This section applies when a person has a spouse” and, outside IWTC,
+  “the Commissioner must determine which”. The plan no longer labels generic
+  partner presence as entitlement or selection. It instead accepts the family
+  unit's adult reference person for the declared caller-evidenced partner
+  relation, and explicitly leaves MC 7(1) applicability and MC 7(2) allocation
+  or Commissioner selection out of scope.
+
+These remain Tier-B plan inputs and cited limitations. No legal reading became
+an engine default. The exact citation regression
+`nz_tier_b_legal_choices_are_explicit_cited_inputs_and_limitations` passed.
+
+The source plan, request, expected result, four published schemas, CLI fixture,
+compiled source binding, and harness were regenerated. Relevant final values:
+
+- aggregation-plan file SHA-256:
+  `311f64cb64c3b5a4b0f49fd2ff634cda43cb327d4a148683784a8fe1705787a6`;
+- full compiled source artifact SHA-256:
+  `355659bf30cef49c440d5fa24014f1bf6c9a17964befb164880196950462f3b2`;
+- full compiled aggregation artifact SHA-256:
+  `46d9bb6cbd03d69cde3419b409225e62f23f43056fc9133340b0c7138eba4f2c`;
+- bound plan digest:
+  `sha256:7bf9c7984041b15bedcaeba32e282654a33de823594fef2eecd9989ccfd4cde2`;
+- bound source-artifact digest:
+  `sha256:5162363e74b0e5246e3da3d42513ccbbcc3dd42cf655e1c3a4b71540ae2888bd`;
+- constitution digest:
+  `sha256:94545f002fd9b1596e7186684c75b335a58e2d9a20a2871512f9b147565d9bc3`.
+
+## Preserved findings and test totals
+
+Finding 3 remained resolved:
+
+- `reviewer_best_start_plan_is_rejected_by_named_family_scope_guard`: 1 passed;
+- `every_stage3_structural_guard_kills_its_isolated_plan_mutant`: 1 passed,
+  covering all 11 isolated structural mutants.
+
+Finding 4 remained resolved. The final patch was applied to a fresh copy made
+from `git -C ops show`/the equivalent path-limited archive at `bcf631b5`; its
+dirty-checkout, unbound-binary, wrong-commit, wrong-digest, foreign-plan, and
+operational-boundary mutants all passed:
+
+```text
+python3 -m pytest -q test_declared_closures.py
+14 passed, 0 failed
+```
+
+Finding 5 remained resolved. The production registry/source loader, CLI exact
+fixture, source/plan/constitution/phase tamper test, duplicate registration,
+raw-sidecar rejection, and schemas passed. `schema_golden` passed 8 tests.
+
+Finding 7 remained resolved. Final full-suite reruns were:
+
+| Suite | Passed | Failed | Ignored |
+| --- | ---: | ---: | ---: |
+| flag off | 285 | 0 | 0 |
+| `unit-derivation` | 331 | 0 | 0 |
+| all features | 347 | 0 | 0 |
+| copied harness mutants | 14 | 0 | — |
+
+The flag-off current and parent (`d32cf980`) release binaries compiled the same
+176-output format-2 composition artifact byte-for-byte. Both artifact SHA-256
+values are
+`355659bf30cef49c440d5fa24014f1bf6c9a17964befb164880196950462f3b2`,
+and their top-level help was byte-identical.
+
+## End-to-end parity
+
+Two independent external invocations ran from the patched harness copy. Each
+invocation itself compiled and evaluated twice and byte-compared its two fresh
+passes.
+
+| Check | Run 1 | Run 2 |
+| --- | ---: | ---: |
+| amount/control cells agreeing to cent | 1,454 / 1,976 | 1,454 / 1,976 |
+| outside-cent dispositions | 522 | 522 |
+| class B / class C / class A / class D | 520 / 2 / 0 / 0 | 520 / 2 / 0 / 0 |
+| ordinary engine evaluations per pass | 881 | 881 |
+| unit-aggregation evaluations per pass | 1,411 | 1,411 |
+
+Both `comparison.csv` files are byte-identical, with SHA-256
+`ccaa4dcb61b112587b47afb0e1892f670df354670fcd35f4d801edc621dd4bf2`.
+The sorted disposition identity over `scenario_id`, `weekly_wage`, `column`,
+`classification`, `reason_code`, and `reason_title` contains the same 522 IDs
+in both runs and has SHA-256
+`44063af7ec7c3a4dc6a296b70efc18914762a0d88e59594610e025c4d671e14e`.
+
+The ordinary compiled artifact is the frozen
+`355659bf30cef49c440d5fa24014f1bf6c9a17964befb164880196950462f3b2`.
+The intentionally regenerated unit-aggregation artifact is
+`46d9bb6cbd03d69cde3419b409225e62f23f43056fc9133340b0c7138eba4f2c`.
+
+## Honesty notes
+
+- No comparison cell or disposition changed.
+- I do not claim the two external `comparison.json` files are byte-identical:
+  each truthfully embeds its own output-directory path. That one path causes
+  the corresponding external `SHA256SUMS` line to differ. The requested
+  `comparison.csv` files are byte-identical, all 522 disposition identities
+  are identical, and each invocation's two internal fresh passes compared all
+  generated artifacts byte-for-byte.
+- The ops repository remained read-only. The regenerated change exists only as
+  `stage3-nz/ops-harness.patch` and in scratch copies.
+- `d9069693e92ee338ab2c1d62461e73bcb02f195d` is the final implementation SHA
+  pinned by the binary and harness. The later certificate/report commit does
+  not alter implementation or harness execution.

--- a/tests/fixtures/unit_derivation/nz_best_start_gross.rulespec.yaml
+++ b/tests/fixtures/unit_derivation/nz_best_start_gross.rulespec.yaml
@@ -1,0 +1,39 @@
+format: rulespec/v1
+module:
+  summary: >-
+    Minimal source program used to exercise the stage-3 aggregation fixture's
+    engine-computed Best Start gross binding. The production harness binds the
+    same public rule id in the full NZ composition artifact.
+units:
+  - name: NZD
+    kind: currency
+    minor_units: 2
+rules:
+  - name: best_start_tax_credit_prescribed_amount
+    kind: parameter
+    dtype: Money
+    unit: NZD
+    versions:
+      - effective_from: '2026-04-01'
+        formula: '4041'
+  - name: wff_days_in_tax_year
+    kind: parameter
+    dtype: Integer
+    versions:
+      - effective_from: '2026-04-01'
+        formula: '365'
+  - name: best_start_tax_credit_before_abatement
+    kind: derived
+    entity: Child
+    dtype: Money
+    period: Year
+    unit: NZD
+    versions:
+      - effective_from: '2026-04-01'
+        formula: |-
+          (
+              best_start_tax_credit_prescribed_amount
+              * max(0, best_start_entitlement_days)
+              / wff_days_in_tax_year
+              * min(1, max(0, best_start_child_care_fraction))
+          )

--- a/tests/fixtures/unit_derivation/nz_income_explorer_family.yaml
+++ b/tests/fixtures/unit_derivation/nz_income_explorer_family.yaml
@@ -1,0 +1,128 @@
+# Experimental stage-3 plan for the pinned NZ IncomeExplorer comparison only.
+#
+# There is no Tier-B SNAP legal reading here. `partner_of` and
+# `dependent_child_of` are explicit, complete scenario facts. Their cited NZ
+# provisions determine which family/person or family/child projection consumes
+# those facts; the engine does not infer relationship status from age or income.
+schema: axiom/unit-aggregation-plan-stage3/1
+id: nz:incomeexplorer:family-aggregation-2026-27
+# Reproduce the pinned comparison's explicit Python Decimal context. This is a
+# numeric transport input, not a legal-family interpretation.
+decimal_precision: 40
+constitution:
+  id: nz:income-tax:family-unit-2026-27
+  entity_type: Family
+  roster_relation: nz:incomeexplorer#scenario_person
+  unit_constituent_relation: nz:incomeexplorer#family_member
+  participating_member_relation: nz:incomeexplorer#family_scheme_member
+membership_relations:
+  - relation: partner_of
+    symmetric: true
+    citation:
+      provision: Income Tax Act 2007 ss MB 2 and MC 2
+      authority: nz/statute/act/public/2007/0097/section/mb-2
+  - relation: dependent_child_of
+    symmetric: false
+    citation:
+      provision: Income Tax Act 2007 ss MC 2, MC 6, MC 9, and MC 10
+      authority: nz/statute/act/public/2007/0097/section/mc-2
+partner_relation: partner_of
+child_relation: dependent_child_of
+scalar_aggregations:
+  - output: weekly_wages
+    input: weekly_wage
+    selector: adults
+    citation: &mb2
+      provision: Income Tax Act 2007 s MB 2
+      authority: nz/statute/act/public/2007/0097/section/mb-2
+  - output: annual_wages
+    input: annual_wage
+    selector: adults
+    citation: *mb2
+  - output: annual_family_scheme_base_income
+    input: annual_family_scheme_base_income
+    selector: adults
+    citation: *mb2
+  - output: weekly_net_benefit
+    input: weekly_net_benefit
+    selector: adults
+    citation:
+      provision: Social Security Act 2018 main-benefit family rate provisions
+      authority: nz/statute/act/public/2018/0032/schedule/4
+  - output: weekly_gross_benefit
+    input: weekly_gross_benefit
+    selector: adults
+    citation: *mb2
+  - output: weekly_wage_tax
+    input: weekly_wage_tax
+    selector: adults
+    citation:
+      provision: Income Tax Act 2007 Schedule 1 and s MB 2
+      authority: nz/statute/act/public/2007/0097/schedule/1
+  - output: weekly_net_wage
+    input: weekly_net_wage
+    selector: adults
+    citation:
+      provision: Income Tax Act 2007 Schedule 1; Accident Compensation Act 2001 s 219
+      authority: nz/statute/act/public/2007/0097/schedule/1
+  - output: hours_total
+    input: weekly_hours
+    selector: adults
+    citation:
+      provision: Income Tax Act 2007 ss MD 9 and ME 1
+      authority: nz/statute/act/public/2007/0097/section/md-9
+  - output: ietc_weekly
+    input: ietc_weekly
+    selector: adults
+    citation:
+      provision: Income Tax Act 2007 s LC 13
+      authority: nz/statute/act/public/2007/0097/section/lc-13
+  - output: ietc_continuous_weekly
+    input: ietc_continuous_weekly
+    selector: adults
+    citation:
+      provision: Income Tax Act 2007 s LC 13
+      authority: nz/statute/act/public/2007/0097/section/lc-13
+child_counts:
+  - output: dependent_child_count
+    citation: &mc2
+      provision: Income Tax Act 2007 ss MC 2, MC 6, and MC 9
+      authority: nz/statute/act/public/2007/0097/section/mc-2
+  - output: best_start_eligible_child_count
+    minimum_age: 0
+    maximum_age: 2
+    citation:
+      provision: Income Tax Act 2007 ss MC 6(c), MC 8, MG 1, and MG 2
+      authority: nz/statute/act/public/2007/0097/section/mg-2
+  - output: child_count_age_0_13
+    minimum_age: 0
+    maximum_age: 13
+    citation: *mc2
+  - output: child_count_age_14_18
+    minimum_age: 14
+    maximum_age: 18
+    citation:
+      provision: Income Tax Act 2007 s MC 9(1)
+      authority: nz/statute/act/public/2007/0097/section/mc-9
+child_minima:
+  - output: youngest_child_age
+    input: age_years
+    empty_value: 0
+    citation: *mc2
+broadcasts:
+  - output: family_scheme_income
+    family_input: family_scheme_income
+    citation:
+      provision: Income Tax Act 2007 ss MB 2 and MG 3
+      authority: nz/statute/act/public/2007/0097/section/mg-3
+family_reductions:
+  - output: best_start_total
+    gross_output: best_start_total_before_abatement
+    operation: sum_children_then_subtract_family_once
+    child_value: best_start_before_abatement
+    family_once_value: best_start_family_abatement
+    minimum_age: 0
+    maximum_age: 2
+    citation:
+      provision: Income Tax Act 2007 ss MG 1, MG 2, and MG 3
+      authority: nz/statute/act/public/2007/0097/section/mg-3

--- a/tests/fixtures/unit_derivation/nz_income_explorer_family.yaml
+++ b/tests/fixtures/unit_derivation/nz_income_explorer_family.yaml
@@ -1,13 +1,8 @@
-# Experimental stage-3 plan for the pinned NZ IncomeExplorer comparison only.
-#
-# There is no Tier-B SNAP legal reading here. `partner_of` and
-# `dependent_child_of` are explicit, complete scenario facts. Their cited NZ
-# provisions determine which family/person or family/child projection consumes
-# those facts; the engine does not infer relationship status from age or income.
+# Experimental, compiled stage-3 plan for the pinned NZ IncomeExplorer
+# comparison. Tier-B legal determinations are explicit caller inputs; the
+# engine supplies no family, relationship, age-18, or care defaults.
 schema: axiom/unit-aggregation-plan-stage3/1
 id: nz:incomeexplorer:family-aggregation-2026-27
-# Reproduce the pinned comparison's explicit Python Decimal context. This is a
-# numeric transport input, not a legal-family interpretation.
 decimal_precision: 40
 constitution:
   id: nz:income-tax:family-unit-2026-27
@@ -15,85 +10,188 @@ constitution:
   roster_relation: nz:incomeexplorer#scenario_person
   unit_constituent_relation: nz:incomeexplorer#family_member
   participating_member_relation: nz:incomeexplorer#family_scheme_member
-membership_relations:
-  - relation: partner_of
-    symmetric: true
-    citation:
-      provision: Income Tax Act 2007 ss MB 2 and MC 2
-      authority: nz/statute/act/public/2007/0097/section/mb-2
-  - relation: dependent_child_of
-    symmetric: false
-    citation:
-      provision: Income Tax Act 2007 ss MC 2, MC 6, MC 9, and MC 10
-      authority: nz/statute/act/public/2007/0097/section/mc-2
-partner_relation: partner_of
-child_relation: dependent_child_of
-scalar_aggregations:
-  - output: weekly_wages
-    input: weekly_wage
-    selector: adults
+
+inputs:
+  - name: weekly_wage
+    scope: adult
+    kind: additive_amount
     citation: &mb2
       provision: Income Tax Act 2007 s MB 2
-      authority: nz/statute/act/public/2007/0097/section/mb-2
-  - output: annual_wages
-    input: annual_wage
-    selector: adults
+      authority: nz/statute/act/public/2007/0097/section/MB-2
+  - name: annual_wage
+    scope: adult
+    kind: additive_amount
     citation: *mb2
-  - output: annual_family_scheme_base_income
-    input: annual_family_scheme_base_income
-    selector: adults
+  - name: annual_family_scheme_base_income
+    scope: adult
+    kind: additive_amount
     citation: *mb2
-  - output: weekly_net_benefit
-    input: weekly_net_benefit
-    selector: adults
+  - name: weekly_net_benefit
+    scope: adult
+    kind: additive_amount
     citation:
       provision: Social Security Act 2018 main-benefit family rate provisions
       authority: nz/statute/act/public/2018/0032/schedule/4
-  - output: weekly_gross_benefit
-    input: weekly_gross_benefit
-    selector: adults
+  - name: weekly_gross_benefit
+    scope: adult
+    kind: additive_amount
     citation: *mb2
-  - output: weekly_wage_tax
-    input: weekly_wage_tax
-    selector: adults
+  - name: weekly_wage_tax
+    scope: adult
+    kind: additive_amount
     citation:
       provision: Income Tax Act 2007 Schedule 1 and s MB 2
       authority: nz/statute/act/public/2007/0097/schedule/1
-  - output: weekly_net_wage
-    input: weekly_net_wage
-    selector: adults
+  - name: weekly_net_wage
+    scope: adult
+    kind: additive_amount
     citation:
       provision: Income Tax Act 2007 Schedule 1; Accident Compensation Act 2001 s 219
       authority: nz/statute/act/public/2007/0097/schedule/1
-  - output: hours_total
-    input: weekly_hours
-    selector: adults
+  - name: weekly_hours
+    scope: adult
+    kind: additive_amount
     citation:
       provision: Income Tax Act 2007 ss MD 9 and ME 1
-      authority: nz/statute/act/public/2007/0097/section/md-9
-  - output: ietc_weekly
-    input: ietc_weekly
-    selector: adults
-    citation:
+      authority: nz/statute/act/public/2007/0097/section/MD-9
+  - name: ietc_weekly
+    scope: adult
+    kind: additive_amount
+    citation: &lc13
       provision: Income Tax Act 2007 s LC 13
-      authority: nz/statute/act/public/2007/0097/section/lc-13
-  - output: ietc_continuous_weekly
-    input: ietc_continuous_weekly
-    selector: adults
+      authority: nz/statute/act/public/2007/0097/section/LC-13
+  - name: ietc_continuous_weekly
+    scope: adult
+    kind: additive_amount
+    citation: *lc13
+  - name: best_start_before_care_and_abatement
+    scope: child
+    kind: child_gross_amount
+    reduction_key: best_start
+    citation: &mg2
+      provision: Income Tax Act 2007 ss MG 1 and MG 2
+      authority: nz/statute/act/public/2007/0097/section/MG-2
+  - name: best_start_claimant_care_fraction
+    scope: child
+    kind: care_fraction
+    citation: &mg25
+      provision: Income Tax Act 2007 s MG 2(5)
+      authority: nz/statute/act/public/2007/0097/section/MG-2
+  - name: in_work_tax_credit_child_exclusive_care_fraction
+    scope: child
+    kind: care_fraction
+    citation: &mc10
+      provision: Income Tax Act 2007 s MC 10(3)
+      authority: nz/statute/act/public/2007/0097/section/MC-10
+  - name: principal_care_for_family_scheme
+    scope: child
+    kind: eligibility_boolean
+    citation: &mc4
+      provision: Income Tax Act 2007 ss MC 4 and MC 10
+      authority: nz/statute/act/public/2007/0097/section/MC-4
+  - name: in_work_tax_credit_principal_caregiver
+    scope: child
+    kind: eligibility_boolean
+    citation: *mc10
+  - name: not_financially_independent_at_age_18
+    scope: child
+    kind: eligibility_boolean
+    citation: &mc9
+      provision: Income Tax Act 2007 s MC 9(1)(a)
+      authority: nz/statute/act/public/2007/0097/section/MC-9
+  - name: attending_school_or_tertiary_at_age_18
+    scope: child
+    kind: eligibility_boolean
     citation:
-      provision: Income Tax Act 2007 s LC 13
-      authority: nz/statute/act/public/2007/0097/section/lc-13
+      provision: Income Tax Act 2007 s MC 9(1)(b)
+      authority: nz/statute/act/public/2007/0097/section/MC-9
+  - name: commissioner_period_contains_segment_at_age_18
+    scope: child
+    kind: eligibility_boolean
+    citation:
+      provision: Income Tax Act 2007 s MC 9(2)-(3)
+      authority: nz/statute/act/public/2007/0097/section/MC-9
+  - name: family_scheme_income
+    scope: family
+    kind: family_amount
+    citation: &mg3
+      provision: Income Tax Act 2007 ss MB 2 and MG 3
+      authority: nz/statute/act/public/2007/0097/section/MG-3
+  - name: best_start_family_abatement
+    scope: family
+    kind: family_adjustment
+    reduction_key: best_start
+    citation: *mg3
+  - name: best_start_abatement_threshold
+    scope: family
+    kind: family_amount
+    citation: *mg3
+  - name: best_start_abatement_rate
+    scope: family
+    kind: decimal_rate
+    citation: *mg3
+
+membership_relations:
+  - relation: partner_of
+    direction: symmetric
+    left_role: partner
+    right_role: partner
+    citation: &partner_input
+      provision: Caller-evidenced spouse or partner classification used by Income Tax Act 2007 s MC 7
+      authority: nz/statute/act/public/2007/0097/section/MC-7
+  - relation: dependent_child_of
+    direction: directed
+    left_role: caregiver
+    right_role: child
+    citation:
+      provision: Caller-evidenced caregiver/dependent-child classification under Income Tax Act 2007 ss MC 4, MC 9, and MC 10
+      authority: nz/statute/act/public/2007/0097/section/MC-4
+partner_relation: partner_of
+child_relation: dependent_child_of
+partner_presence:
+  entitlement_holder_input: mc7_entitlement_holder
+  citation: &mc7
+    provision: Income Tax Act 2007 s MC 7
+    authority: nz/statute/act/public/2007/0097/section/MC-7
+  caller_determination: Caller supplies the MC 7 entitlement holder; the engine does not choose between partners or exercise Commissioner discretion.
+adult_selection:
+  operation: explicit_person_role
+  citation: &mc2
+    provision: Caller-evidenced adult role after dependent-child classification under Income Tax Act 2007 ss MC 2, MC 4, MC 9, and MC 10
+    authority: nz/statute/act/public/2007/0097/section/MC-2
+  caller_determination: Every person carries an evidenced adult or child role; the engine does not infer adulthood by taking the complement of child relations.
+age_18_conditions:
+  age: 18
+  not_financially_independent_input: not_financially_independent_at_age_18
+  attending_school_or_tertiary_input: attending_school_or_tertiary_at_age_18
+  commissioner_period_input: commissioner_period_contains_segment_at_age_18
+  citation: *mc9
+care:
+  principal_care_input: principal_care_for_family_scheme
+  claimant_care_fraction_input: best_start_claimant_care_fraction
+  citation: *mc4
+
+scalar_aggregations:
+  - { output: weekly_wages, input: weekly_wage, selector: adults, citation: *mb2 }
+  - { output: annual_wages, input: annual_wage, selector: adults, citation: *mb2 }
+  - { output: annual_family_scheme_base_income, input: annual_family_scheme_base_income, selector: adults, citation: *mb2 }
+  - { output: weekly_net_benefit, input: weekly_net_benefit, selector: adults, citation: { provision: Social Security Act 2018 main-benefit family rate provisions, authority: nz/statute/act/public/2018/0032/schedule/4 } }
+  - { output: weekly_gross_benefit, input: weekly_gross_benefit, selector: adults, citation: *mb2 }
+  - { output: weekly_wage_tax, input: weekly_wage_tax, selector: adults, citation: { provision: Income Tax Act 2007 Schedule 1 and s MB 2, authority: nz/statute/act/public/2007/0097/schedule/1 } }
+  - { output: weekly_net_wage, input: weekly_net_wage, selector: adults, citation: { provision: Income Tax Act 2007 Schedule 1; Accident Compensation Act 2001 s 219, authority: nz/statute/act/public/2007/0097/schedule/1 } }
+  - { output: hours_total, input: weekly_hours, selector: adults, citation: { provision: Income Tax Act 2007 ss MD 9 and ME 1, authority: nz/statute/act/public/2007/0097/section/MD-9 } }
+  - { output: ietc_weekly, input: ietc_weekly, selector: adults, citation: *lc13 }
+  - { output: ietc_continuous_weekly, input: ietc_continuous_weekly, selector: adults, citation: *lc13 }
+
 child_counts:
   - output: dependent_child_count
-    citation: &mc2
-      provision: Income Tax Act 2007 ss MC 2, MC 6, and MC 9
-      authority: nz/statute/act/public/2007/0097/section/mc-2
+    minimum_age: 0
+    maximum_age: 18
+    citation: *mc2
   - output: best_start_eligible_child_count
     minimum_age: 0
     maximum_age: 2
-    citation:
-      provision: Income Tax Act 2007 ss MC 6(c), MC 8, MG 1, and MG 2
-      authority: nz/statute/act/public/2007/0097/section/mg-2
+    citation: *mg2
   - output: child_count_age_0_13
     minimum_age: 0
     maximum_age: 13
@@ -101,28 +199,107 @@ child_counts:
   - output: child_count_age_14_18
     minimum_age: 14
     maximum_age: 18
-    citation:
-      provision: Income Tax Act 2007 s MC 9(1)
-      authority: nz/statute/act/public/2007/0097/section/mc-9
+    citation: *mc9
 child_minima:
   - output: youngest_child_age
     input: age_years
     empty_value: 0
     citation: *mc2
+
+family_predicates:
+  - output: has_dependent_children
+    operation: { kind: count_at_least, count: dependent_child_count, minimum: 1 }
+    citation: *mc2
+  - output: has_two_or_more_dependent_children
+    operation: { kind: count_at_least, count: dependent_child_count, minimum: 2 }
+    citation: *mc2
+  - output: youngest_child_age_at_least_14
+    operation: { kind: youngest_age_at_least, youngest: youngest_child_age, minimum: 14 }
+    citation:
+      provision: Social Security Act 2018 Schedule 4 lone-parent benefit age branch
+      authority: nz/statute/act/public/2018/0032/schedule/4
+  - output: sole_parent_with_dependent_children
+    operation: { kind: sole_parent_with_children, count: dependent_child_count }
+    citation: *mc2
+  - output: jss_sole_parent_youngest_age_at_least_14
+    operation: { kind: sole_parent_youngest_age_at_least, count: dependent_child_count, youngest: youngest_child_age, minimum: 14 }
+    citation:
+      provision: Social Security Act 2018 Schedule 4 lone-parent benefit age branch
+      authority: nz/statute/act/public/2018/0032/schedule/4
+
+family_shape_scalars:
+  - output: family_tax_credit_eldest_dependent_child_care_units
+    operation: { kind: eldest_care_units, count: dependent_child_count }
+    citation: *mc2
+  - output: family_tax_credit_subsequent_dependent_child_care_units
+    operation: { kind: subsequent_care_units, count: dependent_child_count }
+    citation: *mc2
+  - output: family_tax_credit_entitlement_days
+    operation: { kind: fixed_if_children, count: dependent_child_count, present: "365", absent: "0" }
+    citation: *mc2
+  - output: wff_family_credit_abatement_days
+    operation: { kind: fixed_if_children, count: dependent_child_count, present: "365", absent: "0" }
+    citation: *mg3
+  - output: in_work_tax_credit_weekly_periods
+    operation: { kind: fixed_if_children, count: dependent_child_count, present: "52", absent: "0" }
+    citation: *mc2
+  - output: best_start_entitlement_days
+    operation: { kind: fixed_if_children, count: best_start_eligible_child_count, present: "365", absent: "0" }
+    citation: *mg2
+
+child_agreements:
+  - output: in_work_tax_credit_child_exclusive_care_fraction
+    input: in_work_tax_credit_child_exclusive_care_fraction
+    eligible_if: in_work_tax_credit_principal_caregiver
+    empty_value: "0"
+    citation: *mc10
+child_projections:
+  - output: best_start_claimant_care_fraction
+    input: best_start_claimant_care_fraction
+    citation: *mg25
 broadcasts:
   - output: family_scheme_income
     family_input: family_scheme_income
-    citation:
-      provision: Income Tax Act 2007 ss MB 2 and MG 3
-      authority: nz/statute/act/public/2007/0097/section/mg-3
+    citation: *mg3
+
 family_reductions:
   - output: best_start_total
     gross_output: best_start_total_before_abatement
     operation: sum_children_then_subtract_family_once
-    child_value: best_start_before_abatement
-    family_once_value: best_start_family_abatement
+    reduction_key: best_start
+    child_gross_input: best_start_before_care_and_abatement
+    family_adjustment_input: best_start_family_abatement
+    care_fraction_input: best_start_claimant_care_fraction
     minimum_age: 0
     maximum_age: 2
+    continuous:
+      output: best_start_total_continuous_abatement
+      family_income_input: family_scheme_income
+      threshold_input: best_start_abatement_threshold
+      rate_input: best_start_abatement_rate
+    citation: *mg3
+
+limitations:
+  - id: mc7-entitlement-selection
+    statement: The caller must supply the person already determined to hold partner entitlement under MC 7; Commissioner choice and competing-partner eligibility are outside this aggregation plan.
+    citation: *mc7
+  - id: mc9-commissioner-period
+    statement: For an age-18 child the caller must explicitly state whether the Commissioner-determined MC 9 entitlement period contains the requested segment; omission remains Unknown.
+    citation: *mc9
+  - id: mg2-care-fact
+    statement: The caller supplies evidenced principal-care status and the claimant share after time in another qualifying person's exclusive care; no care fraction is defaulted.
+    citation: *mg25
+  - id: relationship-and-role-classification
+    statement: The caller supplies evidenced spouse/partner, caregiver/child, and adult/child classifications. MC 7 consolidates an already-classified spouse or partner entitlement; this plan does not decide whether a legal relationship or dependent-child status exists.
+    citation: *partner_input
+  - id: mc10-iwtc-care
+    statement: The caller separately supplies the MC 10(3) in-work-tax-credit exclusive-care fraction and principal-caregiver determination; the MG 2(5) Best Start care share is never reused for IWTC.
+    citation: *mc10
+  - id: pinned-full-period-scenario
+    statement: The 365-day and 52-week shape scalars are mechanics of the pinned full-year comparison scenario, not general entitlement-period determinations. The caller must choose a different plan for partial periods.
+    citation: *mc2
+  - id: jss-scenario-gate
+    statement: The sole-parent youngest-age-at-least-14 output is only the relationship/age gate consumed by the pinned Jobseeker Support scenario; it is not a complete Social Security Act entitlement determination.
     citation:
-      provision: Income Tax Act 2007 ss MG 1, MG 2, and MG 3
-      authority: nz/statute/act/public/2007/0097/section/mg-3
+      provision: Social Security Act 2018 Schedule 4 lone-parent benefit age branch
+      authority: nz/statute/act/public/2018/0032/schedule/4

--- a/tests/fixtures/unit_derivation/nz_income_explorer_request.json
+++ b/tests/fixtures/unit_derivation/nz_income_explorer_request.json
@@ -60,7 +60,6 @@
         "evidence": { "id": "age:child-0" }
       },
       "scalars": {
-        "best_start_before_care_and_abatement": { "status": "known", "value": "4041", "evidence": { "id": "scalar:child-0:best-start" } },
         "best_start_claimant_care_fraction": { "status": "known", "value": "1", "evidence": { "id": "scalar:child-0:care" } },
         "in_work_tax_credit_child_exclusive_care_fraction": { "status": "known", "value": "1", "evidence": { "id": "scalar:child-0:iwtc-care" } }
       },
@@ -70,6 +69,16 @@
         "in_work_tax_credit_principal_caregiver": { "status": "known", "value": true, "evidence": { "id": "iwtc-principal-care:child-0" } },
         "not_financially_independent_at_age_18": { "status": "known", "value": true, "evidence": { "id": "financial-dependence:child-0" } },
         "principal_care_for_family_scheme": { "status": "known", "value": true, "evidence": { "id": "principal-care:child-0" } }
+      },
+      "engine_computations": {
+        "best_start_before_care_and_abatement": {
+          "dataset": {
+            "inputs": [
+              { "name": "nz:statutes/income_tax/family_scheme/tax_credits#input.best_start_entitlement_days", "entity": "Child", "entity_id": "child-0", "interval": { "start": "2026-04-01", "end": "2027-03-31" }, "value": { "kind": "integer", "value": 365 } },
+              { "name": "nz:statutes/income_tax/family_scheme/tax_credits#input.best_start_child_care_fraction", "entity": "Child", "entity_id": "child-0", "interval": { "start": "2026-04-01", "end": "2027-03-31" }, "value": { "kind": "decimal", "value": "1" } }
+            ]
+          }
+        }
       }
     },
     {
@@ -82,7 +91,6 @@
         "evidence": { "id": "age:child-1" }
       },
       "scalars": {
-        "best_start_before_care_and_abatement": { "status": "known", "value": "4041", "evidence": { "id": "scalar:child-1:best-start" } },
         "best_start_claimant_care_fraction": { "status": "known", "value": "1", "evidence": { "id": "scalar:child-1:care" } },
         "in_work_tax_credit_child_exclusive_care_fraction": { "status": "known", "value": "1", "evidence": { "id": "scalar:child-1:iwtc-care" } }
       },
@@ -92,6 +100,16 @@
         "in_work_tax_credit_principal_caregiver": { "status": "known", "value": true, "evidence": { "id": "iwtc-principal-care:child-1" } },
         "not_financially_independent_at_age_18": { "status": "known", "value": true, "evidence": { "id": "financial-dependence:child-1" } },
         "principal_care_for_family_scheme": { "status": "known", "value": true, "evidence": { "id": "principal-care:child-1" } }
+      },
+      "engine_computations": {
+        "best_start_before_care_and_abatement": {
+          "dataset": {
+            "inputs": [
+              { "name": "nz:statutes/income_tax/family_scheme/tax_credits#input.best_start_entitlement_days", "entity": "Child", "entity_id": "child-1", "interval": { "start": "2026-04-01", "end": "2027-03-31" }, "value": { "kind": "integer", "value": 365 } },
+              { "name": "nz:statutes/income_tax/family_scheme/tax_credits#input.best_start_child_care_fraction", "entity": "Child", "entity_id": "child-1", "interval": { "start": "2026-04-01", "end": "2027-03-31" }, "value": { "kind": "decimal", "value": "1" } }
+            ]
+          }
+        }
       }
     }
   ],
@@ -128,10 +146,10 @@
       "anchor_person": "primary",
       "evidence": { "id": "family-input:primary" },
       "named_people": {
-        "mc7_entitlement_holder": {
+        "family_unit_reference_person": {
           "status": "known",
           "value": "primary",
-          "evidence": { "id": "mc7:primary" }
+          "evidence": { "id": "family-reference:primary" }
         }
       },
       "scalars": {

--- a/tests/fixtures/unit_derivation/nz_income_explorer_request.json
+++ b/tests/fixtures/unit_derivation/nz_income_explorer_request.json
@@ -1,0 +1,145 @@
+{
+  "scope": "scenario:binding-best-start",
+  "segment": "2026-04-01/2027-03-31",
+  "roster_completeness": { "id": "complete:roster" },
+  "segment_completeness": { "id": "complete:segment" },
+  "persons": [
+    {
+      "id": "primary",
+      "role": "adult",
+      "evidence": { "id": "person:primary" },
+      "age_years": {
+        "status": "known",
+        "value": 25,
+        "evidence": { "id": "age:primary" }
+      },
+      "scalars": {
+        "annual_family_scheme_base_income": { "status": "known", "value": "52000", "evidence": { "id": "scalar:primary:base-income" } },
+        "annual_wage": { "status": "known", "value": "52000", "evidence": { "id": "scalar:primary:annual-wage" } },
+        "ietc_continuous_weekly": { "status": "known", "value": "4", "evidence": { "id": "scalar:primary:ietc-continuous" } },
+        "ietc_weekly": { "status": "known", "value": "3", "evidence": { "id": "scalar:primary:ietc" } },
+        "weekly_gross_benefit": { "status": "known", "value": "13", "evidence": { "id": "scalar:primary:gross-benefit" } },
+        "weekly_hours": { "status": "known", "value": "40", "evidence": { "id": "scalar:primary:hours" } },
+        "weekly_net_benefit": { "status": "known", "value": "11", "evidence": { "id": "scalar:primary:net-benefit" } },
+        "weekly_net_wage": { "status": "known", "value": "899", "evidence": { "id": "scalar:primary:net-wage" } },
+        "weekly_wage": { "status": "known", "value": "1000.12345678901234567890123456789012345", "evidence": { "id": "scalar:primary:weekly-wage" } },
+        "weekly_wage_tax": { "status": "known", "value": "101", "evidence": { "id": "scalar:primary:wage-tax" } }
+      },
+      "facts": {}
+    },
+    {
+      "id": "partner",
+      "role": "adult",
+      "evidence": { "id": "person:partner" },
+      "age_years": {
+        "status": "known",
+        "value": 25,
+        "evidence": { "id": "age:partner" }
+      },
+      "scalars": {
+        "annual_family_scheme_base_income": { "status": "known", "value": "38480", "evidence": { "id": "scalar:partner:base-income" } },
+        "annual_wage": { "status": "known", "value": "38480", "evidence": { "id": "scalar:partner:annual-wage" } },
+        "ietc_continuous_weekly": { "status": "known", "value": "6", "evidence": { "id": "scalar:partner:ietc-continuous" } },
+        "ietc_weekly": { "status": "known", "value": "2", "evidence": { "id": "scalar:partner:ietc" } },
+        "weekly_gross_benefit": { "status": "known", "value": "5", "evidence": { "id": "scalar:partner:gross-benefit" } },
+        "weekly_hours": { "status": "known", "value": "20", "evidence": { "id": "scalar:partner:hours" } },
+        "weekly_net_benefit": { "status": "known", "value": "7", "evidence": { "id": "scalar:partner:net-benefit" } },
+        "weekly_net_wage": { "status": "known", "value": "669", "evidence": { "id": "scalar:partner:net-wage" } },
+        "weekly_wage": { "status": "known", "value": "740.87654321098765432109876543210987655", "evidence": { "id": "scalar:partner:weekly-wage" } },
+        "weekly_wage_tax": { "status": "known", "value": "71", "evidence": { "id": "scalar:partner:wage-tax" } }
+      },
+      "facts": {}
+    },
+    {
+      "id": "child-0",
+      "role": "child",
+      "evidence": { "id": "person:child-0" },
+      "age_years": {
+        "status": "known",
+        "value": 1,
+        "evidence": { "id": "age:child-0" }
+      },
+      "scalars": {
+        "best_start_before_care_and_abatement": { "status": "known", "value": "4041", "evidence": { "id": "scalar:child-0:best-start" } },
+        "best_start_claimant_care_fraction": { "status": "known", "value": "1", "evidence": { "id": "scalar:child-0:care" } },
+        "in_work_tax_credit_child_exclusive_care_fraction": { "status": "known", "value": "1", "evidence": { "id": "scalar:child-0:iwtc-care" } }
+      },
+      "facts": {
+        "attending_school_or_tertiary_at_age_18": { "status": "known", "value": true, "evidence": { "id": "education:child-0" } },
+        "commissioner_period_contains_segment_at_age_18": { "status": "known", "value": true, "evidence": { "id": "mc9-period:child-0" } },
+        "in_work_tax_credit_principal_caregiver": { "status": "known", "value": true, "evidence": { "id": "iwtc-principal-care:child-0" } },
+        "not_financially_independent_at_age_18": { "status": "known", "value": true, "evidence": { "id": "financial-dependence:child-0" } },
+        "principal_care_for_family_scheme": { "status": "known", "value": true, "evidence": { "id": "principal-care:child-0" } }
+      }
+    },
+    {
+      "id": "child-1",
+      "role": "child",
+      "evidence": { "id": "person:child-1" },
+      "age_years": {
+        "status": "known",
+        "value": 2,
+        "evidence": { "id": "age:child-1" }
+      },
+      "scalars": {
+        "best_start_before_care_and_abatement": { "status": "known", "value": "4041", "evidence": { "id": "scalar:child-1:best-start" } },
+        "best_start_claimant_care_fraction": { "status": "known", "value": "1", "evidence": { "id": "scalar:child-1:care" } },
+        "in_work_tax_credit_child_exclusive_care_fraction": { "status": "known", "value": "1", "evidence": { "id": "scalar:child-1:iwtc-care" } }
+      },
+      "facts": {
+        "attending_school_or_tertiary_at_age_18": { "status": "known", "value": true, "evidence": { "id": "education:child-1" } },
+        "commissioner_period_contains_segment_at_age_18": { "status": "known", "value": true, "evidence": { "id": "mc9-period:child-1" } },
+        "in_work_tax_credit_principal_caregiver": { "status": "known", "value": true, "evidence": { "id": "iwtc-principal-care:child-1" } },
+        "not_financially_independent_at_age_18": { "status": "known", "value": true, "evidence": { "id": "financial-dependence:child-1" } },
+        "principal_care_for_family_scheme": { "status": "known", "value": true, "evidence": { "id": "principal-care:child-1" } }
+      }
+    }
+  ],
+  "relations": [
+    {
+      "name": "partner_of",
+      "scope": "scenario:binding-best-start",
+      "completeness": { "id": "complete:partner-of" },
+      "facts": [
+        {
+          "tuple": ["primary", "partner"],
+          "knowledge": { "status": "known", "value": true, "evidence": { "id": "relation:partner:primary:partner" } }
+        }
+      ]
+    },
+    {
+      "name": "dependent_child_of",
+      "scope": "scenario:binding-best-start",
+      "completeness": { "id": "complete:dependent-child-of" },
+      "facts": [
+        {
+          "tuple": ["primary", "child-0"],
+          "knowledge": { "status": "known", "value": true, "evidence": { "id": "relation:child:primary:child-0" } }
+        },
+        {
+          "tuple": ["primary", "child-1"],
+          "knowledge": { "status": "known", "value": true, "evidence": { "id": "relation:child:primary:child-1" } }
+        }
+      ]
+    }
+  ],
+  "family_inputs": [
+    {
+      "anchor_person": "primary",
+      "evidence": { "id": "family-input:primary" },
+      "named_people": {
+        "mc7_entitlement_holder": {
+          "status": "known",
+          "value": "primary",
+          "evidence": { "id": "mc7:primary" }
+        }
+      },
+      "scalars": {
+        "best_start_abatement_rate": { "status": "known", "value": "0.1", "evidence": { "id": "best-start-rate" } },
+        "best_start_abatement_threshold": { "status": "known", "value": "80000", "evidence": { "id": "best-start-threshold" } },
+        "best_start_family_abatement": { "status": "known", "value": "1000", "evidence": { "id": "best-start-adjustment" } },
+        "family_scheme_income": { "status": "known", "value": "90480", "evidence": { "id": "family-income" } }
+      }
+    }
+  ]
+}

--- a/tests/fixtures/unit_derivation/nz_income_explorer_result.json
+++ b/tests/fixtures/unit_derivation/nz_income_explorer_result.json
@@ -1,13 +1,13 @@
 {
   "schema": "axiom/unit-aggregation-plan-stage3/1",
   "plan": "nz:incomeexplorer:family-aggregation-2026-27",
-  "plan_digest": "sha256:91324344f6eec3c64e34b99702cd7a0ac0e1a8402a2d8b814b58a672c708dc7c",
-  "trace_root": "sha256:af25a06a5aa58119a024f3d7aec51cb4d1fa754832569cf14e13976d2025f20e",
+  "plan_digest": "sha256:e0a833232e758efbe1da4a6212cb93906719e62a6f9298909169d71f1db64b6c",
+  "trace_root": "sha256:80ed812db8a13e57b708218c0d6a3320dd59915494374e1c942eb9cc06b34085",
   "families": {
     "status": "determined",
     "value": [
       {
-        "id": "Family:sha256:4c187a40837d65b23958d64aef28befd0ac5ce7704c39f19fe364d508b1bd7bd",
+        "id": "Family:sha256:60490911749d9bc93f5a692773d70ff5da97d9e86fcc5ea558f02faeabbca18d",
         "members": [
           "child-0",
           "child-1",
@@ -147,7 +147,7 @@
         "children": [
           {
             "person": "child-0",
-            "family": "Family:sha256:4c187a40837d65b23958d64aef28befd0ac5ce7704c39f19fe364d508b1bd7bd",
+            "family": "Family:sha256:60490911749d9bc93f5a692773d70ff5da97d9e86fcc5ea558f02faeabbca18d",
             "age_years": {
               "status": "determined",
               "value": 1
@@ -183,7 +183,7 @@
           },
           {
             "person": "child-1",
-            "family": "Family:sha256:4c187a40837d65b23958d64aef28befd0ac5ce7704c39f19fe364d508b1bd7bd",
+            "family": "Family:sha256:60490911749d9bc93f5a692773d70ff5da97d9e86fcc5ea558f02faeabbca18d",
             "age_years": {
               "status": "determined",
               "value": 2

--- a/tests/fixtures/unit_derivation/nz_income_explorer_result.json
+++ b/tests/fixtures/unit_derivation/nz_income_explorer_result.json
@@ -1,0 +1,224 @@
+{
+  "schema": "axiom/unit-aggregation-plan-stage3/1",
+  "plan": "nz:incomeexplorer:family-aggregation-2026-27",
+  "plan_digest": "sha256:91324344f6eec3c64e34b99702cd7a0ac0e1a8402a2d8b814b58a672c708dc7c",
+  "trace_root": "sha256:af25a06a5aa58119a024f3d7aec51cb4d1fa754832569cf14e13976d2025f20e",
+  "families": {
+    "status": "determined",
+    "value": [
+      {
+        "id": "Family:sha256:4c187a40837d65b23958d64aef28befd0ac5ce7704c39f19fe364d508b1bd7bd",
+        "members": [
+          "child-0",
+          "child-1",
+          "partner",
+          "primary"
+        ],
+        "partner_present": {
+          "status": "determined",
+          "value": true
+        },
+        "scalars": {
+          "annual_family_scheme_base_income": {
+            "status": "determined",
+            "value": "90480"
+          },
+          "annual_wages": {
+            "status": "determined",
+            "value": "90480"
+          },
+          "best_start_entitlement_days": {
+            "status": "determined",
+            "value": "365"
+          },
+          "best_start_total": {
+            "status": "determined",
+            "value": "7082"
+          },
+          "best_start_total_before_abatement": {
+            "status": "determined",
+            "value": "8082"
+          },
+          "best_start_total_continuous_abatement": {
+            "status": "determined",
+            "value": "7034"
+          },
+          "family_tax_credit_eldest_dependent_child_care_units": {
+            "status": "determined",
+            "value": "1"
+          },
+          "family_tax_credit_entitlement_days": {
+            "status": "determined",
+            "value": "365"
+          },
+          "family_tax_credit_subsequent_dependent_child_care_units": {
+            "status": "determined",
+            "value": "1"
+          },
+          "hours_total": {
+            "status": "determined",
+            "value": "60"
+          },
+          "ietc_continuous_weekly": {
+            "status": "determined",
+            "value": "10"
+          },
+          "ietc_weekly": {
+            "status": "determined",
+            "value": "5"
+          },
+          "in_work_tax_credit_child_exclusive_care_fraction": {
+            "status": "determined",
+            "value": "1"
+          },
+          "in_work_tax_credit_weekly_periods": {
+            "status": "determined",
+            "value": "52"
+          },
+          "weekly_gross_benefit": {
+            "status": "determined",
+            "value": "18"
+          },
+          "weekly_net_benefit": {
+            "status": "determined",
+            "value": "18"
+          },
+          "weekly_net_wage": {
+            "status": "determined",
+            "value": "1568"
+          },
+          "weekly_wage_tax": {
+            "status": "determined",
+            "value": "172"
+          },
+          "weekly_wages": {
+            "status": "determined",
+            "value": "1741"
+          },
+          "wff_family_credit_abatement_days": {
+            "status": "determined",
+            "value": "365"
+          }
+        },
+        "counts": {
+          "best_start_eligible_child_count": {
+            "status": "determined",
+            "value": 2
+          },
+          "child_count_age_0_13": {
+            "status": "determined",
+            "value": 2
+          },
+          "child_count_age_14_18": {
+            "status": "determined",
+            "value": 0
+          },
+          "dependent_child_count": {
+            "status": "determined",
+            "value": 2
+          },
+          "youngest_child_age": {
+            "status": "determined",
+            "value": 1
+          }
+        },
+        "predicates": {
+          "has_dependent_children": {
+            "status": "determined",
+            "value": true
+          },
+          "has_two_or_more_dependent_children": {
+            "status": "determined",
+            "value": true
+          },
+          "jss_sole_parent_youngest_age_at_least_14": {
+            "status": "determined",
+            "value": false
+          },
+          "sole_parent_with_dependent_children": {
+            "status": "determined",
+            "value": false
+          },
+          "youngest_child_age_at_least_14": {
+            "status": "determined",
+            "value": false
+          }
+        },
+        "children": [
+          {
+            "person": "child-0",
+            "family": "Family:sha256:4c187a40837d65b23958d64aef28befd0ac5ce7704c39f19fe364d508b1bd7bd",
+            "age_years": {
+              "status": "determined",
+              "value": 1
+            },
+            "age_bands": {
+              "best_start_eligible_child_count": {
+                "status": "determined",
+                "value": true
+              },
+              "child_count_age_0_13": {
+                "status": "determined",
+                "value": true
+              },
+              "child_count_age_14_18": {
+                "status": "determined",
+                "value": false
+              },
+              "dependent_child_count": {
+                "status": "determined",
+                "value": true
+              }
+            },
+            "scalars": {
+              "best_start_claimant_care_fraction": {
+                "status": "determined",
+                "value": "1"
+              },
+              "family_scheme_income": {
+                "status": "determined",
+                "value": "90480"
+              }
+            }
+          },
+          {
+            "person": "child-1",
+            "family": "Family:sha256:4c187a40837d65b23958d64aef28befd0ac5ce7704c39f19fe364d508b1bd7bd",
+            "age_years": {
+              "status": "determined",
+              "value": 2
+            },
+            "age_bands": {
+              "best_start_eligible_child_count": {
+                "status": "determined",
+                "value": true
+              },
+              "child_count_age_0_13": {
+                "status": "determined",
+                "value": true
+              },
+              "child_count_age_14_18": {
+                "status": "determined",
+                "value": false
+              },
+              "dependent_child_count": {
+                "status": "determined",
+                "value": true
+              }
+            },
+            "scalars": {
+              "best_start_claimant_care_fraction": {
+                "status": "determined",
+                "value": "1"
+              },
+              "family_scheme_income": {
+                "status": "determined",
+                "value": "90480"
+              }
+            }
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/fixtures/unit_derivation/per_child_expressible.yaml
+++ b/tests/fixtures/unit_derivation/per_child_expressible.yaml
@@ -41,6 +41,8 @@ family_reductions:
     citation:
       provision: Income Tax Act 2007 ss MG 1, MG 2, and MG 3
       authority: nz/statute/act/public/2007/0097/section/mg-3
+  # Even the sole nominally-safe reducer accepts a post-abatement child field
+  # and a caller-supplied zero as its "family once" field.
   - output: best_start_total
     gross_output: best_start_total_before_abatement
     operation: sum_children_then_subtract_family_once

--- a/tests/fixtures/unit_derivation/per_child_expressible.yaml
+++ b/tests/fixtures/unit_derivation/per_child_expressible.yaml
@@ -1,0 +1,63 @@
+schema: axiom/unit-aggregation-plan-stage3/1
+id: adversarial:per-child-abatement-is-expressible
+decimal_precision: 40
+constitution:
+  id: adversarial:nz-family
+  entity_type: Family
+  roster_relation: adversarial#roster
+  unit_constituent_relation: adversarial#family_member
+  participating_member_relation: adversarial#family_scheme_member
+membership_relations:
+  - relation: partner_of
+    symmetric: true
+    citation:
+      provision: test partner relationship
+      authority: adversarial:test
+  - relation: dependent_child_of
+    symmetric: false
+    citation:
+      provision: Income Tax Act 2007 ss MC 2 and MC 6
+      authority: nz/statute/act/public/2007/0097/section/mc-2
+partner_relation: partner_of
+child_relation: dependent_child_of
+scalar_aggregations:
+  # This is the old defect: the ordinary child calculation has already applied
+  # the family abatement once to each child, and the generic family sum accepts
+  # and sums those post-abatement person scalars without rejection.
+  - output: unsafe_best_start_total
+    input: post_abated_for_generic_sum
+    selector: all_members
+    citation:
+      provision: adversarial expression of the old per-child host reduction
+      authority: adversarial:test
+family_reductions:
+  - output: safe_best_start_total
+    gross_output: safe_best_start_gross
+    operation: sum_children_then_subtract_family_once
+    child_value: best_start_before_abatement
+    family_once_value: best_start_family_abatement
+    minimum_age: 0
+    maximum_age: 2
+    citation:
+      provision: Income Tax Act 2007 ss MG 1, MG 2, and MG 3
+      authority: nz/statute/act/public/2007/0097/section/mg-3
+  - output: best_start_total
+    gross_output: best_start_total_before_abatement
+    operation: sum_children_then_subtract_family_once
+    child_value: best_start_before_abatement
+    family_once_value: two_child_abatement
+    minimum_age: 0
+    maximum_age: 2
+    citation:
+      provision: adversarial expression using the nominally safe operator
+      authority: adversarial:test
+  - output: unsafe_post_abatement_via_family_once
+    gross_output: unsafe_post_abatement_via_family_once_gross
+    operation: sum_children_then_subtract_family_once
+    child_value: best_start_after_per_child_abatement
+    family_once_value: zero_family_abatement
+    minimum_age: 0
+    maximum_age: 2
+    citation:
+      provision: adversarial post-abatement child inputs through nominally safe operator
+      authority: adversarial:test

--- a/tests/fixtures/unit_derivation/per_child_request.json
+++ b/tests/fixtures/unit_derivation/per_child_request.json
@@ -1,0 +1,46 @@
+{
+  "scope": "scenario:adversarial-per-child",
+  "segment": "2026-04-01/2027-03-31",
+  "primary_person": "primary",
+  "persons": [
+    {
+      "id": "primary",
+      "age_years": 25,
+      "scalars": {
+        "post_abated_for_generic_sum": "0"
+      }
+    },
+    {
+      "id": "child-0",
+      "age_years": 1,
+      "scalars": {
+        "post_abated_for_generic_sum": "3041",
+        "best_start_after_per_child_abatement": "3041",
+        "best_start_before_abatement": "4041",
+        "best_start_family_abatement": "1000",
+        "two_child_abatement": "2000",
+        "zero_family_abatement": "0"
+      }
+    },
+    {
+      "id": "child-1",
+      "age_years": 2,
+      "scalars": {
+        "post_abated_for_generic_sum": "3041",
+        "best_start_after_per_child_abatement": "3041",
+        "best_start_before_abatement": "4041",
+        "best_start_family_abatement": "1000",
+        "two_child_abatement": "2000",
+        "zero_family_abatement": "0"
+      }
+    }
+  ],
+  "relations": {
+    "partner_of": [],
+    "dependent_child_of": [
+      ["primary", "child-0"],
+      ["primary", "child-1"]
+    ]
+  },
+  "family_scalars": {}
+}

--- a/tests/fixtures/unit_derivation/renamed_child_gross_plan.yaml
+++ b/tests/fixtures/unit_derivation/renamed_child_gross_plan.yaml
@@ -64,7 +64,7 @@ inputs:
     scope: adult
     kind: additive_amount
     citation: *lc13
-  - name: best_start_before_care_and_abatement
+  - name: best_start_after_per_child_abatement
     scope: child
     kind: child_gross_amount
     reduction_key: best_start
@@ -273,7 +273,7 @@ family_reductions:
     gross_output: best_start_total_before_abatement
     operation: sum_children_then_subtract_family_once
     reduction_key: best_start
-    child_gross_input: best_start_before_care_and_abatement
+    child_gross_input: best_start_after_per_child_abatement
     family_adjustment_input: best_start_family_abatement
     care_fraction_input: best_start_claimant_care_fraction
     minimum_age: 0

--- a/tests/fixtures/unit_derivation/renamed_child_gross_request.json
+++ b/tests/fixtures/unit_derivation/renamed_child_gross_request.json
@@ -1,0 +1,440 @@
+{
+  "scope": "scenario:binding-best-start",
+  "segment": "2026-04-01/2027-03-31",
+  "roster_completeness": {
+    "id": "complete:roster"
+  },
+  "segment_completeness": {
+    "id": "complete:segment"
+  },
+  "persons": [
+    {
+      "id": "primary",
+      "role": "adult",
+      "evidence": {
+        "id": "person:primary"
+      },
+      "age_years": {
+        "status": "known",
+        "value": 25,
+        "evidence": {
+          "id": "age:primary"
+        }
+      },
+      "scalars": {
+        "annual_family_scheme_base_income": {
+          "status": "known",
+          "value": "52000",
+          "evidence": {
+            "id": "scalar:primary:base-income"
+          }
+        },
+        "annual_wage": {
+          "status": "known",
+          "value": "52000",
+          "evidence": {
+            "id": "scalar:primary:annual-wage"
+          }
+        },
+        "ietc_continuous_weekly": {
+          "status": "known",
+          "value": "4",
+          "evidence": {
+            "id": "scalar:primary:ietc-continuous"
+          }
+        },
+        "ietc_weekly": {
+          "status": "known",
+          "value": "3",
+          "evidence": {
+            "id": "scalar:primary:ietc"
+          }
+        },
+        "weekly_gross_benefit": {
+          "status": "known",
+          "value": "13",
+          "evidence": {
+            "id": "scalar:primary:gross-benefit"
+          }
+        },
+        "weekly_hours": {
+          "status": "known",
+          "value": "40",
+          "evidence": {
+            "id": "scalar:primary:hours"
+          }
+        },
+        "weekly_net_benefit": {
+          "status": "known",
+          "value": "11",
+          "evidence": {
+            "id": "scalar:primary:net-benefit"
+          }
+        },
+        "weekly_net_wage": {
+          "status": "known",
+          "value": "899",
+          "evidence": {
+            "id": "scalar:primary:net-wage"
+          }
+        },
+        "weekly_wage": {
+          "status": "known",
+          "value": "1000.12345678901234567890123456789012345",
+          "evidence": {
+            "id": "scalar:primary:weekly-wage"
+          }
+        },
+        "weekly_wage_tax": {
+          "status": "known",
+          "value": "101",
+          "evidence": {
+            "id": "scalar:primary:wage-tax"
+          }
+        }
+      },
+      "facts": {}
+    },
+    {
+      "id": "partner",
+      "role": "adult",
+      "evidence": {
+        "id": "person:partner"
+      },
+      "age_years": {
+        "status": "known",
+        "value": 25,
+        "evidence": {
+          "id": "age:partner"
+        }
+      },
+      "scalars": {
+        "annual_family_scheme_base_income": {
+          "status": "known",
+          "value": "38480",
+          "evidence": {
+            "id": "scalar:partner:base-income"
+          }
+        },
+        "annual_wage": {
+          "status": "known",
+          "value": "38480",
+          "evidence": {
+            "id": "scalar:partner:annual-wage"
+          }
+        },
+        "ietc_continuous_weekly": {
+          "status": "known",
+          "value": "6",
+          "evidence": {
+            "id": "scalar:partner:ietc-continuous"
+          }
+        },
+        "ietc_weekly": {
+          "status": "known",
+          "value": "2",
+          "evidence": {
+            "id": "scalar:partner:ietc"
+          }
+        },
+        "weekly_gross_benefit": {
+          "status": "known",
+          "value": "5",
+          "evidence": {
+            "id": "scalar:partner:gross-benefit"
+          }
+        },
+        "weekly_hours": {
+          "status": "known",
+          "value": "20",
+          "evidence": {
+            "id": "scalar:partner:hours"
+          }
+        },
+        "weekly_net_benefit": {
+          "status": "known",
+          "value": "7",
+          "evidence": {
+            "id": "scalar:partner:net-benefit"
+          }
+        },
+        "weekly_net_wage": {
+          "status": "known",
+          "value": "669",
+          "evidence": {
+            "id": "scalar:partner:net-wage"
+          }
+        },
+        "weekly_wage": {
+          "status": "known",
+          "value": "740.87654321098765432109876543210987655",
+          "evidence": {
+            "id": "scalar:partner:weekly-wage"
+          }
+        },
+        "weekly_wage_tax": {
+          "status": "known",
+          "value": "71",
+          "evidence": {
+            "id": "scalar:partner:wage-tax"
+          }
+        }
+      },
+      "facts": {}
+    },
+    {
+      "id": "child-0",
+      "role": "child",
+      "evidence": {
+        "id": "person:child-0"
+      },
+      "age_years": {
+        "status": "known",
+        "value": 1,
+        "evidence": {
+          "id": "age:child-0"
+        }
+      },
+      "scalars": {
+        "best_start_claimant_care_fraction": {
+          "status": "known",
+          "value": "1",
+          "evidence": {
+            "id": "scalar:child-0:care"
+          }
+        },
+        "in_work_tax_credit_child_exclusive_care_fraction": {
+          "status": "known",
+          "value": "1",
+          "evidence": {
+            "id": "scalar:child-0:iwtc-care"
+          }
+        },
+        "best_start_after_per_child_abatement": {
+          "status": "known",
+          "value": "3041",
+          "evidence": {
+            "id": "audit:post-abated:child-0"
+          }
+        }
+      },
+      "facts": {
+        "attending_school_or_tertiary_at_age_18": {
+          "status": "known",
+          "value": true,
+          "evidence": {
+            "id": "education:child-0"
+          }
+        },
+        "commissioner_period_contains_segment_at_age_18": {
+          "status": "known",
+          "value": true,
+          "evidence": {
+            "id": "mc9-period:child-0"
+          }
+        },
+        "in_work_tax_credit_principal_caregiver": {
+          "status": "known",
+          "value": true,
+          "evidence": {
+            "id": "iwtc-principal-care:child-0"
+          }
+        },
+        "not_financially_independent_at_age_18": {
+          "status": "known",
+          "value": true,
+          "evidence": {
+            "id": "financial-dependence:child-0"
+          }
+        },
+        "principal_care_for_family_scheme": {
+          "status": "known",
+          "value": true,
+          "evidence": {
+            "id": "principal-care:child-0"
+          }
+        }
+      }
+    },
+    {
+      "id": "child-1",
+      "role": "child",
+      "evidence": {
+        "id": "person:child-1"
+      },
+      "age_years": {
+        "status": "known",
+        "value": 2,
+        "evidence": {
+          "id": "age:child-1"
+        }
+      },
+      "scalars": {
+        "best_start_claimant_care_fraction": {
+          "status": "known",
+          "value": "1",
+          "evidence": {
+            "id": "scalar:child-1:care"
+          }
+        },
+        "in_work_tax_credit_child_exclusive_care_fraction": {
+          "status": "known",
+          "value": "1",
+          "evidence": {
+            "id": "scalar:child-1:iwtc-care"
+          }
+        },
+        "best_start_after_per_child_abatement": {
+          "status": "known",
+          "value": "3041",
+          "evidence": {
+            "id": "audit:post-abated:child-1"
+          }
+        }
+      },
+      "facts": {
+        "attending_school_or_tertiary_at_age_18": {
+          "status": "known",
+          "value": true,
+          "evidence": {
+            "id": "education:child-1"
+          }
+        },
+        "commissioner_period_contains_segment_at_age_18": {
+          "status": "known",
+          "value": true,
+          "evidence": {
+            "id": "mc9-period:child-1"
+          }
+        },
+        "in_work_tax_credit_principal_caregiver": {
+          "status": "known",
+          "value": true,
+          "evidence": {
+            "id": "iwtc-principal-care:child-1"
+          }
+        },
+        "not_financially_independent_at_age_18": {
+          "status": "known",
+          "value": true,
+          "evidence": {
+            "id": "financial-dependence:child-1"
+          }
+        },
+        "principal_care_for_family_scheme": {
+          "status": "known",
+          "value": true,
+          "evidence": {
+            "id": "principal-care:child-1"
+          }
+        }
+      }
+    }
+  ],
+  "relations": [
+    {
+      "name": "partner_of",
+      "scope": "scenario:binding-best-start",
+      "completeness": {
+        "id": "complete:partner-of"
+      },
+      "facts": [
+        {
+          "tuple": [
+            "primary",
+            "partner"
+          ],
+          "knowledge": {
+            "status": "known",
+            "value": true,
+            "evidence": {
+              "id": "relation:partner:primary:partner"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "dependent_child_of",
+      "scope": "scenario:binding-best-start",
+      "completeness": {
+        "id": "complete:dependent-child-of"
+      },
+      "facts": [
+        {
+          "tuple": [
+            "primary",
+            "child-0"
+          ],
+          "knowledge": {
+            "status": "known",
+            "value": true,
+            "evidence": {
+              "id": "relation:child:primary:child-0"
+            }
+          }
+        },
+        {
+          "tuple": [
+            "primary",
+            "child-1"
+          ],
+          "knowledge": {
+            "status": "known",
+            "value": true,
+            "evidence": {
+              "id": "relation:child:primary:child-1"
+            }
+          }
+        }
+      ]
+    }
+  ],
+  "family_inputs": [
+    {
+      "anchor_person": "primary",
+      "evidence": {
+        "id": "family-input:primary"
+      },
+      "named_people": {
+        "family_unit_reference_person": {
+          "status": "known",
+          "value": "primary",
+          "evidence": {
+            "id": "family-reference:primary"
+          }
+        }
+      },
+      "scalars": {
+        "best_start_abatement_rate": {
+          "status": "known",
+          "value": "0.1",
+          "evidence": {
+            "id": "best-start-rate"
+          }
+        },
+        "best_start_abatement_threshold": {
+          "status": "known",
+          "value": "80000",
+          "evidence": {
+            "id": "best-start-threshold"
+          }
+        },
+        "best_start_family_abatement": {
+          "status": "known",
+          "value": "0",
+          "evidence": {
+            "id": "audit:zero-family-adjustment"
+          }
+        },
+        "family_scheme_income": {
+          "status": "known",
+          "value": "90480",
+          "evidence": {
+            "id": "family-income"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/tests/schema_golden.rs
+++ b/tests/schema_golden.rs
@@ -22,6 +22,24 @@ fn schemas_dir() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("schemas")
 }
 
+#[cfg(feature = "unit-derivation")]
+struct NzGrossModuleSource;
+
+#[cfg(feature = "unit-derivation")]
+impl axiom_rules_engine::source::ModuleSource for NzGrossModuleSource {
+    fn load(
+        &self,
+        target: &str,
+    ) -> Result<Option<String>, axiom_rules_engine::source::SourceError> {
+        Ok(
+            (target == "nz:statutes/income_tax/family_scheme/tax_credits").then(|| {
+                include_str!("fixtures/unit_derivation/nz_best_start_gross.rulespec.yaml")
+                    .to_string()
+            }),
+        )
+    }
+}
+
 #[test]
 fn schemas_are_current() {
     let dir = schemas_dir();
@@ -101,9 +119,16 @@ fn experimental_unit_aggregation_schemas_accept_the_exact_cli_fixtures() {
             .expect("aggregation request fixture is readable");
     let plan: AggregationPlan = serde_yaml::from_str(&source).unwrap();
     let request: AggregationRequest = serde_json::from_str(&request_source).unwrap();
+    let source_artifact = CompiledProgramArtifact::from_rulespec_with_source(
+        "nz:statutes/income_tax/family_scheme/tax_credits",
+        &NzGrossModuleSource,
+    )
+    .unwrap();
     let mut registry = UnitDerivationDocumentRegistry::default();
     let (plan_id, artifact_json) = {
-        let artifact = registry.register_aggregation_source(&source).unwrap();
+        let artifact = registry
+            .register_aggregation_source(&source, &source_artifact)
+            .unwrap();
         (
             artifact.plan_id().to_string(),
             serde_json::to_value(artifact).unwrap(),

--- a/tests/schema_golden.rs
+++ b/tests/schema_golden.rs
@@ -85,6 +85,77 @@ fn artifact_schema_accepts_a_real_compiled_artifact() {
     );
 }
 
+#[cfg(feature = "unit-derivation")]
+#[test]
+fn experimental_unit_aggregation_schemas_accept_the_exact_cli_fixtures() {
+    use axiom_rules_engine::unit_derivation::{
+        AggregationPlan, AggregationRequest, UnitDerivationConfig, UnitDerivationDocumentRegistry,
+    };
+
+    let fixture_dir =
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/unit_derivation");
+    let source = std::fs::read_to_string(fixture_dir.join("nz_income_explorer_family.yaml"))
+        .expect("aggregation plan fixture is readable");
+    let request_source =
+        std::fs::read_to_string(fixture_dir.join("nz_income_explorer_request.json"))
+            .expect("aggregation request fixture is readable");
+    let plan: AggregationPlan = serde_yaml::from_str(&source).unwrap();
+    let request: AggregationRequest = serde_json::from_str(&request_source).unwrap();
+    let mut registry = UnitDerivationDocumentRegistry::default();
+    let (plan_id, artifact_json) = {
+        let artifact = registry.register_aggregation_source(&source).unwrap();
+        (
+            artifact.plan_id().to_string(),
+            serde_json::to_value(artifact).unwrap(),
+        )
+    };
+    let result = registry
+        .execute_aggregation(
+            &plan_id,
+            &request,
+            &UnitDerivationConfig {
+                enabled: true,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+    let fixtures = [
+        (
+            "experimental-unit-aggregation-plan.stage3.schema.json",
+            serde_json::to_value(plan).unwrap(),
+        ),
+        (
+            "compiled-unit-aggregation.stage3.schema.json",
+            artifact_json,
+        ),
+        (
+            "unit-aggregation-request.stage3.schema.json",
+            serde_json::to_value(request).unwrap(),
+        ),
+        (
+            "unit-aggregation-result.stage3.schema.json",
+            serde_json::to_value(result).unwrap(),
+        ),
+    ];
+    let schemas = all_schemas();
+    for (name, fixture) in fixtures {
+        let schema = schemas
+            .iter()
+            .find(|schema| schema.file_name == name)
+            .unwrap();
+        let validator = jsonschema::draft7::new(&schema.schema).unwrap();
+        let errors = validator
+            .iter_errors(&fixture)
+            .map(|error| format!("{} at {}", error, error.instance_path()))
+            .collect::<Vec<_>>();
+        assert!(
+            errors.is_empty(),
+            "{name} rejected fixture:\n{}",
+            errors.join("\n")
+        );
+    }
+}
+
 #[test]
 fn artifact_schema_accepts_the_annotated_divergences() {
     // Exercise the manually-annotated spots in the derived artifact schema

--- a/tests/unit_aggregation_cli.rs
+++ b/tests/unit_aggregation_cli.rs
@@ -39,8 +39,36 @@ fn compiled_aggregation_cli_is_gated_registered_deterministic_and_exact() {
         fs::remove_dir_all(&temp).expect("remove stale test-owned directory");
     }
     fs::create_dir_all(&temp).expect("create test-owned directory");
+    let temp = fs::canonicalize(&temp).expect("resolve the exact test-owned directory");
     let first_artifact = temp.join("first.json");
     let second_artifact = temp.join("second.json");
+    let rulespec_root = temp.join("rulespec-nz");
+    let source_program =
+        rulespec_root.join("nz/statutes/income_tax/family_scheme/tax_credits.yaml");
+    fs::create_dir_all(source_program.parent().unwrap()).expect("create canonical source tree");
+    fs::copy(
+        fixture("nz_best_start_gross.rulespec.yaml"),
+        &source_program,
+    )
+    .expect("copy source fixture into canonical tree");
+    let source_artifact = temp.join("source.json");
+    let source_compile = engine()
+        .args([
+            "compile",
+            "--program",
+            source_program.to_str().unwrap(),
+            "--rulespec-root",
+            rulespec_root.to_str().unwrap(),
+            "--output",
+            source_artifact.to_str().unwrap(),
+        ])
+        .output()
+        .expect("compile provenance source artifact");
+    assert!(
+        source_compile.status.success(),
+        "source compile failed: {}",
+        String::from_utf8_lossy(&source_compile.stderr)
+    );
     let plan = fixture("nz_income_explorer_family.yaml");
     let request = fs::read(fixture("nz_income_explorer_request.json")).unwrap();
     let expected = fs::read(fixture("nz_income_explorer_result.json")).unwrap();
@@ -51,6 +79,8 @@ fn compiled_aggregation_cli_is_gated_registered_deterministic_and_exact() {
                 "compile-unit-aggregation",
                 "--plan",
                 plan.to_str().unwrap(),
+                "--source-artifact",
+                source_artifact.to_str().unwrap(),
                 "--output",
                 artifact.to_str().unwrap(),
             ])

--- a/tests/unit_aggregation_cli.rs
+++ b/tests/unit_aggregation_cli.rs
@@ -1,0 +1,124 @@
+#![cfg(feature = "unit-derivation")]
+
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output, Stdio};
+
+fn engine() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_axiom-rules-engine"))
+}
+
+fn fixture(name: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/unit_derivation")
+        .join(name)
+}
+
+fn run_with_stdin(args: &[&str], input: &[u8]) -> Output {
+    let mut child = engine()
+        .args(args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn aggregation CLI");
+    child
+        .stdin
+        .take()
+        .expect("piped stdin")
+        .write_all(input)
+        .expect("write request");
+    child.wait_with_output().expect("wait for aggregation CLI")
+}
+
+#[test]
+fn compiled_aggregation_cli_is_gated_registered_deterministic_and_exact() {
+    let temp = std::env::temp_dir().join(format!("axiom-stage3-cli-test-{}", std::process::id()));
+    if temp.exists() {
+        fs::remove_dir_all(&temp).expect("remove stale test-owned directory");
+    }
+    fs::create_dir_all(&temp).expect("create test-owned directory");
+    let first_artifact = temp.join("first.json");
+    let second_artifact = temp.join("second.json");
+    let plan = fixture("nz_income_explorer_family.yaml");
+    let request = fs::read(fixture("nz_income_explorer_request.json")).unwrap();
+    let expected = fs::read(fixture("nz_income_explorer_result.json")).unwrap();
+
+    for artifact in [&first_artifact, &second_artifact] {
+        let output = engine()
+            .args([
+                "compile-unit-aggregation",
+                "--plan",
+                plan.to_str().unwrap(),
+                "--output",
+                artifact.to_str().unwrap(),
+            ])
+            .output()
+            .expect("compile aggregation artifact");
+        assert!(
+            output.status.success(),
+            "compile failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+    assert_eq!(
+        fs::read(&first_artifact).unwrap(),
+        fs::read(&second_artifact).unwrap(),
+        "registered compilation must be byte-deterministic"
+    );
+
+    let artifact = first_artifact.to_str().unwrap();
+    let disabled = run_with_stdin(&["run-unit-aggregation", "--artifact", artifact], &request);
+    assert!(!disabled.status.success());
+    assert!(String::from_utf8_lossy(&disabled.stderr).contains("unit derivation is disabled"));
+
+    let raw_plan = run_with_stdin(
+        &[
+            "run-unit-aggregation",
+            "--plan",
+            plan.to_str().unwrap(),
+            "--enable-experimental-unit-derivation",
+        ],
+        &request,
+    );
+    assert!(!raw_plan.status.success());
+    assert!(
+        String::from_utf8_lossy(&raw_plan.stderr)
+            .contains("unknown run-unit-aggregation argument `--plan`")
+    );
+
+    let args = [
+        "run-unit-aggregation",
+        "--artifact",
+        artifact,
+        "--enable-experimental-unit-derivation",
+    ];
+    let first = run_with_stdin(&args, &request);
+    let second = run_with_stdin(&args, &request);
+    assert!(
+        first.status.success(),
+        "run failed: {}",
+        String::from_utf8_lossy(&first.stderr)
+    );
+    assert_eq!(first.stdout, second.stdout);
+    assert_eq!(first.stdout, expected, "fixture JSON must match exactly");
+
+    let mut malformed: serde_json::Value = serde_json::from_slice(&request).unwrap();
+    malformed["unexpected_request_field"] = serde_json::json!(true);
+    let malformed = run_with_stdin(&args, &serde_json::to_vec(&malformed).unwrap());
+    assert!(!malformed.status.success());
+    assert!(String::from_utf8_lossy(&malformed.stderr).contains("unknown field"));
+
+    let mut unknown_relation: serde_json::Value = serde_json::from_slice(&request).unwrap();
+    unknown_relation["relations"][1]["facts"][0]["knowledge"] = serde_json::json!({
+        "status": "unknown",
+        "evidence": {"id": "cli-child-relation-unknown"}
+    });
+    let unknown = run_with_stdin(&args, &serde_json::to_vec(&unknown_relation).unwrap());
+    assert!(unknown.status.success());
+    let unknown: serde_json::Value = serde_json::from_slice(&unknown.stdout).unwrap();
+    assert_eq!(unknown["families"]["status"], "indeterminate");
+
+    fs::remove_dir_all(&temp).expect("remove test-owned directory");
+}


### PR DESCRIPTION
Moves the NZ IncomeExplorer comparison's person→family/child aggregation engine-side, under the tier A+D semantics ratified in #134 and the stage-2 prototype merged in #159. Feature-gated behind `unit-derivation`, off by default; flag-off behavior is byte-identical to main (artifact SHA `355659bf…f3b2`).

## What the plan grammar guarantees

- **Typed inputs with provenance**: adult/child/family input classes; the family-scope reduction accepts a child-gross operand only when it carries the engine-computed provenance marker — a request-supplied scalar under any name is rejected with a named error. The audit's renamed-input plan is committed as a negative regression fixture (byte-identical to the finding plan, SHA `39011e1c…`).
- **One family-scope reduction per key**: `sum_children_then_subtract_family_once` is the single reduction operation; duplicate family-scope consumers reject with `DuplicateFamilyScopeReduction`. The Best Start per-child double-application defect is structurally inexpressible, and the plan-mutant test rejects all 11 single-property variants.
- **Knowledge propagation**: Unknown/Conflict evidence survives derived-relation gates; mixed indeterminate evidence makes the family-level status Indeterminate while retaining complete member topology (committed regression from the verification audit's probe).
- **Cited legal inputs**: every operation carries a statutory citation; MC 7/MC 9/MC 10/MD 10 citations verified against the legislation text, with age-band authorities split to their actual subsections.

## Parity against the pinned Treasury comparison

The regenerated ops-harness patch (under `stage3-nz/`, pinning implementation commit `d906969`) reruns the full IncomeExplorer comparison with engine-side aggregation: **1,454/1,976 cells to-the-cent, the same 522 dispositioned exceptions by id, comparison.csv byte-identical** (SHA `ccaa4dcb…4bf2`), deterministic across two runs. Machine receipt in `stage3-nz/parity-proof.json`.

Tests: 285 flag-off / 331 flag-on / 347 all-features / 14 harness mutants; every guard carries a regression that fails with that guard removed.

Unblocks the `host-side aggregation pin` and ACC `person-locality` blockers on the seven NZ certificates in axiom-oracles (the ops harness cutover and certificate regeneration follow this merge).

Review record: stage3-nz/sol-review-q.md, sol-stage3-fixes.md, sol-verify-r3.md, sol-stage3-final.md on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)