### PR TITLE
Make non-indexed parameters queryable as execution outputs

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -321,9 +321,37 @@ fn execute_explain(
         let mut outputs = BTreeMap::new();
 
         for output_reference in &query.outputs {
-            let output_name = program
-                .resolve_derived_name(output_reference)
-                .ok_or_else(|| EvalError::UnknownDerived(output_reference.clone()))?;
+            let Some(output_name) = program.resolve_derived_name(output_reference) else {
+                // A non-indexed parameter is a first-class statutory fact
+                // (for example a bare amount provision), so it is queryable
+                // directly; anything else stays an unknown output.
+                let parameter_name = program
+                    .resolve_parameter_name(output_reference)
+                    .ok_or_else(|| EvalError::UnknownDerived(output_reference.clone()))?;
+                let parameter = program
+                    .parameters
+                    .get(&parameter_name)
+                    .ok_or_else(|| EvalError::UnknownDerived(output_reference.clone()))?;
+                let output_key = parameter
+                    .id
+                    .clone()
+                    .unwrap_or_else(|| parameter_name.clone());
+                let name = parameter.name.clone();
+                let id = parameter.id.clone();
+                let unit = parameter.unit.clone();
+                let value = engine.evaluate_parameter(&parameter_name, &period)?;
+                outputs.insert(
+                    output_key,
+                    OutputValue::Scalar {
+                        name,
+                        id,
+                        dtype: DTypeSpec::from_scalar_value(&value),
+                        unit,
+                        value: ScalarValueSpec::from_model(value),
+                    },
+                );
+                continue;
+            };
             let derived = program
                 .derived
                 .get(&output_name)

--- a/src/bulk.rs
+++ b/src/bulk.rs
@@ -109,9 +109,18 @@ pub fn try_execute(
     let mut requested = HashSet::new();
     for query in queries {
         for output_reference in &query.outputs {
-            let output_name = program
-                .resolve_derived_name(output_reference)
-                .ok_or_else(|| EvalError::UnknownDerived(output_reference.clone()))?;
+            let Some(output_name) = program.resolve_derived_name(output_reference) else {
+                if program.resolve_parameter_name(output_reference).is_some() {
+                    // Parameter outputs evaluate on the explain path; report
+                    // Unsupported so fast mode falls back instead of erroring.
+                    return Ok(FastPathResult::Unsupported {
+                        reason: format!(
+                            "parameter output `{output_reference}` uses the explain path"
+                        ),
+                    });
+                }
+                return Err(EvalError::UnknownDerived(output_reference.clone()));
+            };
             requested.insert(output_name.to_string());
         }
     }

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1032,6 +1032,30 @@ impl<'a> Engine<'a> {
         Ok(selected.value.clone())
     }
 
+    /// Evaluate a non-indexed parameter at a period for a direct query
+    /// output. Indexed parameters need a key expression, so they stay
+    /// reachable only through derived formulas.
+    pub fn evaluate_parameter(
+        &mut self,
+        name: &str,
+        period: &Period,
+    ) -> Result<ScalarValue, EvalError> {
+        let indexed_by = {
+            let parameter = self
+                .program
+                .parameters
+                .get(name)
+                .ok_or_else(|| EvalError::UnknownParameter(name.to_string()))?;
+            parameter.indexed_by.clone()
+        };
+        if indexed_by.is_some() {
+            return Err(EvalError::TypeMismatch(format!(
+                "parameter `{name}` is indexed; query it through a derived rule"
+            )));
+        }
+        self.lookup_parameter(name, 0, period)
+    }
+
     fn lookup_parameter(
         &mut self,
         name: &str,

--- a/src/model.rs
+++ b/src/model.rs
@@ -576,6 +576,22 @@ impl Program {
         }
     }
 
+    pub fn resolve_parameter_name(&self, reference: &str) -> Option<String> {
+        if let Some(parameter) = self
+            .parameters
+            .values()
+            .find(|parameter| parameter.id.as_deref() == Some(reference))
+        {
+            return Some(parameter.name.clone());
+        }
+        let parameter = self.parameters.get(reference)?;
+        if parameter.id.is_none() {
+            Some(reference.to_string())
+        } else {
+            None
+        }
+    }
+
     pub fn resolve_input_name(&self, reference: &str) -> Option<String> {
         let input_catalog = self.input_catalog();
         self.resolve_input_name_with_catalog(reference, &input_catalog)

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -806,6 +806,19 @@ pub enum DTypeSpec {
 }
 
 impl DTypeSpec {
+    /// Runtime dtype of an already-evaluated value. Parameters do not carry a
+    /// declared dtype in the compiled program, so their query outputs report
+    /// the dtype of the selected value.
+    pub fn from_scalar_value(value: &ScalarValue) -> Self {
+        match value {
+            ScalarValue::Bool(_) => Self::Bool,
+            ScalarValue::Integer(_) => Self::Integer,
+            ScalarValue::Decimal(_) => Self::Decimal,
+            ScalarValue::Text(_) => Self::Text,
+            ScalarValue::Date(_) => Self::Date,
+        }
+    }
+
     pub fn from_model(dtype: &DType) -> Self {
         match dtype {
             DType::Judgment => Self::Judgment,

--- a/tests/execution.rs
+++ b/tests/execution.rs
@@ -3023,3 +3023,95 @@ fn mixed_parameter_and_derived_outputs_answer_in_one_query() {
         assert_eq!(response.metadata.actual_mode, ExecutionMode::Explain);
     }
 }
+
+#[test]
+fn parameter_output_serializes_the_exact_amount_row_shape() {
+    let rulespec = r#"
+format: rulespec/v1
+rules:
+  - name: monthly_kindergeld_per_child
+    kind: parameter
+    dtype: Money
+    unit: EUR
+    versions:
+      - effective_from: 2025-01-01
+        formula: 255
+      - effective_from: 2026-01-01
+        formula: 259
+"#;
+    let mut program =
+        axiom_rules_engine::rulespec::lower_rulespec_str(rulespec).expect("RuleSpec lowers");
+    program
+        .parameters
+        .iter_mut()
+        .find(|parameter| parameter.name == "monthly_kindergeld_per_child")
+        .expect("amount parameter")
+        .id = Some("de:statutes/estg/66#monthly_kindergeld_per_child".to_string());
+
+    let query_for = |year: i32| ExecutionQuery {
+        assessment_date: None,
+        entity_id: "case-0::tax_unit".to_string(),
+        period: PeriodSpec {
+            kind: PeriodKindSpec::Month,
+            start: chrono::NaiveDate::from_ymd_opt(year, 6, 1).expect("valid date"),
+            end: chrono::NaiveDate::from_ymd_opt(year, 6, 30).expect("valid date"),
+        },
+        outputs: vec!["de:statutes/estg/66#monthly_kindergeld_per_child".to_string()],
+    };
+
+    // 2025 period selects the 255 version; the serialized row is the exact
+    // shape the DE Kindergeld certificate premise validates.
+    let response = execute_request(ExecutionRequest {
+        mode: ExecutionMode::Explain,
+        program: program.clone(),
+        dataset: DatasetSpec {
+            inputs: vec![],
+            relations: vec![],
+        },
+        queries: vec![query_for(2025)],
+    })
+    .expect("2025 parameter query succeeds");
+    assert!(response.results[0].trace.is_empty());
+    let row = serde_json::to_value(
+        response.results[0]
+            .outputs
+            .get("de:statutes/estg/66#monthly_kindergeld_per_child")
+            .expect("amount output"),
+    )
+    .expect("output serializes");
+    assert_eq!(
+        row,
+        serde_json::json!({
+            "kind": "scalar",
+            "name": "monthly_kindergeld_per_child",
+            "id": "de:statutes/estg/66#monthly_kindergeld_per_child",
+            "dtype": "integer",
+            "unit": "EUR",
+            "value": {"kind": "integer", "value": 255},
+        })
+    );
+
+    // A 2026 period selects the later version: effective dating, not key
+    // shape, drives the answer.
+    let response = execute_request(ExecutionRequest {
+        mode: ExecutionMode::Explain,
+        program,
+        dataset: DatasetSpec {
+            inputs: vec![],
+            relations: vec![],
+        },
+        queries: vec![query_for(2026)],
+    })
+    .expect("2026 parameter query succeeds");
+    let row = serde_json::to_value(
+        response.results[0]
+            .outputs
+            .get("de:statutes/estg/66#monthly_kindergeld_per_child")
+            .expect("amount output"),
+    )
+    .expect("output serializes");
+    assert_eq!(
+        row["value"],
+        serde_json::json!({"kind": "integer", "value": 259})
+    );
+}

--- a/tests/execution.rs
+++ b/tests/execution.rs
@@ -2780,3 +2780,203 @@ fn judgment_output(output: &OutputValue) -> JudgmentOutcomeSpec {
 fn decimal(value: &str) -> Decimal {
     Decimal::from_str(value).expect("valid decimal literal")
 }
+
+#[test]
+fn non_indexed_parameters_are_queryable_outputs_in_every_mode() {
+    let program =
+        axiom_rules_engine::rulespec::lower_rulespec_str(SIMPLE_RULESPEC).expect("RuleSpec lowers");
+    let period = simple_period();
+    for mode in [ExecutionMode::Explain, ExecutionMode::Fast] {
+        let response = execute_request(ExecutionRequest {
+            mode: mode.clone(),
+            program: program.clone(),
+            dataset: DatasetSpec {
+                inputs: vec![],
+                relations: vec![],
+            },
+            queries: vec![ExecutionQuery {
+                assessment_date: None,
+                entity_id: "household-1".to_string(),
+                period: period.clone(),
+                outputs: vec!["base_amount".to_string()],
+            }],
+        })
+        .expect("parameter query succeeds");
+        let output = response.results[0]
+            .outputs
+            .get("base_amount")
+            .expect("parameter output");
+        assert_eq!(decimal_output(output), decimal("10"));
+        let OutputValue::Scalar {
+            name,
+            id,
+            dtype,
+            unit,
+            ..
+        } = output
+        else {
+            panic!("parameter output is a scalar");
+        };
+        assert_eq!(name, "base_amount");
+        assert_eq!(id.as_deref(), None);
+        // Whole-number literals lower to integers; the output reports the
+        // runtime dtype of the selected value.
+        assert_eq!(*dtype, DTypeSpec::Integer);
+        assert_eq!(unit.as_deref(), Some("USD"));
+        assert_eq!(response.metadata.actual_mode, ExecutionMode::Explain);
+        if mode == ExecutionMode::Fast {
+            let reason = response
+                .metadata
+                .fallback_reason
+                .clone()
+                .expect("fast mode reports the parameter fallback");
+            assert!(reason.contains("parameter output"));
+        }
+    }
+}
+
+#[test]
+fn parameter_outputs_resolve_by_canonical_id_when_present() {
+    let mut program =
+        axiom_rules_engine::rulespec::lower_rulespec_str(SIMPLE_RULESPEC).expect("RuleSpec lowers");
+    let parameter = program
+        .parameters
+        .iter_mut()
+        .find(|parameter| parameter.name == "base_amount")
+        .expect("base amount parameter");
+    parameter.id = Some("us:statutes/example/1#base_amount".to_string());
+    let response = execute_request(ExecutionRequest {
+        mode: ExecutionMode::Explain,
+        program: program.clone(),
+        dataset: DatasetSpec {
+            inputs: vec![],
+            relations: vec![],
+        },
+        queries: vec![ExecutionQuery {
+            assessment_date: None,
+            entity_id: "household-1".to_string(),
+            period: simple_period(),
+            outputs: vec!["us:statutes/example/1#base_amount".to_string()],
+        }],
+    })
+    .expect("id-addressed parameter query succeeds");
+    let output = response.results[0]
+        .outputs
+        .get("us:statutes/example/1#base_amount")
+        .expect("output keyed by canonical id");
+    assert_eq!(decimal_output(output), decimal("10"));
+    let OutputValue::Scalar { id, .. } = output else {
+        panic!("parameter output is a scalar");
+    };
+    assert_eq!(id.as_deref(), Some("us:statutes/example/1#base_amount"));
+
+    // With an id present the bare name is no longer addressable, matching
+    // derived-rule resolution.
+    let error = execute_request(ExecutionRequest {
+        mode: ExecutionMode::Explain,
+        program,
+        dataset: DatasetSpec {
+            inputs: vec![],
+            relations: vec![],
+        },
+        queries: vec![ExecutionQuery {
+            assessment_date: None,
+            entity_id: "household-1".to_string(),
+            period: simple_period(),
+            outputs: vec!["base_amount".to_string()],
+        }],
+    })
+    .expect_err("bare name is not addressable once an id exists");
+    assert_eq!(error.to_string(), "unknown derived output: base_amount");
+}
+
+#[test]
+fn indexed_parameters_are_not_directly_queryable() {
+    let rulespec = r#"
+format: rulespec/v1
+rules:
+  - name: phase_in_rates
+    kind: parameter
+    dtype: Rate
+    indexed_by: qualifying_child_count
+    versions:
+      - effective_from: 2026-01-01
+        values:
+          0: 0.0765
+          1: 0.34
+"#;
+    let program =
+        axiom_rules_engine::rulespec::lower_rulespec_str(rulespec).expect("RuleSpec lowers");
+    let error = execute_request(ExecutionRequest {
+        mode: ExecutionMode::Explain,
+        program,
+        dataset: DatasetSpec {
+            inputs: vec![],
+            relations: vec![],
+        },
+        queries: vec![ExecutionQuery {
+            assessment_date: None,
+            entity_id: "household-1".to_string(),
+            period: simple_period(),
+            outputs: vec!["phase_in_rates".to_string()],
+        }],
+    })
+    .expect_err("indexed parameters need a key expression");
+    assert!(
+        error
+            .to_string()
+            .contains("is indexed; query it through a derived rule"),
+        "unexpected error: {error}"
+    );
+}
+
+#[test]
+fn parameter_outputs_without_a_covering_version_error() {
+    let program =
+        axiom_rules_engine::rulespec::lower_rulespec_str(SIMPLE_RULESPEC).expect("RuleSpec lowers");
+    let error = execute_request(ExecutionRequest {
+        mode: ExecutionMode::Explain,
+        program,
+        dataset: DatasetSpec {
+            inputs: vec![],
+            relations: vec![],
+        },
+        queries: vec![ExecutionQuery {
+            assessment_date: None,
+            entity_id: "household-1".to_string(),
+            period: PeriodSpec {
+                kind: PeriodKindSpec::Month,
+                start: chrono::NaiveDate::from_ymd_opt(2025, 1, 1).expect("valid date"),
+                end: chrono::NaiveDate::from_ymd_opt(2025, 1, 31).expect("valid date"),
+            },
+            outputs: vec!["base_amount".to_string()],
+        }],
+    })
+    .expect_err("no version covers 2025");
+    assert!(
+        error.to_string().contains("base_amount"),
+        "unexpected error: {error}"
+    );
+}
+
+#[test]
+fn unknown_query_outputs_still_error_with_parameters_present() {
+    let program =
+        axiom_rules_engine::rulespec::lower_rulespec_str(SIMPLE_RULESPEC).expect("RuleSpec lowers");
+    let error = execute_request(ExecutionRequest {
+        mode: ExecutionMode::Explain,
+        program,
+        dataset: DatasetSpec {
+            inputs: vec![],
+            relations: vec![],
+        },
+        queries: vec![ExecutionQuery {
+            assessment_date: None,
+            entity_id: "household-1".to_string(),
+            period: simple_period(),
+            outputs: vec!["no_such_output".to_string()],
+        }],
+    })
+    .expect_err("unknown outputs are rejected");
+    assert_eq!(error.to_string(), "unknown derived output: no_such_output");
+}

--- a/tests/execution.rs
+++ b/tests/execution.rs
@@ -2980,3 +2980,46 @@ fn unknown_query_outputs_still_error_with_parameters_present() {
     .expect_err("unknown outputs are rejected");
     assert_eq!(error.to_string(), "unknown derived output: no_such_output");
 }
+
+#[test]
+fn mixed_parameter_and_derived_outputs_answer_in_one_query() {
+    let program =
+        axiom_rules_engine::rulespec::lower_rulespec_str(SIMPLE_RULESPEC).expect("RuleSpec lowers");
+    let period = simple_period();
+    for mode in [ExecutionMode::Explain, ExecutionMode::Fast] {
+        let response = execute_request(ExecutionRequest {
+            mode: mode.clone(),
+            program: program.clone(),
+            dataset: DatasetSpec {
+                inputs: vec![InputRecordSpec {
+                    name: "amount".to_string(),
+                    entity: "Household".to_string(),
+                    entity_id: "household-1".to_string(),
+                    interval: IntervalSpec {
+                        start: period.start,
+                        end: period.end,
+                    },
+                    value: decimal_value("5"),
+                }],
+                relations: vec![],
+            },
+            queries: vec![ExecutionQuery {
+                assessment_date: None,
+                entity_id: "household-1".to_string(),
+                period: period.clone(),
+                outputs: vec!["adjusted_amount".to_string(), "base_amount".to_string()],
+            }],
+        })
+        .expect("mixed query succeeds");
+        let outputs = &response.results[0].outputs;
+        assert_eq!(
+            decimal_output(outputs.get("base_amount").expect("parameter")),
+            decimal("10")
+        );
+        assert_eq!(
+            decimal_output(outputs.get("adjusted_amount").expect("derived")),
+            decimal("15")
+        );
+        assert_eq!(response.metadata.actual_mode, ExecutionMode::Explain);
+    }
+}


### PR DESCRIPTION
## Why

A bare statutory amount compiles to a compiled-program **parameter** (only parameter tables and derived rules were queryable). The DE Kindergeld certificate lane's signed module (rulespec-de `de/statutes/estg/66.yaml`, merged at `d83ba3db`) carries its amount root as `kind: parameter` — statutorily correct for EStG §66(1) — and the pinned v0.2.1 release answers its query with `unknown derived output`. The certification premise (axiom-oracles `scripts/de_executable.py`) already validates the signed rule as a parameter and expects the engine to answer the query.

## What

- `Program::resolve_parameter_name` mirrors `resolve_derived_name`: canonical id first, bare name only when no id exists.
- `Engine::evaluate_parameter`: non-indexed parameters evaluate at the query period (key 0). Indexed parameters error with `parameter `…` is indexed; query it through a derived rule`.
- Explain mode emits the parameter as an `OutputValue::Scalar` keyed by its canonical id, with the parameter's unit and the runtime dtype of the selected value (parameters carry no declared dtype in the compiled program).
- Fast mode reports parameter outputs as `FastPathResult::Unsupported`, so it falls back to Explain with a reason instead of erroring.
- Unknown references keep the exact existing error (`unknown derived output: …`).

## Tests

`tests/execution.rs`: query by bare name in both modes (with fast-fallback metadata assert), query by canonical id (and bare-name shadowing once an id exists, matching derived semantics), indexed-parameter rejection, missing covering version, unknown output unchanged. Full suite, fmt, clippy-clean for the touched code.

## Consumer

Unblocks the (de, kindergeld) certificate: after release + `ENGINE_PIN` bump, `de_executable.py --run` can execute the amount query against the signed module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)