### PR TITLE
Cut the crate at 0.2.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,7 +85,7 @@ dependencies = [
 
 [[package]]
 name = "axiom-rules-engine"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "chrono",
  "jsonschema",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "axiom-rules-engine"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2024"
 license = "Apache-2.0"
 description = "Temporal-relational runtime for compiling and executing Axiom RuleSpec (experimental API)."

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ axiom-rules-engine capabilities
 ```json
 {
   "artifact_format_version": 2,
-  "engine_version": "0.2.1"
+  "engine_version": "0.2.2"
 }
 ```
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -215,7 +215,7 @@ mod tests {
 
     #[test]
     fn version_line_uses_package_version() {
-        assert_eq!(version_line(), "axiom-rules-engine 0.2.1");
+        assert_eq!(version_line(), "axiom-rules-engine 0.2.2");
     }
 
     /// Registration is the sole command-name inventory: recognition and rendered help


### PR DESCRIPTION
Version cut after #162 (parameter query outputs), mirroring the #157 cut: Cargo.toml, Cargo.lock, the README capabilities example, and the CLI version-line test. Tag `v0.2.2` on the merge commit triggers the release build; the DE Kindergeld certificate lane then re-pins its `ENGINE_PIN` to the new linux-gnu asset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)